### PR TITLE
Adopt Kubernetes style command dialect

### DIFF
--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -33,7 +33,7 @@ class CompletionMng(AbstractCompletionMng):
         "clone": ["env"],
         "rename": ["env"],
         "checkout": ["auto-env"],
-        "delete": ["env", "svc"],
+        "delete": ["env"],
         "list": ["auto-env"],
         "up": ["env", "svc"],
         "halt": ["env", "svc"],

--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -26,7 +26,23 @@ from config import ConfigMng
 
 class CompletionMng(AbstractCompletionMng):
 
-    CATEGORIES = ["env", "svc"]
+    # Mapping of verbs to valid categories
+    VERB_CATEGORIES = {
+        "get": ["env", "svc"],
+        "add": ["env", "svc"],
+        "clone": ["env"],
+        "rename": ["env"],
+        "checkout": ["auto-env"],
+        "delete": ["env", "svc"],
+        "list": ["auto-env"],
+        "up": ["env", "svc"],
+        "halt": ["env", "svc"],
+        "reload": ["env", "svc"],
+        "status": ["env"],
+        "logs": ["auto-svc"],
+        "shell": ["auto-svc"],
+        "build": ["auto-svc"],
+    }
 
     def __init__(self, cli_flags: dict[str, bool], configMng: ConfigMng):
         self.cli_flags = cli_flags
@@ -34,40 +50,61 @@ class CompletionMng(AbstractCompletionMng):
         self.completionEnvMng = CompletionEnvMng(cli_flags, configMng)
         self.completionSvcMng = CompletionSvcMng(cli_flags, configMng)
 
-    def is_category_chosen(self, args: list[str]) -> bool:
-        """
-        Checks if the first argument is a valid category.
-        """
+    @property
+    def VERBS(self) -> list[str]:
+        """return all verbs from the mapping."""
+        return list(self.VERB_CATEGORIES.keys())
+
+    def is_verb_chosen(self, args: list[str]) -> bool:
         if not args or len(args) < 1:
             return False
-        return args[0] in self.CATEGORIES
+        return args[0] in self.VERBS
 
-    def get_completion_manager(
-        self, args: list[str]
-    ) -> Optional[AbstractCompletionMng]:
-        """
-        Returns the appropriate completion manager based on the category.
-        """
+    def is_category_chosen(self, args: list[str]) -> bool:
+        if not args or len(args) < 2:
+            return False
+        verb = args[0]
+        category = args[1]
+        return category in self.VERB_CATEGORIES.get(verb, [])
 
-        category = args[0]
-        if category == "env":
-            return self.completionEnvMng
-        elif category == "svc":
-            return self.completionSvcMng
+    def get_auto_category(self, args: list[str]) -> Optional[str]:
+        if not args:
+            return None
+        verb = args[0]
+        if self.VERB_CATEGORIES.get(verb, [])[0].startswith("auto-"):
+            return self.VERB_CATEGORIES[verb][0].split("-")[1]
         else:
             return None
 
+    def get_completion_manager(
+        self, args: list[str], auto_category: Optional[str] = None
+    ) -> Optional[AbstractCompletionMng]:
+        # Priority: use auto_category if provided, otherwise try args[1]
+        category = auto_category or (args[1] if len(args) > 1 else None)
+        if not category:
+            return None
+
+        if category == "env":
+            return self.completionEnvMng
+        if category == "svc":
+            return self.completionSvcMng
+
+        return None
+
     @override
     def get_completions(self, args: list[str]) -> list[str]:
-        """
-        Returns a list of completions based on the provided arguments.
-        """
+        if not self.is_verb_chosen(args):
+            return self.VERBS
 
-        if not self.is_category_chosen(args):
-            return self.CATEGORIES
+        auto_category = self.get_auto_category(args)
 
-        completion_manager = self.get_completion_manager(args)
+        if not auto_category and not self.is_category_chosen(args):
+            # suggest only valid categories for this verb
+            verb = args[0]
+            return self.VERB_CATEGORIES.get(verb, [])
+
+        completion_manager = self.get_completion_manager(args, auto_category)
         if completion_manager:
-            return completion_manager.get_completions(args[1:])
+            return completion_manager.get_completions(args)
 
         return []

--- a/src/completion/completion_env.py
+++ b/src/completion/completion_env.py
@@ -24,66 +24,36 @@ from config import ConfigMng
 
 class CompletionEnvMng(AbstractCompletionMng):
 
-    COMMANDS_ENV = [
-        "init",
-        "clone",
-        "rename",
-        "checkout",
-        "delete",
-        "list",
-        "up",
-        "halt",
-        "render",
-        "reload",
-        "status",
-        "add",
-    ]
-
     def __init__(self, cli_flags: dict[str, bool], configMng: ConfigMng):
         self.cli_flags = cli_flags
         self.configMng = configMng
 
-    def is_command_chosen(self, args: list[str]) -> bool:
-        """
-        Checks if the second argument is a valid command
-        for the chosen category.
-        """
-        if not args or len(args) < 1:
-            return False
-        command = args[0]
-        return command in self.COMMANDS_ENV
-
     @override
     def get_completions(self, args: list[str]) -> list[str]:
-        if not self.is_command_chosen(args):
-            return self.COMMANDS_ENV
-
         command = args[0]
         match command:
-            case "init":
-                return self.get_init_completions(args[1:])
+            case "add":
+                return self.get_add_completions(args[2:])
             case "clone":
-                return self.get_clone_completions(args[1:])
+                return self.get_clone_completions(args[2:])
             case "rename":
-                return self.get_rename_completions(args[1:])
+                return self.get_rename_completions(args[2:])
             case "checkout":
                 return self.get_checkout_completions(args[1:])
             case "delete":
-                return self.get_delete_completions(args[1:])
+                return self.get_delete_completions(args[2:])
             case "list":
                 return self.get_list_completions(args[1:])
             case "up":
-                return self.get_up_completions(args[1:])
+                return self.get_start_completions(args[2:])
             case "halt":
-                return self.get_halt_completions(args[1:])
-            case "render":
-                return self.get_render_completions(args[1:])
+                return self.get_stop_completions(args[2:])
+            case "get":
+                return self.get_render_completions(args[2:])
             case "reload":
-                return self.get_reload_completions(args[1:])
+                return self.get_reload_completions(args[2:])
             case "status":
-                return self.get_status_completions(args[1:])
-            case "add":
-                return self.get_add_resource_completions(args[1:])
+                return self.get_status_completions(args[2:])
             case _:
                 return []
 
@@ -101,7 +71,7 @@ class CompletionEnvMng(AbstractCompletionMng):
             env.tag == src_env_tag for env in self.configMng.get_environments()
         )
 
-    def get_init_completions(self, args: list[str]) -> list[str]:
+    def get_add_completions(self, args: list[str]) -> list[str]:
         if not self.is_env_template_chosen(args):
             return self.configMng.get_environment_template_tags()
         return []
@@ -133,10 +103,10 @@ class CompletionEnvMng(AbstractCompletionMng):
     def get_list_completions(self, args: list[str]) -> list[str]:
         return []
 
-    def get_up_completions(self, args: list[str]) -> list[str]:
+    def get_start_completions(self, args: list[str]) -> list[str]:
         return []
 
-    def get_halt_completions(self, args: list[str]) -> list[str]:
+    def get_stop_completions(self, args: list[str]) -> list[str]:
         return []
 
     def get_render_completions(self, args: list[str]) -> list[str]:
@@ -148,49 +118,4 @@ class CompletionEnvMng(AbstractCompletionMng):
         return []
 
     def get_status_completions(self, args: list[str]) -> list[str]:
-        return []
-
-    def is_resource_type_chosen(self, args: list[str]) -> bool:
-        if not args or len(args) < 1:
-            return False
-        resource_type = args[0]
-        return resource_type in self.configMng.constants.RESOURCE_TYPES
-
-    def is_resource_tag_chosen(self, args: list[str]) -> bool:
-        if len(args) < 2:
-            return False
-        return True
-
-    def is_resource_template_chosen(self, args: list[str]) -> bool:
-        if len(args) < 3:
-            return False
-        resource_template = args[2]
-        return resource_template in self.configMng.get_resource_templates(
-            args[0]
-        )
-
-    def get_resource_templates(self, args: list[str]) -> list[str]:
-        return self.configMng.get_resource_templates(args[0])
-
-    def is_resource_class_chosen(self, args: list[str]) -> bool:
-        if len(args) < 4:
-            return False
-        resource_class = args[3]
-        return resource_class in self.get_resource_classes(args)
-
-    def get_resource_classes(self, args: list[str]) -> list[str]:
-        env = self.configMng.get_active_environment()
-        if env:
-            return self.configMng.get_resource_classes(env, args[0])
-        return []
-
-    def get_add_resource_completions(self, args: list[str]) -> list[str]:
-        if not self.is_resource_type_chosen(args):
-            return self.configMng.constants.RESOURCE_TYPES
-        if not self.is_resource_tag_chosen(args):
-            return []
-        if not self.is_resource_template_chosen(args):
-            return self.get_resource_templates(args)
-        if not self.is_resource_class_chosen(args):
-            return self.get_resource_classes(args)
         return []

--- a/src/completion/completion_svc.py
+++ b/src/completion/completion_svc.py
@@ -24,51 +24,30 @@ from config import ConfigMng
 
 class CompletionSvcMng(AbstractCompletionMng):
 
-    COMMANDS_SVC = [
-        "build",
-        "up",
-        "halt",
-        "stdout",
-        "shell",
-        "render",
-        "reload",
-    ]
-
     def __init__(self, cli_flags: dict[str, bool], configMng: ConfigMng):
         self.cli_flags = cli_flags
         self.configMng = configMng
 
-    def is_command_chosen(self, args: list[str]) -> bool:
-        """
-        Checks if the second argument is a valid command
-        for the chosen category.
-        """
-        if not args or len(args) < 1:
-            return False
-        command = args[0]
-        return command in self.COMMANDS_SVC
-
     @override
     def get_completions(self, args: list[str]) -> list[str]:
-        if not self.is_command_chosen(args):
-            return self.COMMANDS_SVC
-
         command = args[0]
         match command:
+            case "add":
+                return self.get_add_completions(args[2:])
             case "build":
                 return self.get_build_completions(args[1:])
             case "up":
-                return self.get_up_completions(args[1:])
+                return self.get_start_completions(args[2:])
             case "halt":
-                return self.get_halt_completions(args[1:])
-            case "stdout":
-                return self.get_stdout_completions(args[1:])
+                return self.get_stop_completions(args[2:])
+            case "logs":
+                return self.get_logs_completions(args[1:])
             case "shell":
                 return self.get_shell_completions(args[1:])
-            case "render":
-                return self.get_render_completions(args[1:])
+            case "get":
+                return self.get_render_completions(args[2:])
             case "reload":
-                return self.get_reload_completions(args[1:])
+                return self.get_reload_completions(args[2:])
             case _:
                 return []
 
@@ -102,17 +81,17 @@ class CompletionSvcMng(AbstractCompletionMng):
             return self.configMng.get_service_tags(env)
         return []
 
-    def get_up_completions(self, args: list[str]) -> list[str]:
+    def get_start_completions(self, args: list[str]) -> list[str]:
         if not self.is_svc_tag_chosen(args):
             return self.get_svc_tags(args)
         return []
 
-    def get_halt_completions(self, args: list[str]) -> list[str]:
+    def get_stop_completions(self, args: list[str]) -> list[str]:
         if not self.is_svc_tag_chosen(args):
             return self.get_svc_tags(args)
         return []
 
-    def get_stdout_completions(self, args: list[str]) -> list[str]:
+    def get_logs_completions(self, args: list[str]) -> list[str]:
         if not self.is_svc_tag_chosen(args):
             return self.get_svc_tags(args)
         return []
@@ -130,4 +109,32 @@ class CompletionSvcMng(AbstractCompletionMng):
     def get_reload_completions(self, args: list[str]) -> list[str]:
         if not self.is_svc_tag_chosen(args):
             return self.get_svc_tags(args)
+        return []
+
+    def is_svc_class_chosen(self, args: list[str]) -> bool:
+        if len(args) < 3:
+            return False
+        svc_class = args[2]
+        return svc_class in self.get_svc_classes(args)
+
+    def get_svc_classes(self, args: list[str]) -> list[str]:
+        env = self.configMng.get_active_environment()
+        if env:
+            return self.configMng.get_resource_classes(
+                env, self.configMng.constants.RESOURCE_TYPE_SVC
+            )
+        return []
+
+    def is_svc_tag_produced(self, args: list[str]) -> bool:
+        if len(args) < 2:
+            return False
+        return True
+
+    def get_add_completions(self, args: list[str]) -> list[str]:
+        if not self.is_svc_template_chosen(args):
+            return self.get_svc_templates(args)
+        if not self.is_svc_tag_produced(args):
+            return []
+        if not self.is_svc_class_chosen(args):
+            return self.get_svc_classes(args)
         return []

--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -80,7 +80,7 @@ class DockerComposeEnv(Environment):
             run_compose(self.envCfg.status.triggered_config, "up", "-d")
 
     @override
-    def halt(self):
+    def stop(self):
         """Halt the environment."""
         if self.envCfg.status.triggered_config:
             run_compose(self.envCfg.status.triggered_config, "down")

--- a/src/docker/docker_compose_svc.py
+++ b/src/docker/docker_compose_svc.py
@@ -85,7 +85,7 @@ class DockerComposeSvc(Service):
             )
 
     @override
-    def halt(self):
+    def stop(self):
         """Stop the service."""
         if self.envCfg.status.triggered_config:
             run_compose(
@@ -113,7 +113,7 @@ class DockerComposeSvc(Service):
             )
 
     @override
-    def show_stdout(self):
+    def get_stdout(self):
         """Show the service stdout."""
         if self.envCfg.status.triggered_config:
             run_compose(

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -59,7 +59,7 @@ class Environment(ABC):
         self.ensure_resources()
 
     @abstractmethod
-    def halt(self):
+    def stop(self):
         """Halt the environment."""
         pass
 
@@ -221,7 +221,7 @@ class EnvironmentMng:
         env = self.envFactory.new_environment_cfg(env_cfg)
         return env
 
-    def init_env(self, env_template: str, env_tag: str):
+    def add_env(self, env_template: str, env_tag: str):
         """Initialize an environment."""
         if self.configMng.get_environment(env_tag):
             Util.print_error_and_die(
@@ -325,10 +325,10 @@ class EnvironmentMng:
         env.start()
         Util.print(f"Started environment: {env.envCfg.tag}")
 
-    def halt_env(self, envCfg: EnvironmentCfg):
+    def stop_env(self, envCfg: EnvironmentCfg):
         """Halt an environment."""
         env = self.get_environment_from_cfg(envCfg)
-        env.halt()
+        env.stop()
         env.envCfg.status.triggered_config = None
         env.sync_config()
         Util.print(f"Halted environment: {env.envCfg.tag}")

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -65,7 +65,7 @@ class Service(ABC):
         pass
 
     @abstractmethod
-    def halt(self):
+    def stop(self):
         """Stop the service."""
         pass
 
@@ -75,7 +75,7 @@ class Service(ABC):
         pass
 
     @abstractmethod
-    def show_stdout(self):
+    def get_stdout(self):
         """Show the service stdout."""
         pass
 
@@ -140,11 +140,11 @@ class ServiceMng:
         if service:
             service.start()
 
-    def halt_svc(self, envCfg: EnvironmentCfg, svc_tag: str):
+    def stop_svc(self, envCfg: EnvironmentCfg, svc_tag: str):
         """Halt a service."""
         service = self.get_service(envCfg, svc_tag)
         if service:
-            service.halt()
+            service.stop()
 
     def reload_svc(self, envCfg: EnvironmentCfg, svc_tag: str):
         """Reload a service."""
@@ -159,11 +159,11 @@ class ServiceMng:
             return service.render()
         return None
 
-    def stdout_svc(self, envCfg: EnvironmentCfg, svc_tag: str):
+    def logs_svc(self, envCfg: EnvironmentCfg, svc_tag: str):
         """Get service stdout."""
         service = self.get_service(envCfg, svc_tag)
         if service:
-            service.show_stdout()
+            service.get_stdout()
 
     def shell_svc(self, envCfg: EnvironmentCfg, svc_tag: str):
         """Get a shell session for a service."""

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -84,46 +84,12 @@ def require_active_env(func: Callable[..., Any]) -> Callable[..., Any]:
     is_flag=True,
     help="Automatic yes to prompts; run non-interactively.",
 )
-@click.option("-a", "--all", is_flag=True, help="Apply to all.")
-@click.option("-f", "--follow", is_flag=True, help="Follow log output.")
-@click.option(
-    "-p", "--porcelain", is_flag=True, help="Produce machine-readable output."
-)
-@click.option("-k", "--keep", is_flag=True, help="Keep instead of drop.")
-@click.option(
-    "-r", "--replace", is_flag=True, help="Replace when already there."
-)
-@click.option(
-    "-c",
-    "--checkout",
-    is_flag=True,
-    help="Contextually checkout the environment.",
-)
 @click.pass_context
-def cli(
-    ctx: click.Context,
-    verbose: bool,
-    yes: bool,
-    all: bool,
-    follow: bool,
-    porcelain: bool,
-    keep: bool,
-    replace: bool,
-    checkout: bool,
-):
+def cli(ctx: click.Context, verbose: bool, yes: bool):
     """Shepherd CLI:
     A tool to manage your environments, services, and databases.
     """
-    cli_flags = {
-        "verbose": verbose,
-        "yes": yes,
-        "all": all,
-        "follow": follow,
-        "porcelain": porcelain,
-        "keep": keep,
-        "replace": replace,
-        "checkout": checkout,
-    }
+    cli_flags = {"verbose": verbose, "yes": yes}
 
     if ctx.obj is None:
         ctx.obj = ShepherdMng(cli_flags)

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -19,7 +19,7 @@
 import functools
 import logging
 import os
-from typing import Any, Callable, Optional
+from typing import Any, Callable, List, Optional
 
 import click
 
@@ -66,7 +66,7 @@ class ShepherdMng:
 def require_active_env(func: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(func)
     def wrapper(
-        shepherd: ShepherdMng, *args: list[str], **kwargs: dict[str, str]
+        shepherd: ShepherdMng, *args: List[str], **kwargs: dict[str, str]
     ) -> Callable[..., Any]:
         envCfg = shepherd.configMng.get_active_environment()
         if not envCfg:
@@ -131,7 +131,7 @@ def cli(
 
 @cli.command(name="test", hidden=True)
 def empty():
-    """Empty testing purpose stub"""
+    """Empty testing purpose stub."""
     pass
 
 
@@ -155,199 +155,298 @@ def complete(shepherd: ShepherdMng, args: list[str]):
         click.echo(c)
 
 
-# Environment commands
+# =====================================================
+# GET
+# =====================================================
 @cli.group()
-def env():
-    """Environment related operations."""
+def get():
+    """Get resources."""
     pass
 
 
-@env.command(name="init")
-@click.argument("env_template", required=True)
-@click.argument("env_tag", required=True)
+@get.command(name="env")
+@click.argument("tag", required=False)
+@click.option(
+    "-o", "--output", type=click.Choice(["yaml", "json"]), default=None
+)
 @click.pass_obj
-def env_init(shepherd: ShepherdMng, env_template: str, env_tag: str):
-    """Init an environment with ENV_TEMPLATE and tag ENV_TAG."""
-    shepherd.environmentMng.init_env(env_template, env_tag)
+def get_env(shepherd: ShepherdMng, tag: str, output: Optional[str]):
+    """Get environment details or config."""
+    if output:
+        click.echo(shepherd.environmentMng.render_env(tag))
 
 
-@env.command(name="clone")
-@click.argument("src_env_tag", required=True)
-@click.argument("dst_env_tag", required=True)
+@get.command(name="svc")
+@click.argument("tag", required=True)
+@click.option(
+    "-o", "--output", type=click.Choice(["yaml", "json"]), default=None
+)
 @click.pass_obj
-def env_clone(shepherd: ShepherdMng, src_env_tag: str, dst_env_tag: str):
+@require_active_env
+def get_svc(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    tag: str,
+    output: Optional[str],
+):
+    """Get service details or config."""
+    if output:
+        click.echo(shepherd.serviceMng.render_svc(envCfg, tag))
+
+
+# =====================================================
+# ADD
+# =====================================================
+@cli.group()
+def add():
+    """Add resources."""
+    pass
+
+
+@add.command(name="env")
+@click.argument("template", required=True)
+@click.argument("tag", required=True)
+@click.pass_obj
+def add_env(shepherd: ShepherdMng, template: str, tag: str):
+    """Add a new environment."""
+    shepherd.environmentMng.add_env(template, tag)
+
+
+@add.command(name="svc")
+@click.argument("svc_template", required=True)
+@click.argument("svc_tag", required=True)
+@click.argument("svc_class", required=False)
+@click.pass_obj
+@require_active_env
+def add_svc(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    svc_template: str,
+    svc_tag: str,
+    svc_class: Optional[str] = None,
+):
+    """Add a new service."""
+    shepherd.environmentMng.add_service(
+        envCfg.tag, svc_tag, svc_template, svc_class
+    )
+
+
+# =====================================================
+# CLONE
+# =====================================================
+@cli.group()
+def clone():
+    """Clone resources."""
+    pass
+
+
+@clone.command(name="env")
+@click.argument("src_tag", required=True)
+@click.argument("dst_tag", required=True)
+@click.pass_obj
+def clone_env(shepherd: ShepherdMng, src_tag: str, dst_tag: str):
     """Clone an environment."""
-    shepherd.environmentMng.clone_env(src_env_tag, dst_env_tag)
+    shepherd.environmentMng.clone_env(src_tag, dst_tag)
 
 
-@env.command(name="rename")
-@click.argument("src_env_tag", required=True)
-@click.argument("dst_env_tag", required=True)
+# =====================================================
+# RENAME
+# =====================================================
+@cli.group()
+def rename():
+    """Rename resources."""
+    pass
+
+
+@rename.command(name="env")
+@click.argument("src_tag", required=True)
+@click.argument("dst_tag", required=True)
 @click.pass_obj
-def env_rename(shepherd: ShepherdMng, src_env_tag: str, dst_env_tag: str):
+def rename_env(shepherd: ShepherdMng, src_tag: str, dst_tag: str):
     """Rename an environment."""
-    shepherd.environmentMng.rename_env(src_env_tag, dst_env_tag)
+    shepherd.environmentMng.rename_env(src_tag, dst_tag)
 
 
-@env.command(name="checkout")
-@click.argument("env_tag", required=True)
+# =====================================================
+# CHECKOUT
+# =====================================================
+@cli.command(name="checkout")
+@click.argument("tag", required=True)
 @click.pass_obj
-def env_checkout(shepherd: ShepherdMng, env_tag: str):
+def checkout(shepherd: ShepherdMng, tag: str):
     """Checkout an environment."""
-    shepherd.environmentMng.checkout_env(env_tag)
+    shepherd.environmentMng.checkout_env(tag)
 
 
-@env.command(name="delete")
-@click.argument("env_tag", required=True)
+# =====================================================
+# DELETE
+# =====================================================
+@cli.group()
+def delete():
+    """Delete resources."""
+    pass
+
+
+@delete.command(name="env")
+@click.argument("tag", required=True)
 @click.pass_obj
-def env_delete(shepherd: ShepherdMng, env_tag: str):
+def delete_env(shepherd: ShepherdMng, tag: str):
     """Delete an environment."""
-    shepherd.environmentMng.delete_env(env_tag)
+    shepherd.environmentMng.delete_env(tag)
 
 
-@env.command(name="list")
+# =====================================================
+# LIST
+# =====================================================
+@cli.command(name="list")
 @click.pass_obj
-def env_list(shepherd: ShepherdMng):
-    """List all available environments."""
+def list(shepherd: ShepherdMng):
+    """List environments."""
     shepherd.environmentMng.list_envs()
 
 
-@env.command(name="up")
+# =====================================================
+# UP
+# =====================================================
+@cli.group(invoke_without_command=True)
 @click.pass_obj
 @require_active_env
-def env_up(shepherd: ShepherdMng, envCfg: EnvironmentCfg):
+def up(shepherd: ShepherdMng, envCfg: EnvironmentCfg):
+    """Start resources."""
+    # If no subcommand is given, default to "env"
+    ctx = click.get_current_context()
+    if ctx.invoked_subcommand is None:
+        shepherd.environmentMng.start_env(envCfg)
+
+
+@up.command(name="env")
+@click.pass_obj
+@require_active_env
+def up_env(shepherd: ShepherdMng, envCfg: EnvironmentCfg):
     """Start environment."""
     shepherd.environmentMng.start_env(envCfg)
 
 
-@env.command(name="halt")
+@up.command(name="svc")
+@click.argument("tag", required=True)
 @click.pass_obj
 @require_active_env
-def env_halt(shepherd: ShepherdMng, envCfg: EnvironmentCfg):
-    """Halt environment."""
-    shepherd.environmentMng.halt_env(envCfg)
+def up_svc(shepherd: ShepherdMng, envCfg: EnvironmentCfg, tag: str):
+    """Start service."""
+    shepherd.serviceMng.start_svc(envCfg, tag)
 
 
-@env.command(name="reload")
+# =====================================================
+# STOP
+# =====================================================
+@cli.group(invoke_without_command=True)
 @click.pass_obj
 @require_active_env
-def env_reload(shepherd: ShepherdMng, envCfg: EnvironmentCfg):
+def halt(shepherd: ShepherdMng, envCfg: EnvironmentCfg):
+    """Stop resources."""
+    # If no subcommand is given, default to "env"
+    ctx = click.get_current_context()
+    if ctx.invoked_subcommand is None:
+        shepherd.environmentMng.stop_env(envCfg)
+
+
+@halt.command(name="env")
+@click.pass_obj
+@require_active_env
+def halt_env(shepherd: ShepherdMng, envCfg: EnvironmentCfg):
+    """Stop environment."""
+    shepherd.environmentMng.stop_env(envCfg)
+
+
+@halt.command(name="svc")
+@click.argument("tag", required=True)
+@click.pass_obj
+@require_active_env
+def halt_svc(shepherd: ShepherdMng, envCfg: EnvironmentCfg, tag: str):
+    """Stop service."""
+    shepherd.serviceMng.stop_svc(envCfg, tag)
+
+
+# =====================================================
+# RELOAD
+# =====================================================
+@cli.group()
+def reload():
+    """Reload resources."""
+    pass
+
+
+@reload.command(name="env")
+@click.pass_obj
+@require_active_env
+def reload_env(shepherd: ShepherdMng, envCfg: EnvironmentCfg):
     """Reload environment."""
     shepherd.environmentMng.reload_env(envCfg)
 
 
-@env.command(name="render")
-@click.argument("env_tag", required=False)
-@click.pass_obj
-def env_render(shepherd: ShepherdMng, env_tag: str):
-    """Render environment configuration."""
-    click.echo(shepherd.environmentMng.render_env(env_tag))
-
-
-@env.command(name="status")
+@reload.command(name="svc")
+@click.argument("tag", required=True)
 @click.pass_obj
 @require_active_env
-def env_status(shepherd: ShepherdMng, envCfg: EnvironmentCfg):
-    """Print environment's status."""
-    shepherd.environmentMng.status_env(envCfg)
-
-
-@env.command(name="add")
-@click.argument("resource_type", required=True)
-@click.argument("resource_tag", required=True)
-@click.argument("resource_template", required=False)
-@click.argument("resource_class", required=False)
-@click.pass_obj
-@require_active_env
-def env_add_resource(
-    shepherd: ShepherdMng,
-    envCfg: EnvironmentCfg,
-    resource_type: str,
-    resource_tag: str,
-    resource_template: Optional[str] = None,
-    resource_class: Optional[str] = None,
-):
-    """Add a resource to the current environment.
-
-    RESOURCE_TYPE: The type of resource to add (e.g., svc).
-    RESOURCE_TAG: The name of the resource (e.g., redis-1).
-    RESOURCE_TEMPLATE: Optional template for the resource (e.g., redis).
-    RESOURCE_CLASS: Optional class of the resource (e.g., database).
-    """
-    if resource_type == shepherd.configMng.constants.RESOURCE_TYPE_SVC:
-        shepherd.environmentMng.add_service(
-            envCfg.tag, resource_tag, resource_template, resource_class
-        )
-    else:
-        raise click.UsageError(f"Unsupported resource type: {resource_type}")
-
-
-@cli.group()
-def svc():
-    """Service related operations."""
-    pass
-
-
-@svc.command(name="build")
-@click.argument("service_template", type=str, required=True)
-@click.pass_obj
-def svc_build(shepherd: ShepherdMng, service_template: str):
-    """Build service image."""
-    shepherd.serviceMng.build_image_svc(service_template)
-
-
-@svc.command(name="up")
-@click.argument("service_tag", type=str, required=True)
-@click.pass_obj
-@require_active_env
-def svc_up(shepherd: ShepherdMng, envCfg: EnvironmentCfg, service_tag: str):
-    """Start service."""
-    shepherd.serviceMng.start_svc(envCfg, service_tag)
-
-
-@svc.command(name="halt")
-@click.argument("service_tag", type=str, required=True)
-@click.pass_obj
-@require_active_env
-def svc_halt(shepherd: ShepherdMng, envCfg: EnvironmentCfg, service_tag: str):
-    """Halt service."""
-    shepherd.serviceMng.halt_svc(envCfg, service_tag)
-
-
-@svc.command(name="reload")
-@click.argument("service_tag", type=str, required=True)
-@click.pass_obj
-@require_active_env
-def svc_reload(shepherd: ShepherdMng, envCfg: EnvironmentCfg, service_tag: str):
+def reload_svc(shepherd: ShepherdMng, envCfg: EnvironmentCfg, tag: str):
     """Reload service."""
-    shepherd.serviceMng.reload_svc(envCfg, service_tag)
+    shepherd.serviceMng.reload_svc(envCfg, tag)
 
 
-@svc.command(name="render")
-@click.argument("service_tag", type=str, required=True)
+# =====================================================
+# BUILD
+# =====================================================
+@cli.command(name="build")
+@click.argument("tag", required=True)
+@click.pass_obj
+def build(shepherd: ShepherdMng, tag: str):
+    """Build service image."""
+    shepherd.serviceMng.build_image_svc(tag)
+
+
+# =====================================================
+# LOGS
+# =====================================================
+@cli.command(name="logs")
+@click.argument("tag", required=True)
 @click.pass_obj
 @require_active_env
-def svc_render(shepherd: ShepherdMng, envCfg: EnvironmentCfg, service_tag: str):
-    """Render service configuration."""
-    click.echo(shepherd.serviceMng.render_svc(envCfg, service_tag))
+def logs(shepherd: ShepherdMng, envCfg: EnvironmentCfg, tag: str):
+    """Show service logs."""
+    shepherd.serviceMng.logs_svc(envCfg, tag)
 
 
-@svc.command(name="stdout")
-@click.argument("service_tag", type=str, required=True)
+# =====================================================
+# SHELL
+# =====================================================
+@cli.command(name="shell")
+@click.argument("tag", required=True)
 @click.pass_obj
 @require_active_env
-def svc_stdout(shepherd: ShepherdMng, envCfg: EnvironmentCfg, service_tag: str):
-    """Show service stdout."""
-    shepherd.serviceMng.stdout_svc(envCfg, service_tag)
+def shell(shepherd: ShepherdMng, envCfg: EnvironmentCfg, tag: str):
+    """Get a shell session for a service."""
+    shepherd.serviceMng.shell_svc(envCfg, tag)
 
 
-@svc.command(name="shell")
-@click.argument("service_tag", type=str, required=True)
+# =====================================================
+# STATUS
+# =====================================================
+@cli.group(invoke_without_command=True)
 @click.pass_obj
 @require_active_env
-def svc_shell(shepherd: ShepherdMng, envCfg: EnvironmentCfg, service_tag: str):
-    """Get a shell session for the service."""
-    shepherd.serviceMng.shell_svc(envCfg, service_tag)
+def status(shepherd: ShepherdMng, envCfg: EnvironmentCfg):
+    """Show status of resources."""
+    ctx = click.get_current_context()
+    if ctx.invoked_subcommand is None:
+        shepherd.environmentMng.status_env(envCfg)
+
+
+@status.command(name="env")
+@click.pass_obj
+@require_active_env
+def status_env(shepherd: ShepherdMng, envCfg: EnvironmentCfg):
+    """Show environment status."""
+    shepherd.environmentMng.status_env(envCfg)
 
 
 if __name__ == "__main__":

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -249,25 +249,12 @@ def test_completion_no_args(
     sm = ShepherdMng()
     completions = sm.completionMng.get_completions([])
     assert (
-        completions == sm.completionMng.CATEGORIES
-    ), "Expected categories only"
+        completions == sm.completionMng.VERBS
+    ), "Expected Verbs and Shortcuts only"
 
 
 @pytest.mark.compl
-def test_completion_env_commands(
-    shpd_conf: tuple[Path, Path],
-    runner: CliRunner,
-    mocker: MockerFixture,
-):
-    sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["env"])
-    assert (
-        completions == sm.completionMng.completionEnvMng.COMMANDS_ENV
-    ), "Expected env commands only"
-
-
-@pytest.mark.compl
-def test_completion_env_init(
+def test_completion_add(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -278,14 +265,32 @@ def test_completion_env_init(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["env", "init"])
+    completions = sm.completionMng.get_completions(["add"])
+    assert (
+        completions == sm.completionMng.VERB_CATEGORIES["add"]
+    ), "Expected add completion"
+
+
+@pytest.mark.compl
+def test_completion_add_env(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["add", "env"])
     assert (
         completions == sm.configMng.get_environment_template_tags()
-    ), "Expected init completion"
+    ), "Expected add-env completion"
 
 
 @pytest.mark.compl
-def test_completion_env_clone(
+def test_completion_add_svc_1(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -296,12 +301,12 @@ def test_completion_env_clone(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["env", "clone"])
-    assert completions == ["test-1", "test-2"], "Expected clone completion"
+    completions = sm.completionMng.get_completions(["add", "svc"])
+    assert completions == ["t1", "t2"], "Expected add svc -1- completion"
 
 
 @pytest.mark.compl
-def test_completion_env_rename(
+def test_completion_add_svc_2(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -312,198 +317,12 @@ def test_completion_env_rename(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["env", "rename"])
-    assert completions == ["test-1", "test-2"], "Expected rename completion"
+    completions = sm.completionMng.get_completions(["add", "svc", "t1"])
+    assert completions == [], "Expected add svc -2- completion"
 
 
 @pytest.mark.compl
-def test_completion_env_checkout(
-    shpd_conf: tuple[Path, Path],
-    runner: CliRunner,
-    mocker: MockerFixture,
-):
-    shpd_path = shpd_conf[0]
-    shpd_path.mkdir(parents=True, exist_ok=True)
-    shpd_yaml = shpd_path / ".shpd.yaml"
-    shpd_yaml.write_text(shpd_config)
-
-    sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["env", "checkout"])
-    assert completions == [
-        "test-2",
-    ], "Expected checkout completion"
-
-
-@pytest.mark.compl
-def test_completion_env_delete(
-    shpd_conf: tuple[Path, Path],
-    runner: CliRunner,
-    mocker: MockerFixture,
-):
-    shpd_path = shpd_conf[0]
-    shpd_path.mkdir(parents=True, exist_ok=True)
-    shpd_yaml = shpd_path / ".shpd.yaml"
-    shpd_yaml.write_text(shpd_config)
-
-    sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["env", "delete"])
-    assert completions == [
-        "test-1",
-        "test-2",
-    ], "Expected delete completion"
-
-
-@pytest.mark.compl
-def test_completion_env_list(
-    shpd_conf: tuple[Path, Path],
-    runner: CliRunner,
-    mocker: MockerFixture,
-):
-    shpd_path = shpd_conf[0]
-    shpd_path.mkdir(parents=True, exist_ok=True)
-    shpd_yaml = shpd_path / ".shpd.yaml"
-    shpd_yaml.write_text(shpd_config)
-
-    sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["env", "list"])
-    assert completions == [], "Expected list completion"
-
-
-@pytest.mark.compl
-def test_completion_env_up(
-    shpd_conf: tuple[Path, Path],
-    runner: CliRunner,
-    mocker: MockerFixture,
-):
-    shpd_path = shpd_conf[0]
-    shpd_path.mkdir(parents=True, exist_ok=True)
-    shpd_yaml = shpd_path / ".shpd.yaml"
-    shpd_yaml.write_text(shpd_config)
-
-    sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["env", "up"])
-    assert completions == [], "Expected up completion"
-
-
-@pytest.mark.compl
-def test_completion_env_halt(
-    shpd_conf: tuple[Path, Path],
-    runner: CliRunner,
-    mocker: MockerFixture,
-):
-    shpd_path = shpd_conf[0]
-    shpd_path.mkdir(parents=True, exist_ok=True)
-    shpd_yaml = shpd_path / ".shpd.yaml"
-    shpd_yaml.write_text(shpd_config)
-
-    sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["env", "halt"])
-    assert completions == [], "Expected halt completion"
-
-
-@pytest.mark.compl
-def test_completion_env_reload(
-    shpd_conf: tuple[Path, Path],
-    runner: CliRunner,
-    mocker: MockerFixture,
-):
-    shpd_path = shpd_conf[0]
-    shpd_path.mkdir(parents=True, exist_ok=True)
-    shpd_yaml = shpd_path / ".shpd.yaml"
-    shpd_yaml.write_text(shpd_config)
-
-    sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["env", "reload"])
-    assert completions == [], "Expected reload completion"
-
-
-@pytest.mark.compl
-def test_completion_env_render(
-    shpd_conf: tuple[Path, Path],
-    runner: CliRunner,
-    mocker: MockerFixture,
-):
-    shpd_path = shpd_conf[0]
-    shpd_path.mkdir(parents=True, exist_ok=True)
-    shpd_yaml = shpd_path / ".shpd.yaml"
-    shpd_yaml.write_text(shpd_config)
-
-    sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["env", "render"])
-    assert completions == [
-        "test-1",
-        "test-2",
-    ], "Expected render completion"
-
-
-@pytest.mark.compl
-def test_completion_env_status(
-    shpd_conf: tuple[Path, Path],
-    runner: CliRunner,
-    mocker: MockerFixture,
-):
-    shpd_path = shpd_conf[0]
-    shpd_path.mkdir(parents=True, exist_ok=True)
-    shpd_yaml = shpd_path / ".shpd.yaml"
-    shpd_yaml.write_text(shpd_config)
-
-    sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["env", "status"])
-    assert completions == [], "Expected status completion"
-
-
-@pytest.mark.compl
-def test_completion_env_add_1(
-    shpd_conf: tuple[Path, Path],
-    runner: CliRunner,
-    mocker: MockerFixture,
-):
-    shpd_path = shpd_conf[0]
-    shpd_path.mkdir(parents=True, exist_ok=True)
-    shpd_yaml = shpd_path / ".shpd.yaml"
-    shpd_yaml.write_text(shpd_config)
-
-    sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["env", "add"])
-    assert (
-        completions == sm.configMng.constants.RESOURCE_TYPES
-    ), "Expected add-1 completion"
-
-
-@pytest.mark.compl
-def test_completion_env_add_2(
-    shpd_conf: tuple[Path, Path],
-    runner: CliRunner,
-    mocker: MockerFixture,
-):
-    shpd_path = shpd_conf[0]
-    shpd_path.mkdir(parents=True, exist_ok=True)
-    shpd_yaml = shpd_path / ".shpd.yaml"
-    shpd_yaml.write_text(shpd_config)
-
-    sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["env", "add", "svc"])
-    assert completions == [], "Expected add-2 completion"
-
-
-@pytest.mark.compl
-def test_completion_env_add_3(
-    shpd_conf: tuple[Path, Path],
-    runner: CliRunner,
-    mocker: MockerFixture,
-):
-    shpd_path = shpd_conf[0]
-    shpd_path.mkdir(parents=True, exist_ok=True)
-    shpd_yaml = shpd_path / ".shpd.yaml"
-    shpd_yaml.write_text(shpd_config)
-
-    sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["env", "add", "svc", "foo"])
-    assert completions == ["t1", "t2"], "Expected add-3 completion"
-
-
-@pytest.mark.compl
-def test_completion_env_add_4(
+def test_completion_add_svc_3(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -515,26 +334,31 @@ def test_completion_env_add_4(
 
     sm = ShepherdMng()
     completions = sm.completionMng.get_completions(
-        ["env", "add", "svc", "foo", "t1"]
+        ["add", "svc", "t1", "svc-tag"]
     )
-    assert completions == ["foo-class"], "Expected add-4 completion"
+    assert completions == ["foo-class"], "Expected add svc -3- completion"
 
 
 @pytest.mark.compl
-def test_completion_svc_commands(
+def test_completion_clone(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
 ):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["svc"])
+    completions = sm.completionMng.get_completions(["clone"])
     assert (
-        completions == sm.completionMng.completionSvcMng.COMMANDS_SVC
-    ), "Expected svc commands only"
+        completions == sm.completionMng.VERB_CATEGORIES["clone"]
+    ), "Expected clone completion"
 
 
 @pytest.mark.compl
-def test_completion_svc_build(
+def test_completion_clone_env(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -545,12 +369,12 @@ def test_completion_svc_build(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["svc", "build"])
-    assert completions == ["t1", "t2"], "Expected build completion"
+    completions = sm.completionMng.get_completions(["clone", "env"])
+    assert completions == ["test-1", "test-2"], "Expected env clone completion"
 
 
 @pytest.mark.compl
-def test_completion_svc_up(
+def test_completion_rename(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -561,12 +385,14 @@ def test_completion_svc_up(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["svc", "up"])
-    assert completions == ["red", "white"], "Expected up completion"
+    completions = sm.completionMng.get_completions(["rename"])
+    assert (
+        completions == sm.completionMng.VERB_CATEGORIES["rename"]
+    ), "Expected rename completion"
 
 
 @pytest.mark.compl
-def test_completion_svc_halt(
+def test_completion_rename_env(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -577,12 +403,12 @@ def test_completion_svc_halt(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["svc", "halt"])
-    assert completions == ["red", "white"], "Expected halt completion"
+    completions = sm.completionMng.get_completions(["rename", "env"])
+    assert completions == ["test-1", "test-2"], "Expected env rename completion"
 
 
 @pytest.mark.compl
-def test_completion_svc_reload(
+def test_completion_checkout_env(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -593,12 +419,14 @@ def test_completion_svc_reload(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["svc", "reload"])
-    assert completions == ["red", "white"], "Expected reload completion"
+    completions = sm.completionMng.get_completions(["checkout"])
+    assert completions == [
+        "test-2",
+    ], "Expected env checkout completion"
 
 
 @pytest.mark.compl
-def test_completion_svc_render(
+def test_completion_delete(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -609,12 +437,14 @@ def test_completion_svc_render(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["svc", "render"])
-    assert completions == ["red", "white"], "Expected render completion"
+    completions = sm.completionMng.get_completions(["delete"])
+    assert (
+        completions == sm.completionMng.VERB_CATEGORIES["delete"]
+    ), "Expected delete completion"
 
 
 @pytest.mark.compl
-def test_completion_svc_stdout(
+def test_completion_delete_env(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -625,12 +455,15 @@ def test_completion_svc_stdout(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["svc", "stdout"])
-    assert completions == ["red", "white"], "Expected stdout completion"
+    completions = sm.completionMng.get_completions(["delete", "env"])
+    assert completions == [
+        "test-1",
+        "test-2",
+    ], "Expected env delete completion"
 
 
 @pytest.mark.compl
-def test_completion_svc_shell(
+def test_completion_list(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -641,5 +474,291 @@ def test_completion_svc_shell(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["svc", "shell"])
-    assert completions == ["red", "white"], "Expected shell completion"
+    completions = sm.completionMng.get_completions(["list"])
+    assert completions == [], "Expected list completion"
+
+
+@pytest.mark.compl
+def test_completion_start(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["up"])
+    assert (
+        completions == sm.completionMng.VERB_CATEGORIES["up"]
+    ), "Expected up completion"
+
+
+@pytest.mark.compl
+def test_completion_start_env(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["up", "env"])
+    assert completions == [], "Expected env up completion"
+
+
+@pytest.mark.compl
+def test_completion_start_svc(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["up", "svc"])
+    assert completions == ["red", "white"], "Expected up svc completion"
+
+
+@pytest.mark.compl
+def test_completion_stop(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["halt"])
+    assert (
+        completions == sm.completionMng.VERB_CATEGORIES["halt"]
+    ), "Expected halt completion"
+
+
+@pytest.mark.compl
+def test_completion_stop_env(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["halt", "env"])
+    assert completions == [], "Expected env halt completion"
+
+
+@pytest.mark.compl
+def test_completion_stop_svc(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["halt", "svc"])
+    assert completions == ["red", "white"], "Expected halt svc completion"
+
+
+@pytest.mark.compl
+def test_completion_reload(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["reload"])
+    assert (
+        completions == sm.completionMng.VERB_CATEGORIES["reload"]
+    ), "Expected reload completion"
+
+
+@pytest.mark.compl
+def test_completion_reload_env(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["reload", "env"])
+    assert completions == [], "Expected env reload completion"
+
+
+@pytest.mark.compl
+def test_completion_reload_svc(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["reload", "svc"])
+    assert completions == ["red", "white"], "Expected reload svc completion"
+
+
+@pytest.mark.compl
+def test_completion_get(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["get"])
+    assert (
+        completions == sm.completionMng.VERB_CATEGORIES["get"]
+    ), "Expected get completion"
+
+
+@pytest.mark.compl
+def test_completion_get_env_oyaml(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["get", "env", "-oyaml"])
+    assert completions == [
+        "test-1",
+        "test-2",
+    ], "Expected get env -oyaml completion"
+
+
+@pytest.mark.compl
+def test_completion_get_env(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["get", "env"])
+    assert completions == [
+        "test-1",
+        "test-2",
+    ], "Expected get env completion"
+
+
+@pytest.mark.compl
+def test_completion_get_svc_oyaml(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["get", "svc", "-oyaml"])
+    assert completions == ["red", "white"], "Expected get svc -oyaml completion"
+
+
+@pytest.mark.compl
+def test_completion_build_svc(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["build"])
+    assert completions == ["t1", "t2"], "Expected build svc completion"
+
+
+@pytest.mark.compl
+def test_completion_logs_svc(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["logs"])
+    assert completions == ["red", "white"], "Expected logs svc completion"
+
+
+@pytest.mark.compl
+def test_completion_shell_svc(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["shell"])
+    assert completions == ["red", "white"], "Expected shell svc completion"
+
+
+@pytest.mark.compl
+def test_completion_status_env(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["status", "env"])
+    assert completions == [], "Expected status env completion"

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -304,7 +304,7 @@ def test_env_render_compose_env_ext_net(
     shpd_yaml = shpd_path / ".shpd.yaml"
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["env", "render", "test-1"])
+    result = runner.invoke(cli, ["get", "env", "test-1", "-oyaml"])
     assert result.exit_code == 0
 
     assert result.output == (
@@ -368,7 +368,7 @@ def test_env_render_compose_env_int_net(
     shpd_yaml = shpd_path / ".shpd.yaml"
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["env", "render", "test-2"])
+    result = runner.invoke(cli, ["get", "env", "test-2", "-oyaml"])
     assert result.exit_code == 0
 
     assert result.output == (
@@ -435,7 +435,7 @@ def test_env_render_compose_env_int_net(
 
 
 @pytest.mark.docker
-def test_env_start(
+def test_start_env(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -455,7 +455,7 @@ def test_env_start(
         ),
     )
 
-    result = runner.invoke(cli, ["env", "up"])
+    result = runner.invoke(cli, ["up", "env"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -468,7 +468,7 @@ def test_env_start(
 
 
 @pytest.mark.docker
-def test_env_stop(
+def test_stop_env(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -488,7 +488,7 @@ def test_env_stop(
         ),
     )
 
-    result = runner.invoke(cli, ["env", "up"])
+    result = runner.invoke(cli, ["up", "env"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -500,7 +500,7 @@ def test_env_stop(
         ),
     )
 
-    result = runner.invoke(cli, ["env", "halt"])
+    result = runner.invoke(cli, ["halt", "env"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -513,7 +513,7 @@ def test_env_stop(
 
 
 @pytest.mark.docker
-def test_env_restart(
+def test_reload_env(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -533,7 +533,7 @@ def test_env_restart(
         ),
     )
 
-    result = runner.invoke(cli, ["env", "up"])
+    result = runner.invoke(cli, ["up", "env"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -545,7 +545,7 @@ def test_env_restart(
         ),
     )
 
-    result = runner.invoke(cli, ["env", "reload"])
+    result = runner.invoke(cli, ["reload", "env"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -558,7 +558,7 @@ def test_env_restart(
 
 
 @pytest.mark.docker
-def test_env_status(
+def test_status_env(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -578,6 +578,6 @@ def test_env_status(
         ),
     )
 
-    result = runner.invoke(cli, ["env", "status"])
+    result = runner.invoke(cli, ["status", "env"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()

--- a/src/tests/test_environment.py
+++ b/src/tests/test_environment.py
@@ -286,12 +286,12 @@ def runner() -> CliRunner:
 
 
 @pytest.mark.env
-def test_env_init(
+def test_add_env(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
 ):
-    result = runner.invoke(cli, ["env", "init", "default", "test-init-1"])
+    result = runner.invoke(cli, ["add", "env", "default", "test-init-1"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
@@ -306,16 +306,16 @@ def test_env_init(
 
 
 @pytest.mark.env
-def test_env_clone(
+def test_clone_env(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
 ):
-    result = runner.invoke(cli, ["env", "init", "default", "test-clone-1"])
+    result = runner.invoke(cli, ["add", "env", "default", "test-clone-1"])
     assert result.exit_code == 0
 
     result = runner.invoke(
-        cli, ["env", "clone", "test-clone-1", "test-clone-2"]
+        cli, ["clone", "env", "test-clone-1", "test-clone-2"]
     )
     assert result.exit_code == 0
 
@@ -335,16 +335,16 @@ def test_env_clone(
 
 
 @pytest.mark.env
-def test_env_rename(
+def test_rename_env(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
 ):
-    result = runner.invoke(cli, ["env", "init", "default", "test-rename-1"])
+    result = runner.invoke(cli, ["add", "env", "default", "test-rename-1"])
     assert result.exit_code == 0
 
     result = runner.invoke(
-        cli, ["env", "rename", "test-rename-1", "test-rename-2"]
+        cli, ["rename", "env", "test-rename-1", "test-rename-2"]
     )
     assert result.exit_code == 0
 
@@ -364,22 +364,22 @@ def test_env_rename(
 
 
 @pytest.mark.env
-def test_env_checkout(
+def test_checkout_env(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
 ):
-    result = runner.invoke(cli, ["env", "init", "default", "test-1"])
+    result = runner.invoke(cli, ["add", "env", "default", "test-1"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "init", "default", "test-2"])
+    result = runner.invoke(cli, ["add", "env", "default", "test-2"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
     env = sm.configMng.get_active_environment()
     assert env is None
 
-    result = runner.invoke(cli, ["env", "checkout", "test-1"])
+    result = runner.invoke(cli, ["checkout", "test-1"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
@@ -387,7 +387,7 @@ def test_env_checkout(
     assert env is not None
     assert env.tag == "test-1"
 
-    result = runner.invoke(cli, ["env", "checkout", "test-2"])
+    result = runner.invoke(cli, ["checkout", "test-2"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
@@ -397,38 +397,38 @@ def test_env_checkout(
 
 
 @pytest.mark.env
-def test_env_list(
+def test_list_env(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
 ):
-    result = runner.invoke(cli, ["env", "init", "default", "test-1"])
+    result = runner.invoke(cli, ["add", "env", "default", "test-1"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "list"])
+    result = runner.invoke(cli, ["list"])
     assert result.exit_code == 0
 
 
 @pytest.mark.env
-def test_env_delete_yes(
+def test_delete_env_yes(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
 ):
     mocker.patch("builtins.input", return_value="y")
 
-    result = runner.invoke(cli, ["env", "init", "default", "test-1"])
+    result = runner.invoke(cli, ["add", "env", "default", "test-1"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "delete", "test-1"])
+    result = runner.invoke(cli, ["delete", "env", "test-1"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "init", "default", "test-1"])
+    result = runner.invoke(cli, ["add", "env", "default", "test-1"])
     assert result.exit_code == 0
 
     mocker.patch("builtins.input", return_value="y")
 
-    result = runner.invoke(cli, ["env", "delete", "test-1"])
+    result = runner.invoke(cli, ["delete", "env", "test-1"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
@@ -443,17 +443,17 @@ def test_env_delete_yes(
 
 
 @pytest.mark.env
-def test_env_delete_no(
+def test_delete_env_no(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
 ):
     mocker.patch("builtins.input", return_value="n")
 
-    result = runner.invoke(cli, ["env", "init", "default", "test-1"])
+    result = runner.invoke(cli, ["add", "env", "default", "test-1"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "delete", "test-1"])
+    result = runner.invoke(cli, ["delete", "env", "test-1"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
@@ -468,16 +468,16 @@ def test_env_delete_no(
 
 
 @pytest.mark.env
-def test_env_add_nonexisting_resource(
+def test_add_nonexisting_service(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
 ):
-    result = runner.invoke(cli, ["env", "init", "default", "test-svc-add"])
+    result = runner.invoke(cli, ["add", "env", "default", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "checkout", "test-svc-add"])
+    result = runner.invoke(cli, ["checkout", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "add", "foo", "foo-1"])
-    assert result.exit_code == 2
+    result = runner.invoke(cli, ["add", "svc", "foo", "foo-1"])
+    assert result.exit_code == 1

--- a/src/tests/test_service.py
+++ b/src/tests/test_service.py
@@ -223,16 +223,16 @@ def runner() -> CliRunner:
 
 
 @pytest.mark.svc
-def test_svc_add_one_default(
+def test_add_svc_one_default(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
-    result = runner.invoke(cli, ["env", "init", "default", "test-svc-add"])
+    result = runner.invoke(cli, ["add", "env", "default", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "checkout", "test-svc-add"])
+    result = runner.invoke(cli, ["checkout", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "add", "svc", "svc-1"])
+    result = runner.invoke(cli, ["add", "svc", "default", "svc-1"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
@@ -288,19 +288,19 @@ def test_svc_add_one_default(
 
 
 @pytest.mark.svc
-def test_svc_add_two_default(
+def test_add_svc_two_default(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
-    result = runner.invoke(cli, ["env", "init", "default", "test-svc-add"])
+    result = runner.invoke(cli, ["add", "env", "default", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "checkout", "test-svc-add"])
+    result = runner.invoke(cli, ["checkout", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "add", "svc", "svc-1"])
+    result = runner.invoke(cli, ["add", "svc", "default", "svc-1"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "add", "svc", "svc-2"])
+    result = runner.invoke(cli, ["add", "svc", "default", "svc-2"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
@@ -353,19 +353,19 @@ def test_svc_add_two_default(
 
 
 @pytest.mark.svc
-def test_svc_add_two_same_tag_default(
+def test_add_svc_two_same_tag_default(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
-    result = runner.invoke(cli, ["env", "init", "default", "test-svc-add"])
+    result = runner.invoke(cli, ["add", "env", "default", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "checkout", "test-svc-add"])
+    result = runner.invoke(cli, ["checkout", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "add", "svc", "svc-1"])
+    result = runner.invoke(cli, ["add", "svc", "default", "svc-1"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "add", "svc", "svc-1"])
+    result = runner.invoke(cli, ["add", "svc", "default", "svc-1"])
     assert result.exit_code == 1
 
     sm = ShepherdMng()
@@ -396,7 +396,7 @@ def test_svc_add_two_same_tag_default(
 
 
 @pytest.mark.svc
-def test_svc_add_one_with_template(
+def test_add_svc_one_with_template(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
     shpd_path = shpd_conf[0]
@@ -404,15 +404,13 @@ def test_svc_add_one_with_template(
     shpd_yaml = shpd_path / ".shpd.yaml"
     shpd_yaml.write_text(shpd_config_pg_template)
 
-    result = runner.invoke(cli, ["env", "init", "default", "test-svc-add"])
+    result = runner.invoke(cli, ["add", "env", "default", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["env", "checkout", "test-svc-add"])
+    result = runner.invoke(cli, ["checkout", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(
-        cli, ["env", "add", "svc", "pg-1", "postgres", "database"]
-    )
+    result = runner.invoke(cli, ["add", "svc", "postgres", "pg-1", "database"])
 
     # no 'postgres' factory, so this should fail
     assert result.exit_code == 1
@@ -428,38 +426,3 @@ def test_svc_add_one_with_template(
     assert (
         env.services[0].tag == "service-default"
     ), "Service tag should be 'service-default'"
-
-
-@pytest.mark.svc
-def test_svc_render_compose_service(
-    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
-):
-    shpd_path = shpd_conf[0]
-    shpd_path.mkdir(parents=True, exist_ok=True)
-    shpd_yaml = shpd_path / ".shpd.yaml"
-    shpd_yaml.write_text(shpd_config_svc_default)
-
-    result = runner.invoke(cli, ["svc", "render", "test"])
-    assert result.exit_code == 0
-
-    assert result.output == (
-        "services:\n"
-        "  test-test-1:\n"
-        "    image: test-image:latest\n"
-        "    hostname: test-test-1\n"
-        "    container_name: test-test-1\n"
-        "    labels:\n"
-        "    - com.example.label1=value1\n"
-        "    - com.example.label2=value2\n"
-        "    volumes:\n"
-        "    - /home/test/.ssh:/home/test/.ssh\n"
-        "    - /etc/ssh:/etc/ssh\n"
-        "    ports:\n"
-        "    - 80:80\n"
-        "    - 443:443\n"
-        "    - 8080:8080\n"
-        "    extra_hosts:\n"
-        "    - host.docker.internal:host-gateway\n"
-        "    networks:\n"
-        "    - default\n\n"
-    )

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -444,18 +444,18 @@ def test_cli_complete(
 
 
 @pytest.mark.shpd
-def test_cli_srv_build(
+def test_cli_build_svc(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
     mock_build = mocker.patch.object(ServiceMng, "build_image_svc")
 
-    result = runner.invoke(cli, ["svc", "build", "service_template"])
+    result = runner.invoke(cli, ["build", "service_template"])
     assert result.exit_code == 0
     mock_build.assert_called_once_with("service_template")
 
 
 @pytest.mark.shpd
-def test_cli_srv_up(
+def test_cli_start_svc(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
     mock_start = mocker.patch.object(ServiceMng, "start_svc")
@@ -464,28 +464,28 @@ def test_cli_srv_up(
     shpd_yaml = shpd_path / ".shpd.yaml"
     shpd_yaml.write_text(shpd_config_svc_default)
 
-    result = runner.invoke(cli, ["svc", "up", "service_tag"])
+    result = runner.invoke(cli, ["up", "svc", "service_tag"])
     assert result.exit_code == 0
     mock_start.assert_called_once()
 
 
 @pytest.mark.shpd
-def test_cli_srv_halt(
+def test_cli_stop_svc(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
-    mock_halt = mocker.patch.object(ServiceMng, "halt_svc")
+    mock_stop = mocker.patch.object(ServiceMng, "stop_svc")
     shpd_path = shpd_conf[0]
     shpd_path.mkdir(parents=True, exist_ok=True)
     shpd_yaml = shpd_path / ".shpd.yaml"
     shpd_yaml.write_text(shpd_config_svc_default)
 
-    result = runner.invoke(cli, ["svc", "halt", "service_tag"])
+    result = runner.invoke(cli, ["halt", "svc", "service_tag"])
     assert result.exit_code == 0
-    mock_halt.assert_called_once()
+    mock_stop.assert_called_once()
 
 
 @pytest.mark.shpd
-def test_cli_srv_reload(
+def test_cli_reload_svc(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
     mock_reload = mocker.patch.object(ServiceMng, "reload_svc")
@@ -494,28 +494,28 @@ def test_cli_srv_reload(
     shpd_yaml = shpd_path / ".shpd.yaml"
     shpd_yaml.write_text(shpd_config_svc_default)
 
-    result = runner.invoke(cli, ["svc", "reload", "service_tag"])
+    result = runner.invoke(cli, ["reload", "svc", "service_tag"])
     assert result.exit_code == 0
     mock_reload.assert_called_once()
 
 
 @pytest.mark.shpd
-def test_cli_srv_stdout(
+def test_cli_logs_svc(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
-    mock_stdout = mocker.patch.object(ServiceMng, "stdout_svc")
+    mock_logs = mocker.patch.object(ServiceMng, "logs_svc")
     shpd_path = shpd_conf[0]
     shpd_path.mkdir(parents=True, exist_ok=True)
     shpd_yaml = shpd_path / ".shpd.yaml"
     shpd_yaml.write_text(shpd_config_svc_default)
 
-    result = runner.invoke(cli, ["svc", "stdout", "service_tag"])
+    result = runner.invoke(cli, ["logs", "service_tag"])
     assert result.exit_code == 0
-    mock_stdout.assert_called_once()
+    mock_logs.assert_called_once()
 
 
 @pytest.mark.shpd
-def test_cli_srv_shell(
+def test_cli_shell_svc(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
     mock_shell = mocker.patch.object(ServiceMng, "shell_svc")
@@ -524,7 +524,7 @@ def test_cli_srv_shell(
     shpd_yaml = shpd_path / ".shpd.yaml"
     shpd_yaml.write_text(shpd_config_svc_default)
 
-    result = runner.invoke(cli, ["svc", "shell", "service_tag"])
+    result = runner.invoke(cli, ["shell", "service_tag"])
     assert result.exit_code == 0
     mock_shell.assert_called_once()
 
@@ -533,51 +533,51 @@ def test_cli_srv_shell(
 
 
 @pytest.mark.shpd
-def test_cli_env_init(
+def test_cli_add_env(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
-    mock_init = mocker.patch.object(EnvironmentMng, "init_env")
+    mock_add = mocker.patch.object(EnvironmentMng, "add_env")
 
-    result = runner.invoke(cli, ["env", "init", "docker-compose", "env_tag"])
+    result = runner.invoke(cli, ["add", "env", "docker-compose", "env_tag"])
     assert result.exit_code == 0
-    mock_init.assert_called_once_with("docker-compose", "env_tag")
+    mock_add.assert_called_once_with("docker-compose", "env_tag")
 
 
 @pytest.mark.shpd
-def test_cli_env_clone(
+def test_cli_clone_env(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
     mock_clone = mocker.patch.object(EnvironmentMng, "clone_env")
 
-    result = runner.invoke(cli, ["env", "clone", "src_env_tag", "dst_env_tag"])
+    result = runner.invoke(cli, ["clone", "env", "src_env_tag", "dst_env_tag"])
     assert result.exit_code == 0
     mock_clone.assert_called_once_with("src_env_tag", "dst_env_tag")
 
 
 @pytest.mark.shpd
-def test_cli_env_checkout(
+def test_cli_checkout_env(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
     mock_checkout = mocker.patch.object(EnvironmentMng, "checkout_env")
 
-    result = runner.invoke(cli, ["env", "checkout", "env_tag"])
+    result = runner.invoke(cli, ["checkout", "env_tag"])
     assert result.exit_code == 0
     mock_checkout.assert_called_once_with("env_tag")
 
 
 @pytest.mark.shpd
-def test_cli_env_list(
+def test_cli_list_env(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
     mock_list = mocker.patch.object(EnvironmentMng, "list_envs")
 
-    result = runner.invoke(cli, ["env", "list"])
+    result = runner.invoke(cli, ["list"])
     assert result.exit_code == 0
     mock_list.assert_called_once()
 
 
 @pytest.mark.shpd
-def test_cli_env_up(
+def test_cli_start_env(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
     mock_start = mocker.patch.object(EnvironmentMng, "start_env")
@@ -586,28 +586,28 @@ def test_cli_env_up(
     shpd_yaml = shpd_path / ".shpd.yaml"
     shpd_yaml.write_text(shpd_config_svc_default)
 
-    result = runner.invoke(cli, ["env", "up"])
+    result = runner.invoke(cli, ["up", "env"])
     assert result.exit_code == 0
     mock_start.assert_called_once()
 
 
 @pytest.mark.shpd
-def test_cli_env_halt(
+def test_cli_stop_env(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
-    mock_halt = mocker.patch.object(EnvironmentMng, "halt_env")
+    mock_stop = mocker.patch.object(EnvironmentMng, "stop_env")
     shpd_path = shpd_conf[0]
     shpd_path.mkdir(parents=True, exist_ok=True)
     shpd_yaml = shpd_path / ".shpd.yaml"
     shpd_yaml.write_text(shpd_config_svc_default)
 
-    result = runner.invoke(cli, ["env", "halt"])
+    result = runner.invoke(cli, ["halt", "env"])
     assert result.exit_code == 0
-    mock_halt.assert_called_once()
+    mock_stop.assert_called_once()
 
 
 @pytest.mark.shpd
-def test_cli_env_reload(
+def test_cli_reload_env(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
     mock_reload = mocker.patch.object(EnvironmentMng, "reload_env")
@@ -616,13 +616,13 @@ def test_cli_env_reload(
     shpd_yaml = shpd_path / ".shpd.yaml"
     shpd_yaml.write_text(shpd_config_svc_default)
 
-    result = runner.invoke(cli, ["env", "reload"])
+    result = runner.invoke(cli, ["reload", "env"])
     assert result.exit_code == 0
     mock_reload.assert_called_once()
 
 
 @pytest.mark.shpd
-def test_cli_env_status(
+def test_cli_status_env(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
     mock_status = mocker.patch.object(EnvironmentMng, "status_env")
@@ -631,6 +631,6 @@ def test_cli_env_status(
     shpd_yaml = shpd_path / ".shpd.yaml"
     shpd_yaml.write_text(shpd_config_svc_default)
 
-    result = runner.invoke(cli, ["env", "status"])
+    result = runner.invoke(cli, ["status", "env"])
     assert result.exit_code == 0
     mock_status.assert_called_once()

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -191,18 +191,7 @@ def test_cli_flags_no_flags(
     result = runner.invoke(cli, ["test"])
 
     assert result.exit_code == 0
-    mock_init.assert_called_once_with(
-        {
-            "verbose": False,
-            "yes": False,
-            "all": False,
-            "follow": False,
-            "porcelain": False,
-            "keep": False,
-            "replace": False,
-            "checkout": False,
-        }
-    )
+    mock_init.assert_called_once_with({"verbose": False, "yes": False})
 
 
 @pytest.mark.shpd
@@ -213,16 +202,7 @@ def test_cli_flags_verbose(
 
     result = runner.invoke(cli, ["--verbose", "test"])
 
-    flags = {
-        "verbose": True,
-        "yes": False,
-        "all": False,
-        "follow": False,
-        "porcelain": False,
-        "keep": False,
-        "replace": False,
-        "checkout": False,
-    }
+    flags = {"verbose": True, "yes": False}
 
     assert result.exit_code == 0
     mock_init.assert_called_once_with(flags)
@@ -241,189 +221,12 @@ def test_cli_flags_yes(
 
     result = runner.invoke(cli, ["--yes", "test"])
 
-    flags = {
-        "verbose": False,
-        "yes": True,
-        "all": False,
-        "follow": False,
-        "porcelain": False,
-        "keep": False,
-        "replace": False,
-        "checkout": False,
-    }
+    flags = {"verbose": False, "yes": True}
 
     assert result.exit_code == 0
     mock_init.assert_called_once_with(flags)
 
     result = runner.invoke(cli, ["-y", "test"])
-
-    assert result.exit_code == 0
-    mock_init.assert_called_with(flags)
-
-
-@pytest.mark.shpd
-def test_cli_flags_all(
-    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
-):
-    mock_init = mocker.patch.object(ShepherdMng, "__init__", return_value=None)
-
-    result = runner.invoke(cli, ["--all", "test"])
-
-    flags = {
-        "verbose": False,
-        "yes": False,
-        "all": True,
-        "follow": False,
-        "porcelain": False,
-        "keep": False,
-        "replace": False,
-        "checkout": False,
-    }
-
-    assert result.exit_code == 0
-    mock_init.assert_called_once_with(flags)
-
-    result = runner.invoke(cli, ["-a", "test"])
-
-    assert result.exit_code == 0
-    mock_init.assert_called_with(flags)
-
-
-@pytest.mark.shpd
-def test_cli_flags_follow(
-    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
-):
-    mock_init = mocker.patch.object(ShepherdMng, "__init__", return_value=None)
-
-    result = runner.invoke(cli, ["--follow", "test"])
-
-    flags = {
-        "verbose": False,
-        "yes": False,
-        "all": False,
-        "follow": True,
-        "porcelain": False,
-        "keep": False,
-        "replace": False,
-        "checkout": False,
-    }
-
-    assert result.exit_code == 0
-    mock_init.assert_called_once_with(flags)
-
-    result = runner.invoke(cli, ["-f", "test"])
-
-    assert result.exit_code == 0
-    mock_init.assert_called_with(flags)
-
-
-@pytest.mark.shpd
-def test_cli_flags_porcelain(
-    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
-):
-    mock_init = mocker.patch.object(ShepherdMng, "__init__", return_value=None)
-
-    result = runner.invoke(cli, ["--porcelain", "test"])
-
-    flags = {
-        "verbose": False,
-        "yes": False,
-        "all": False,
-        "follow": False,
-        "porcelain": True,
-        "keep": False,
-        "replace": False,
-        "checkout": False,
-    }
-
-    assert result.exit_code == 0
-    mock_init.assert_called_once_with(flags)
-
-    result = runner.invoke(cli, ["-p", "test"])
-
-    assert result.exit_code == 0
-    mock_init.assert_called_with(flags)
-
-
-@pytest.mark.shpd
-def test_cli_flags_keep(
-    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
-):
-    mock_init = mocker.patch.object(ShepherdMng, "__init__", return_value=None)
-
-    result = runner.invoke(cli, ["--keep", "test"])
-
-    flags = {
-        "verbose": False,
-        "yes": False,
-        "all": False,
-        "follow": False,
-        "porcelain": False,
-        "keep": True,
-        "replace": False,
-        "checkout": False,
-    }
-
-    assert result.exit_code == 0
-    mock_init.assert_called_once_with(flags)
-
-    result = runner.invoke(cli, ["-k", "test"])
-
-    assert result.exit_code == 0
-    mock_init.assert_called_with(flags)
-
-
-@pytest.mark.shpd
-def test_cli_flags_replace(
-    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
-):
-    mock_init = mocker.patch.object(ShepherdMng, "__init__", return_value=None)
-
-    result = runner.invoke(cli, ["--replace", "test"])
-
-    flags = {
-        "verbose": False,
-        "yes": False,
-        "all": False,
-        "follow": False,
-        "porcelain": False,
-        "keep": False,
-        "replace": True,
-        "checkout": False,
-    }
-
-    assert result.exit_code == 0
-    mock_init.assert_called_once_with(flags)
-
-    result = runner.invoke(cli, ["-r", "test"])
-
-    assert result.exit_code == 0
-    mock_init.assert_called_with(flags)
-
-
-@pytest.mark.shpd
-def test_cli_flags_checkout(
-    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
-):
-    mock_init = mocker.patch.object(ShepherdMng, "__init__", return_value=None)
-
-    result = runner.invoke(cli, ["--checkout", "test"])
-
-    flags = {
-        "verbose": False,
-        "yes": False,
-        "all": False,
-        "follow": False,
-        "porcelain": False,
-        "keep": False,
-        "replace": False,
-        "checkout": True,
-    }
-
-    assert result.exit_code == 0
-    mock_init.assert_called_once_with(flags)
-
-    result = runner.invoke(cli, ["-c", "test"])
 
     assert result.exit_code == 0
     mock_init.assert_called_with(flags)

--- a/src/tests/test_svc_docker_compose.py
+++ b/src/tests/test_svc_docker_compose.py
@@ -164,7 +164,7 @@ def test_svc_render_compose_service(
     shpd_yaml = shpd_path / ".shpd.yaml"
     shpd_yaml.write_text(shpd_config_svc_default)
 
-    result = runner.invoke(cli, ["svc", "render", "test"])
+    result = runner.invoke(cli, ["get", "svc", "test", "-oyaml"])
     assert result.exit_code == 0
 
     assert result.output == (
@@ -191,7 +191,7 @@ def test_svc_render_compose_service(
 
 
 @pytest.mark.docker
-def test_svc_start(
+def test_start_svc(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -211,7 +211,7 @@ def test_svc_start(
         ),
     )
 
-    result = runner.invoke(cli, ["env", "up"])
+    result = runner.invoke(cli, ["up", "env"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -223,13 +223,13 @@ def test_svc_start(
         ),
     )
 
-    result = runner.invoke(cli, ["svc", "up", "test"])
+    result = runner.invoke(cli, ["up", "svc", "test"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
 
 @pytest.mark.docker
-def test_svc_stop(
+def test_stop_svc(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -249,7 +249,7 @@ def test_svc_stop(
         ),
     )
 
-    result = runner.invoke(cli, ["env", "up"])
+    result = runner.invoke(cli, ["up", "env"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -261,13 +261,13 @@ def test_svc_stop(
         ),
     )
 
-    result = runner.invoke(cli, ["svc", "halt", "test"])
+    result = runner.invoke(cli, ["halt", "svc", "test"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
 
 @pytest.mark.docker
-def test_svc_reload(
+def test_reload_svc(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -287,7 +287,7 @@ def test_svc_reload(
         ),
     )
 
-    result = runner.invoke(cli, ["env", "up"])
+    result = runner.invoke(cli, ["up", "env"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -299,13 +299,13 @@ def test_svc_reload(
         ),
     )
 
-    result = runner.invoke(cli, ["svc", "reload", "test"])
+    result = runner.invoke(cli, ["reload", "svc", "test"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
 
 @pytest.mark.docker
-def test_svc_stdout(
+def test_logs_svc(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -325,7 +325,7 @@ def test_svc_stdout(
         ),
     )
 
-    result = runner.invoke(cli, ["env", "up"])
+    result = runner.invoke(cli, ["up", "env"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -337,13 +337,13 @@ def test_svc_stdout(
         ),
     )
 
-    result = runner.invoke(cli, ["svc", "stdout", "test"])
+    result = runner.invoke(cli, ["logs", "test"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
 
 @pytest.mark.docker
-def test_svc_shell(
+def test_shell_svc(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -363,7 +363,7 @@ def test_svc_shell(
         ),
     )
 
-    result = runner.invoke(cli, ["env", "up"])
+    result = runner.invoke(cli, ["up", "env"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -375,6 +375,6 @@ def test_svc_shell(
         ),
     )
 
-    result = runner.invoke(cli, ["svc", "shell", "test"])
+    result = runner.invoke(cli, ["shell", "test"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()


### PR DESCRIPTION
Refactored shepctl CLI commands to align with the Kubernetes (kubectl) style of interaction.

Fixes: #134

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality
to change)
- [ ] Change or update to the documentation (with no functional changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
