### PR TITLE
feat(CLI): add -t, --target flag-option for: get env/svc

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -499,6 +499,15 @@ class ServiceCfg(Resolvable):
             self.ingress if self.ingress is not None else "false"
         )
 
+    def get_yaml(self) -> str:
+        """
+        Returns the YAML representation of the service configuration.
+        """
+        self.set_unresolved()
+        yml = yaml.dump(cfg_asdict(self), sort_keys=False)
+        self.set_resolved()
+        return yml
+
 
 @dataclass
 class EnvironmentTemplateCfg(Resolvable):
@@ -540,6 +549,15 @@ class EnvironmentCfg(Resolvable):
             if svc.tag == svcTag:
                 return svc
         return None
+
+    def get_yaml(self) -> str:
+        """
+        Returns the YAML representation of the environment configuration.
+        """
+        self.set_unresolved()
+        yml = yaml.dump(cfg_asdict(self), sort_keys=False)
+        self.set_resolved()
+        return yml
 
 
 @dataclass

--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -92,7 +92,7 @@ class DockerComposeEnv(Environment):
             run_compose(self.envCfg.status.triggered_config, "restart")
 
     @override
-    def render(self) -> str:
+    def render_target(self) -> str:
         """
         Render the full docker-compose YAML configuration for the environment.
         """
@@ -105,8 +105,8 @@ class DockerComposeEnv(Environment):
         }
 
         for svc in self.services:
-            svc_yaml = yaml.safe_load(svc.render())
-            compose_config["services"].update(svc_yaml["services"])
+            svc_yaml = yaml.safe_load(svc.render_target())
+            compose_config["services"].update(svc_yaml)
 
         if self.envCfg.networks:
             for net in self.envCfg.networks:
@@ -157,7 +157,7 @@ class DockerComposeEnv(Environment):
         yaml = (
             self.envCfg.status.triggered_config
             if self.envCfg.status.triggered_config
-            else self.render()
+            else self.render_target()
         )
 
         result = run_compose(yaml, "ps", "--format", "json", capture=True)

--- a/src/docker/docker_compose_svc.py
+++ b/src/docker/docker_compose_svc.py
@@ -38,7 +38,7 @@ class DockerComposeSvc(Service):
         super().__init__(config, envCfg, svcCfg)
 
     @override
-    def render(self) -> str:
+    def render_target(self) -> str:
         """
         Render the docker-compose service configuration for this service.
         """
@@ -61,9 +61,7 @@ class DockerComposeSvc(Service):
         if self.svcCfg.networks:
             service_def["networks"] = self.svcCfg.networks
 
-        return yaml.dump(
-            {"services": {self.name: service_def}}, sort_keys=False
-        )
+        return yaml.dump({self.name: service_def}, sort_keys=False)
 
     @override
     def build(self):

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -68,10 +68,14 @@ class Environment(ABC):
         """Reload the environment."""
         pass
 
-    @abstractmethod
     def render(self) -> str:
+        """Render the environment configuration."""
+        return self.envCfg.get_yaml()
+
+    @abstractmethod
+    def render_target(self) -> str:
         """
-        Render the environment configuration.
+        Render the environment configuration in the target system.
         """
         pass
 
@@ -320,7 +324,7 @@ class EnvironmentMng:
     def start_env(self, envCfg: EnvironmentCfg):
         """Start an environment."""
         env = self.get_environment_from_cfg(envCfg)
-        env.envCfg.status.triggered_config = env.render()
+        env.envCfg.status.triggered_config = env.render_target()
         env.sync_config()
         env.start()
         Util.print(f"Started environment: {env.envCfg.tag}")
@@ -344,10 +348,12 @@ class EnvironmentMng:
         env.reload()
         Util.print(f"Reloaded environment: {env.envCfg.tag}")
 
-    def render_env(self, env_tag: str) -> Optional[str]:
+    def render_env(self, env_tag: str, target: bool) -> Optional[str]:
         """Render an environment configuration."""
         env = self.get_environment_from_tag(env_tag)
         if env:
+            if target:
+                return env.render_target()
             return env.render()
         return None
 

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -47,10 +47,14 @@ class Service(ABC):
         """
         return f"{self.svcCfg.tag}-{self.envCfg.tag}"
 
-    @abstractmethod
     def render(self) -> str:
+        """Render the service configuration."""
+        return self.svcCfg.get_yaml()
+
+    @abstractmethod
+    def render_target(self) -> str:
         """
-        Render the service configuration.
+        Render the service configuration in the target system.
         """
         pass
 
@@ -152,10 +156,14 @@ class ServiceMng:
         if service:
             service.reload()
 
-    def render_svc(self, envCfg: EnvironmentCfg, svc_tag: str) -> Optional[str]:
+    def render_svc(
+        self, envCfg: EnvironmentCfg, svc_tag: str, target: bool
+    ) -> Optional[str]:
         """Render a service configuration."""
         service = self.get_service(envCfg, svc_tag)
         if service:
+            if target:
+                return service.render_target()
             return service.render()
         return None
 

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -135,17 +135,25 @@ def get():
 @click.option(
     "-o", "--output", type=click.Choice(["yaml", "json"]), default=None
 )
+@click.option(
+    "-t", "--target", is_flag=True, help="Get the target configuration."
+)
 @click.pass_obj
-def get_env(shepherd: ShepherdMng, tag: str, output: Optional[str]):
+def get_env(
+    shepherd: ShepherdMng, tag: str, output: Optional[str], target: bool
+):
     """Get environment details or config."""
     if output:
-        click.echo(shepherd.environmentMng.render_env(tag))
+        click.echo(shepherd.environmentMng.render_env(tag, target))
 
 
 @get.command(name="svc")
 @click.argument("tag", required=True)
 @click.option(
     "-o", "--output", type=click.Choice(["yaml", "json"]), default=None
+)
+@click.option(
+    "-t", "--target", is_flag=True, help="Get the target configuration."
 )
 @click.pass_obj
 @require_active_env
@@ -154,10 +162,11 @@ def get_svc(
     envCfg: EnvironmentCfg,
     tag: str,
     output: Optional[str],
+    target: bool,
 ):
     """Get service details or config."""
     if output:
-        click.echo(shepherd.serviceMng.render_svc(envCfg, tag))
+        click.echo(shepherd.serviceMng.render_svc(envCfg, tag, target))
 
 
 # =====================================================

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -308,6 +308,112 @@ def test_env_render_compose_env_ext_net(
     assert result.exit_code == 0
 
     assert result.output == (
+        "template: default\n"
+        "factory: docker-compose\n"
+        "tag: test-1\n"
+        "services:\n"
+        "- template: default\n"
+        "  factory: docker\n"
+        "  tag: test-1\n"
+        "  service_class: null\n"
+        "  image: busybox:stable-glibc\n"
+        "  hostname: null\n"
+        "  container_name: null\n"
+        "  labels:\n"
+        "  - com.example.label1=value1\n"
+        "  - com.example.label2=value2\n"
+        "  workdir: /test\n"
+        "  volumes:\n"
+        "  - /home/test/.ssh:/home/test/.ssh\n"
+        "  - /etc/ssh:/etc/ssh\n"
+        "  ingress: false\n"
+        "  empty_env: null\n"
+        "  environment: []\n"
+        "  ports:\n"
+        "  - 80:80\n"
+        "  - 443:443\n"
+        "  - 8080:8080\n"
+        "  properties: {}\n"
+        "  networks:\n"
+        "  - default\n"
+        "  extra_hosts:\n"
+        "  - host.docker.internal:host-gateway\n"
+        "  subject_alternative_name: null\n"
+        "  upstreams: []\n"
+        "  status:\n"
+        "    active: true\n"
+        "    archived: false\n"
+        "    triggered_config: null\n"
+        "- template: default\n"
+        "  factory: docker\n"
+        "  tag: test-2\n"
+        "  service_class: null\n"
+        "  image: busybox:stable-glibc\n"
+        "  hostname: null\n"
+        "  container_name: null\n"
+        "  labels:\n"
+        "  - com.example.label1=value1\n"
+        "  - com.example.label2=value2\n"
+        "  workdir: /test\n"
+        "  volumes:\n"
+        "  - /home/test/.ssh:/home/test/.ssh\n"
+        "  - /etc/ssh:/etc/ssh\n"
+        "  ingress: false\n"
+        "  empty_env: null\n"
+        "  environment: []\n"
+        "  ports:\n"
+        "  - 80:80\n"
+        "  - 443:443\n"
+        "  - 8080:8080\n"
+        "  properties: {}\n"
+        "  networks:\n"
+        "  - default\n"
+        "  extra_hosts:\n"
+        "  - host.docker.internal:host-gateway\n"
+        "  subject_alternative_name: null\n"
+        "  upstreams: []\n"
+        "  status:\n"
+        "    active: true\n"
+        "    archived: false\n"
+        "    triggered_config: null\n"
+        "networks:\n"
+        "- tag: default\n"
+        "  name: envnet\n"
+        "  external: true\n"
+        "  driver: null\n"
+        "  attachable: null\n"
+        "  enable_ipv6: null\n"
+        "  driver_opts: null\n"
+        "  ipam: null\n"
+        "volumes:\n"
+        "- tag: app_data_ext\n"
+        "  external: true\n"
+        "  name: nfs-1\n"
+        "  driver: null\n"
+        "  driver_opts: null\n"
+        "  labels: null\n"
+        "status:\n"
+        "  active: true\n"
+        "  archived: false\n"
+        "  triggered_config: null\n\n"
+    )
+
+
+@pytest.mark.docker
+def test_env_render_target_compose_env_ext_net(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["get", "env", "test-1", "-oyaml", "-t"])
+    assert result.exit_code == 0
+
+    assert result.output == (
         "name: test-1\n"
         "services:\n"
         "  test-1-test-1:\n"
@@ -358,7 +464,7 @@ def test_env_render_compose_env_ext_net(
 
 
 @pytest.mark.docker
-def test_env_render_compose_env_int_net(
+def test_env_render_target_compose_env_int_net(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
     mocker: MockerFixture,
@@ -368,7 +474,7 @@ def test_env_render_compose_env_int_net(
     shpd_yaml = shpd_path / ".shpd.yaml"
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "env", "test-2", "-oyaml"])
+    result = runner.invoke(cli, ["get", "env", "test-2", "-oyaml", "-t"])
     assert result.exit_code == 0
 
     assert result.output == (

--- a/src/tests/test_svc_docker_compose.py
+++ b/src/tests/test_svc_docker_compose.py
@@ -156,7 +156,7 @@ def runner() -> CliRunner:
 
 
 @pytest.mark.docker
-def test_svc_render_compose_service(
+def test_svc_render_default_compose_service(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
     shpd_path = shpd_conf[0]
@@ -168,25 +168,72 @@ def test_svc_render_compose_service(
     assert result.exit_code == 0
 
     assert result.output == (
-        "services:\n"
-        "  test-test-1:\n"
-        "    image: test-image:latest\n"
-        "    hostname: test-test-1\n"
-        "    container_name: test-test-1\n"
-        "    labels:\n"
-        "    - com.example.label1=value1\n"
-        "    - com.example.label2=value2\n"
-        "    volumes:\n"
-        "    - /home/test/.ssh:/home/test/.ssh\n"
-        "    - /etc/ssh:/etc/ssh\n"
-        "    ports:\n"
-        "    - 80:80\n"
-        "    - 443:443\n"
-        "    - 8080:8080\n"
-        "    extra_hosts:\n"
-        "    - host.docker.internal:host-gateway\n"
-        "    networks:\n"
-        "    - default\n\n"
+        "template: default\n"
+        "factory: docker\n"
+        "tag: test\n"
+        "service_class: null\n"
+        "image: test-image:latest\n"
+        "hostname: null\n"
+        "container_name: null\n"
+        "labels:\n"
+        "- com.example.label1=value1\n"
+        "- com.example.label2=value2\n"
+        "workdir: /test\n"
+        "volumes:\n"
+        "- /home/test/.ssh:/home/test/.ssh\n"
+        "- /etc/ssh:/etc/ssh\n"
+        "ingress: false\n"
+        "empty_env: null\n"
+        "environment: []\n"
+        "ports:\n"
+        "- 80:80\n"
+        "- 443:443\n"
+        "- 8080:8080\n"
+        "properties: {}\n"
+        "networks:\n"
+        "- default\n"
+        "extra_hosts:\n"
+        "- host.docker.internal:host-gateway\n"
+        "subject_alternative_name: null\n"
+        "upstreams: []\n"
+        "status:\n"
+        "  active: true\n"
+        "  archived: false\n"
+        "  triggered_config: null\n\n"
+    )
+
+
+@pytest.mark.docker
+def test_svc_render_target_compose_service(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(shpd_config_svc_default)
+
+    result = runner.invoke(cli, ["get", "svc", "test", "-oyaml", "-t"])
+    assert result.exit_code == 0
+
+    assert result.output == (
+        "test-test-1:\n"
+        "  image: test-image:latest\n"
+        "  hostname: test-test-1\n"
+        "  container_name: test-test-1\n"
+        "  labels:\n"
+        "  - com.example.label1=value1\n"
+        "  - com.example.label2=value2\n"
+        "  volumes:\n"
+        "  - /home/test/.ssh:/home/test/.ssh\n"
+        "  - /etc/ssh:/etc/ssh\n"
+        "  ports:\n"
+        "  - 80:80\n"
+        "  - 443:443\n"
+        "  - 8080:8080\n"
+        "  extra_hosts:\n"
+        "  - host.docker.internal:host-gateway\n"
+        "  networks:\n"
+        "  - default\n\n"
     )
 
 


### PR DESCRIPTION
Added -t, --target flag-option for: `get env/svc`.
The option: -t, --target generates the configuration for the target system.
The flag makes sense only when -o yaml is used.

Fixes: #136

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
to change)
- [ ] Change or update to the documentation (with no functional changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
