### PR TITLE
Add initial probe commands: shepctl get probe / check probe

### DIFF
--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -20,6 +20,7 @@ from typing import Optional, override
 
 from completion.completion_env import CompletionEnvMng
 from completion.completion_mng import AbstractCompletionMng
+from completion.completion_probe import CompletionProbeMng
 from completion.completion_svc import CompletionSvcMng
 from config import ConfigMng
 
@@ -28,7 +29,7 @@ class CompletionMng(AbstractCompletionMng):
 
     # Mapping of verbs to valid categories
     VERB_CATEGORIES = {
-        "get": ["env", "svc"],
+        "get": ["env", "svc", "probe"],
         "add": ["env", "svc"],
         "clone": ["env"],
         "rename": ["env"],
@@ -42,6 +43,7 @@ class CompletionMng(AbstractCompletionMng):
         "logs": ["auto-svc"],
         "shell": ["auto-svc"],
         "build": ["auto-svc"],
+        "check": ["probe"],
     }
 
     def __init__(self, cli_flags: dict[str, bool], configMng: ConfigMng):
@@ -49,6 +51,7 @@ class CompletionMng(AbstractCompletionMng):
         self.configMng = configMng
         self.completionEnvMng = CompletionEnvMng(cli_flags, configMng)
         self.completionSvcMng = CompletionSvcMng(cli_flags, configMng)
+        self.completionProbeMng = CompletionProbeMng(cli_flags, configMng)
 
     @property
     def VERBS(self) -> list[str]:
@@ -88,6 +91,8 @@ class CompletionMng(AbstractCompletionMng):
             return self.completionEnvMng
         if category == "svc":
             return self.completionSvcMng
+        if category == "probe":
+            return self.completionProbeMng
 
         return None
 

--- a/src/completion/completion_probe.py
+++ b/src/completion/completion_probe.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2025 Moony Fringers
+#
+# This file is part of Shepherd Core Stack
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from typing import override
+
+from completion.completion_mng import AbstractCompletionMng
+from config import ConfigMng
+
+
+class CompletionProbeMng(AbstractCompletionMng):
+
+    def __init__(self, cli_flags: dict[str, bool], configMng: ConfigMng):
+        self.cli_flags = cli_flags
+        self.configMng = configMng
+
+    @override
+    def get_completions(self, args: list[str]) -> list[str]:
+        command = args[0]
+        match command:
+            case "get":
+                return self.get_render_completions(args[2:])
+            case "check":
+                return self.get_check_completions(args[2:])
+            case _:
+                return []
+
+    def is_probe_tag_chosen(self, args: list[str]) -> bool:
+        if len(args) < 1:
+            return False
+        svc_tag = args[0]
+        return svc_tag in self.get_probe_tags(args)
+
+    def get_probe_tags(self, args: list[str]) -> list[str]:
+        env = self.configMng.get_active_environment()
+        if env:
+            return self.configMng.get_probe_tags(env)
+        return []
+
+    def get_render_completions(self, args: list[str]) -> list[str]:
+        if not self.is_probe_tag_chosen(args):
+            return self.get_probe_tags(args)
+        return []
+
+    def get_check_completions(self, args: list[str]) -> list[str]:
+        if not self.is_probe_tag_chosen(args):
+            return self.get_probe_tags(args)
+        return []

--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -301,6 +301,18 @@ class DockerComposeEnv(Environment):
         if probe_tag is not None:
             probes = [p for p in probes if p.tag == probe_tag]
         if not probes:
+            if probe_tag is not None:
+                available = self.configMng.get_probe_tags(self.envCfg)
+                if available:
+                    tags = ", ".join(available)
+                    Util.print_error_and_die(
+                        f"Probe '{probe_tag}' not found in environment "
+                        f"'{self.envCfg.tag}'. Available probes: {tags}."
+                    )
+                Util.print_error_and_die(
+                    f"Probe '{probe_tag}' not found in environment "
+                    f"'{self.envCfg.tag}'."
+                )
             return []
 
         probes_yaml = self.render_probes_target(probe_tag=None, resolved=True)

--- a/src/docker/docker_compose_util.py
+++ b/src/docker/docker_compose_util.py
@@ -92,6 +92,14 @@ def run_compose(
                 cmd, returncode=124, stdout=stdout, stderr=stderr
             )
 
+        logging.debug(
+            f"docker compose command run:\n"
+            f"CMD: {' '.join(cmd)}\n"
+            f"with exit code {result.returncode}\n"
+            f"STDOUT:\n{result.stdout}\n"
+            f"STDERR:\n{result.stderr}"
+        )
+
         if result.returncode != 0:
             logging.warning(
                 "docker compose command failed "

--- a/src/docker/docker_compose_util.py
+++ b/src/docker/docker_compose_util.py
@@ -26,7 +26,7 @@ from util import Util
 def run_compose(
     yaml: str, *args: str, capture: bool = False
 ) -> subprocess.CompletedProcess[str]:
-    """Run a docker compose command with the triggered_config YAML."""
+    """Run a docker compose command with the rendered_config YAML."""
 
     with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as tmp:
         tmp.write(yaml)

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -20,11 +20,22 @@ from __future__ import annotations
 
 import os
 from abc import ABC, abstractmethod
-from typing import Optional
+from dataclasses import dataclass
+from typing import Any, Optional
 
 from config import ConfigMng, EnvironmentCfg, EnvironmentTemplateCfg
 from service import Service, ServiceFactory
 from util import Constants, Util
+
+
+@dataclass
+class ProbeRunResult:
+    tag: str
+    exit_code: int
+    stdout: str = ""
+    stderr: str = ""
+    duration_ms: Optional[int] = None
+    timed_out: bool = False
 
 
 class Environment(ABC):
@@ -79,6 +90,53 @@ class Environment(ABC):
         """
         pass
 
+    def render_probes(
+        self, probe_tag: Optional[str], resolved: bool
+    ) -> Optional[str]:
+        """
+        Render the environment probes configuration.
+        """
+        return self.envCfg.get_probes_yaml(probe_tag, resolved)
+
+    @abstractmethod
+    def render_probes_target(
+        self, probe_tag: Optional[str], resolved: bool
+    ) -> Optional[str]:
+        """
+        Render the environment probes configuration in the target system.
+        """
+        pass
+
+    def check_probes(
+        self,
+        probe_tag: Optional[str] = None,
+        fail_fast: bool = True,
+        timeout_seconds: Optional[int] = 120,
+    ) -> list[ProbeRunResult]:
+        """
+        Run environment probes synchronously against the running environment.
+
+        Semantics:
+          - If probe_tag is provided: run only that probe.
+          - Otherwise: run all probes (sequentially).
+          - fail_fast: stop at first failure.
+          - timeout_seconds: per-probe timeout.
+        """
+        return self.check_probes_impl(
+            probe_tag=probe_tag,
+            fail_fast=fail_fast,
+            timeout_seconds=timeout_seconds,
+        )
+
+    @abstractmethod
+    def check_probes_impl(
+        self,
+        probe_tag: Optional[str],
+        fail_fast: bool,
+        timeout_seconds: Optional[int],
+    ) -> list[ProbeRunResult]:
+        pass
+
     @abstractmethod
     def status(self) -> list[dict[str, str]]:
         """Get environment status."""
@@ -97,6 +155,7 @@ class Environment(ABC):
         """Return the directory for the environment with a given tag."""
         return os.path.join(self.configMng.config.envs_path, env_tag)
 
+    @abstractmethod
     def ensure_resources(self):
         """Ensure the environment resources are available."""
         pass
@@ -373,6 +432,176 @@ class EnvironmentMng:
                 return env.render_target(resolved)["ungated"]
             return env.render(resolved)
         return None
+
+    def render_probes(
+        self,
+        envCfg: EnvironmentCfg,
+        probe_tag: Optional[str],
+        target: bool,
+        resolved: bool,
+    ) -> Optional[str]:
+        """Render a probe configuration."""
+        env = self.get_environment_from_cfg(envCfg)
+        if target:
+            return env.render_probes_target(probe_tag, resolved)
+        return env.render_probes(probe_tag, resolved)
+
+    def check_probes(self, envCfg: EnvironmentCfg, probe_tag: Optional[str]):
+        """Check probes."""
+        env = self.get_environment_from_cfg(envCfg)
+
+        if not env.envCfg.status.rendered_config:
+            Util.print_error_and_die(
+                f"Environment '{env.envCfg.tag}' is not started."
+            )
+
+        results = env.check_probes(
+            probe_tag=probe_tag,
+            fail_fast=True,
+            timeout_seconds=120,
+        )
+
+        verbose = bool(self.cli_flags.get("verbose", False))
+        title = f"[white]{envCfg.tag}[/white] probes"
+
+        report = self.build_probe_report(results, verbose=verbose, title=title)
+        self.render_probe_report(report)
+
+        return results
+
+    # --- probe presentation policy ---
+
+    def _probe_status_key(self, r: ProbeRunResult) -> str:
+        if r.timed_out:
+            return "timeout"
+        if r.exit_code == 0:
+            return "ok"
+        return "failed"
+
+    def _probe_status_glyph(self, key: str) -> str:
+        return "✔" if key == "ok" else "✖"
+
+    def _probe_status_color_tag(self, key: str) -> str:
+        if key == "ok":
+            return "bold green"
+        if key == "timeout":
+            return "bold yellow"
+        return "bold red"
+
+    def _fmt_duration_ms(self, ms: Optional[int]) -> str:
+        return "?" if ms is None else f"{ms} ms"
+
+    def probe_exit_code(self, results: list[ProbeRunResult]) -> int:
+        saw_failed = False
+        for r in results:
+            k = self._probe_status_key(r)
+            if k == "timeout":
+                return 2
+            if k == "failed":
+                saw_failed = True
+        return 1 if saw_failed else 0
+
+    def build_probe_report(
+        self,
+        results: list[ProbeRunResult],
+        *,
+        verbose: bool,
+        title: str,
+    ) -> dict[str, Any]:
+        """
+        Returns a probe 'view model' as plain dicts:
+          {
+            "title": str,
+            "rows": [[probe, status_markup, duration], ...],
+            "summary": [("OK","1"), ("FAILED","0"), ("TIMEOUT","0")],
+            "single_ok_stdout": "first line …" | "",
+            "panels": [{"title":..., "body":..., "border_style":...}, ...]
+          }
+        """
+        rows: list[list[str]] = []
+        panels: list[dict[str, Any]] = []
+
+        ok = failed = timeout = 0
+
+        for r in results:
+            key = self._probe_status_key(r)
+            if key == "ok":
+                ok += 1
+            elif key == "timeout":
+                timeout += 1
+            else:
+                failed += 1
+
+            glyph = self._probe_status_glyph(key)
+            label = key.upper()
+            color = self._probe_status_color_tag(key)
+            status_markup = f"[{color}]{glyph} {label}[/{color}]"
+
+            rows.append(
+                [r.tag, status_markup, self._fmt_duration_ms(r.duration_ms)]
+            )
+
+            want_details = verbose or key in ("failed", "timeout")
+            if want_details:
+                out = (r.stdout or "").strip("\n")
+                err = (r.stderr or "").strip("\n")
+
+                body_parts: list[str] = []
+                if out.strip():
+                    body_parts.append("--- stdout ---")
+                    body_parts.append(out)
+
+                if err.strip() and (verbose or key in ("failed", "timeout")):
+                    body_parts.append("--- stderr ---")
+                    body_parts.append(err)
+
+                if key != "ok":
+                    body_parts.append("--- meta ---")
+                    body_parts.append(f"exit_code: {r.exit_code}")
+                    body_parts.append(f"timed_out: {r.timed_out}")
+
+                body = "\n".join(body_parts).strip()
+                if body:
+                    border = (
+                        "green"
+                        if key == "ok"
+                        else ("yellow" if key == "timeout" else "red")
+                    )
+                    panels.append(
+                        {
+                            "title": f"{r.tag} ({label})",
+                            "body": body,
+                            "border_style": border,
+                        }
+                    )
+        return {
+            "title": title,
+            "rows": rows,
+            "summary": [
+                ("OK", str(ok)),
+                ("FAILED", str(failed)),
+                ("TIMEOUT", str(timeout)),
+            ],
+            "panels": panels,
+        }
+
+    def render_probe_report(self, report: dict[str, Any]):
+        Util.render_table(
+            title=report["title"],
+            columns=[
+                {"header": "Probe", "style": "white", "no_wrap": True},
+                {"header": "Status", "no_wrap": True},
+                {
+                    "header": "Duration",
+                    "justify": "right",
+                    "style": "white",
+                    "no_wrap": True,
+                },
+            ],
+            rows=report["rows"],
+        )
+        Util.render_kv_summary(report["summary"])
+        Util.render_panels(panels=report.get("panels") or [])
 
     def status_env(self, envCfg: EnvironmentCfg):
         """Get environment status."""

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -467,7 +467,12 @@ class EnvironmentMng:
         report = self.build_probe_report(results, verbose=verbose, title=title)
         self.render_probe_report(report)
 
-        return results
+        # ---- aggregate exit code ----
+        for r in results:
+            if r.exit_code != 0:
+                return r.exit_code
+
+        return 0
 
     # --- probe presentation policy ---
 
@@ -490,16 +495,6 @@ class EnvironmentMng:
 
     def _fmt_duration_ms(self, ms: Optional[int]) -> str:
         return "?" if ms is None else f"{ms} ms"
-
-    def probe_exit_code(self, results: list[ProbeRunResult]) -> int:
-        saw_failed = False
-        for r in results:
-            k = self._probe_status_key(r)
-            if k == "timeout":
-                return 2
-            if k == "failed":
-                saw_failed = True
-        return 1 if saw_failed else 0
 
     def build_probe_report(
         self,

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -73,7 +73,7 @@ class Environment(ABC):
         return self.envCfg.get_yaml(resolved)
 
     @abstractmethod
-    def render_target(self, resolved: bool) -> str:
+    def render_target(self, resolved: bool) -> dict[str, str]:
         """
         Render the environment configuration in the target system.
         """
@@ -339,7 +339,7 @@ class EnvironmentMng:
     def start_env(self, envCfg: EnvironmentCfg):
         """Start an environment."""
         env = self.get_environment_from_cfg(envCfg)
-        env.envCfg.status.triggered_config = env.render_target(True)
+        env.envCfg.status.rendered_config = env.render_target(True)
         env.sync_config()
         env.start()
         Util.print(f"Started environment: {env.envCfg.tag}")
@@ -348,14 +348,14 @@ class EnvironmentMng:
         """Halt an environment."""
         env = self.get_environment_from_cfg(envCfg)
         env.stop()
-        env.envCfg.status.triggered_config = None
+        env.envCfg.status.rendered_config = None
         env.sync_config()
         Util.print(f"Halted environment: {env.envCfg.tag}")
 
     def reload_env(self, envCfg: EnvironmentCfg):
         """Reload an environment."""
         env = self.get_environment_from_cfg(envCfg)
-        if not env.envCfg.status.triggered_config:
+        if not env.envCfg.status.rendered_config:
             Util.print_error_and_die(
                 f"Environment '{env.envCfg.tag}' is not started."
             )
@@ -370,7 +370,7 @@ class EnvironmentMng:
         env = self.get_environment_from_tag(env_tag)
         if env:
             if target:
-                return env.render_target(resolved)
+                return env.render_target(resolved)["ungated"]
             return env.render(resolved)
         return None
 

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -18,9 +18,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Optional
 
 from config import ConfigMng, EnvironmentCfg, ServiceCfg
+from config.config import ContainerCfg
 
 
 class Service(ABC):
@@ -86,6 +87,13 @@ class Service(ABC):
     def render_target(self, resolved: bool) -> str:
         """
         Render the service configuration in the target system.
+        """
+        pass
+
+    @abstractmethod
+    def render_container_target(self, cnt: ContainerCfg) -> dict[str, Any]:
+        """
+        Render the container configuration in the target system.
         """
         pass
 

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -18,10 +18,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Optional
 
 from config import ConfigMng, EnvironmentCfg, ServiceCfg
-from config.config import ContainerCfg
 
 
 class Service(ABC):
@@ -87,13 +86,6 @@ class Service(ABC):
     def render_target(self, resolved: bool) -> str:
         """
         Render the service configuration in the target system.
-        """
-        pass
-
-    @abstractmethod
-    def render_container_target(self, cnt: ContainerCfg) -> dict[str, Any]:
-        """
-        Render the container configuration in the target system.
         """
         pass
 

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -154,6 +154,40 @@ def get_env(
         click.echo(shepherd.environmentMng.render_env(tag, target, resolved))
 
 
+@get.command(name="probe")
+@click.argument("probe_tag", required=False)
+@click.option(
+    "-o", "--output", type=click.Choice(["yaml", "json"]), default="yaml"
+)
+@click.option(
+    "-t", "--target", is_flag=True, help="Get the target configuration."
+)
+@click.option(
+    "-r", "--resolved", is_flag=True, help="Get the resolved configuration."
+)
+@click.option("-a", "--all", is_flag=True, help="Get all probes.")
+@click.pass_obj
+@require_active_env
+def get_probe(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    probe_tag: Optional[str],
+    output: Optional[str],
+    target: bool,
+    resolved: bool,
+    all: bool,
+):
+    """Get probe details."""
+    if all:
+        probe_tag = None
+    if output:
+        click.echo(
+            shepherd.environmentMng.render_probes(
+                envCfg, probe_tag, target, resolved
+            )
+        )
+
+
 @get.command(name="svc")
 @click.argument("tag", required=True)
 @click.option(
@@ -472,6 +506,32 @@ def status(shepherd: ShepherdMng, envCfg: EnvironmentCfg):
 def status_env(shepherd: ShepherdMng, envCfg: EnvironmentCfg):
     """Show environment status."""
     shepherd.environmentMng.status_env(envCfg)
+
+
+# =====================================================
+# CHECK
+# =====================================================
+@cli.group()
+def check():
+    """Check resources."""
+    pass
+
+
+@check.command(name="probe")
+@click.argument("probe_tag", required=False)
+@click.option("-a", "--all", is_flag=True, help="Check all probes.")
+@click.pass_obj
+@require_active_env
+def check_probe(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    probe_tag: Optional[str],
+    all: bool,
+):
+    """Check probe"""
+    if all:
+        probe_tag = None
+    shepherd.environmentMng.check_probes(envCfg, probe_tag)
 
 
 if __name__ == "__main__":

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -531,7 +531,8 @@ def check_probe(
     """Check probe"""
     if all:
         probe_tag = None
-    shepherd.environmentMng.check_probes(envCfg, probe_tag)
+    exit_code = shepherd.environmentMng.check_probes(envCfg, probe_tag)
+    exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/src/tests/fixtures/cfg/shpd.yaml
+++ b/src/tests/fixtures/cfg/shpd.yaml
@@ -177,7 +177,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
       - template: traefik
         factory: docker
         tag: traefik-1
@@ -205,7 +205,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
       - template: custom-1
         factory: docker
         tag: primary
@@ -235,7 +235,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
       - template: nodejs
         factory: docker
         tag: poke
@@ -266,7 +266,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
     probes: []
     networks:
       - tag: shpdnet
@@ -291,4 +291,4 @@ envs:
     status:
       active: true
       archived: false
-      triggered_config: null
+      rendered_config: null

--- a/src/tests/fixtures/cfg/shpd_lifecycle.yaml
+++ b/src/tests/fixtures/cfg/shpd_lifecycle.yaml
@@ -188,7 +188,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
     probes: []
     networks:
       - tag: shpdnet
@@ -203,4 +203,4 @@ envs:
     status:
       active: true
       archived: false
-      triggered_config: null
+      rendered_config: null

--- a/src/tests/fixtures/cfg/shpd_with_refs.yaml
+++ b/src/tests/fixtures/cfg/shpd_with_refs.yaml
@@ -161,7 +161,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
       - template: postgres
         upstreams: []
         inits: []
@@ -195,7 +195,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
     probes: []
     networks:
       - tag: "#{env.tag}"
@@ -230,4 +230,4 @@ envs:
     status:
       active: true
       archived: false
-      triggered_config: null
+      rendered_config: null

--- a/src/tests/fixtures/completion/shpd.yaml
+++ b/src/tests/fixtures/completion/shpd.yaml
@@ -159,7 +159,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
       - template: t1
         factory: docker
         tag: white
@@ -184,11 +184,11 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
     status:
       active: true
       archived: false
-      triggered_config: null
+      rendered_config: null
   - template: default
     factory: docker-compose
     tag: test-2
@@ -217,8 +217,8 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
     status:
       active: false
       archived: false
-      triggered_config: null
+      rendered_config: null

--- a/src/tests/fixtures/completion/shpd.yaml
+++ b/src/tests/fixtures/completion/shpd.yaml
@@ -189,6 +189,41 @@ envs:
       active: true
       archived: false
       rendered_config: null
+    probes:
+      - tag: db-ready
+        container:
+          tag: db-ready
+          image: postgres:17-3.5
+          hostname: null
+          container_name: null
+          workdir: null
+          volumes: []
+          environment: []
+          ports: []
+          networks:
+            - "#{env.tag}"
+          extra_hosts: []
+          subject_alternative_name: null
+          build: null
+        script: sh -c 'pg_isready -h db -p 5432 -U sys -d docker'
+        script_path: null
+      - tag: db-live
+        container:
+          tag: db-live
+          image: postgres:17-3.5
+          hostname: null
+          container_name: null
+          workdir: null
+          volumes: []
+          environment: []
+          ports: []
+          networks:
+            - "#{env.tag}"
+          extra_hosts: []
+          subject_alternative_name: null
+          build: null
+        script: sh -c 'pg_isready -h db -p 5432 -U docker -d docker'
+        script_path: null
   - template: default
     factory: docker-compose
     tag: test-2

--- a/src/tests/fixtures/env/shpd.yaml
+++ b/src/tests/fixtures/env/shpd.yaml
@@ -111,7 +111,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
       - template: default
         factory: docker
         containers:
@@ -141,7 +141,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
     networks:
       - tag: default
         name: envnet
@@ -153,7 +153,7 @@ envs:
     status:
       active: true
       archived: false
-      triggered_config: null
+      rendered_config: null
   - template: default
     factory: docker-compose
     tag: test-2
@@ -187,7 +187,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
       - template: default
         factory: docker
         containers:
@@ -217,7 +217,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
     networks:
       - tag: internal_net
         external: false
@@ -244,4 +244,4 @@ envs:
     status:
       active: false
       archived: false
-      triggered_config: null
+      rendered_config: null

--- a/src/tests/fixtures/env_docker/shpd.yaml
+++ b/src/tests/fixtures/env_docker/shpd.yaml
@@ -68,7 +68,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
       - template: default
         factory: docker
         tag: test-2
@@ -100,7 +100,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
     networks:
       - tag: default
         name: envnet
@@ -112,7 +112,7 @@ envs:
     status:
       active: true
       archived: false
-      triggered_config: null
+      rendered_config: null
   - template: default
     factory: docker-compose
     tag: test-2
@@ -148,7 +148,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
       - template: default
         factory: docker
         tag: test-2
@@ -180,7 +180,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
     probes: []
     networks:
       - tag: internal_net
@@ -208,4 +208,4 @@ envs:
     status:
       active: false
       archived: false
-      triggered_config: null
+      rendered_config: null

--- a/src/tests/fixtures/env_docker/shpd.yaml
+++ b/src/tests/fixtures/env_docker/shpd.yaml
@@ -101,6 +101,41 @@ envs:
           active: true
           archived: false
           rendered_config: null
+    probes:
+      - tag: db-ready
+        container:
+          tag: db-ready
+          image: postgres:17-3.5
+          hostname: null
+          container_name: null
+          workdir: null
+          volumes: []
+          environment: []
+          ports: []
+          networks:
+            - "#{env.tag}"
+          extra_hosts: []
+          subject_alternative_name: null
+          build: null
+        script: sh -c 'pg_isready -h db -p 5432 -U sys -d docker'
+        script_path: null
+      - tag: db-live
+        container:
+          tag: db-live
+          image: postgres:17-3.5
+          hostname: null
+          container_name: null
+          workdir: null
+          volumes: []
+          environment: []
+          ports: []
+          networks:
+            - "#{env.tag}"
+          extra_hosts: []
+          subject_alternative_name: null
+          build: null
+        script: sh -c 'pg_isready -h db -p 5432 -U docker -d docker'
+        script_path: null
     networks:
       - tag: default
         name: envnet

--- a/src/tests/fixtures/shpd/shpd.yaml
+++ b/src/tests/fixtures/shpd/shpd.yaml
@@ -99,8 +99,8 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
     status:
       active: true
       archived: false
-      triggered_config: null
+      rendered_config: null

--- a/src/tests/fixtures/shpd/shpd.yaml
+++ b/src/tests/fixtures/shpd/shpd.yaml
@@ -100,6 +100,41 @@ envs:
           active: true
           archived: false
           rendered_config: null
+    probes:
+      - tag: db-ready
+        container:
+          tag: db-ready
+          image: postgres:17-3.5
+          hostname: null
+          container_name: null
+          workdir: null
+          volumes: []
+          environment: []
+          ports: []
+          networks:
+            - "#{env.tag}"
+          extra_hosts: []
+          subject_alternative_name: null
+          build: null
+        script: sh -c 'pg_isready -h db -p 5432 -U sys -d docker'
+        script_path: null
+      - tag: db-live
+        container:
+          tag: db-live
+          image: postgres:17-3.5
+          hostname: null
+          container_name: null
+          workdir: null
+          volumes: []
+          environment: []
+          ports: []
+          networks:
+            - "#{env.tag}"
+          extra_hosts: []
+          subject_alternative_name: null
+          build: null
+        script: sh -c 'pg_isready -h db -p 5432 -U docker -d docker'
+        script_path: null
     status:
       active: true
       archived: false

--- a/src/tests/fixtures/svc_docker/shpd.yaml
+++ b/src/tests/fixtures/svc_docker/shpd.yaml
@@ -73,7 +73,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
       - template: default
         factory: docker
         tag: test-1
@@ -123,7 +123,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
       - template: default
         factory: docker
         tag: test-2
@@ -156,7 +156,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
       - template: default
         factory: docker
         tag: test-3
@@ -189,7 +189,7 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
       - template: default
         factory: docker
         tag: test-4
@@ -223,8 +223,8 @@ envs:
         status:
           active: true
           archived: false
-          triggered_config: null
+          rendered_config: null
     status:
       active: true
       archived: false
-      triggered_config: null
+      rendered_config: null

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -720,3 +720,43 @@ def test_completion_status_env(
     sm = ShepherdMng()
     completions = sm.completionMng.get_completions(["status", "env"])
     assert completions == [], "Expected status env completion"
+
+
+@pytest.mark.compl
+def test_completion_get_probe_oyaml(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("completion", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["get", "probe", "-oyaml"])
+    assert completions == [
+        "db-live",
+        "db-ready",
+    ], "Expected get probe -oyaml completion"
+
+
+@pytest.mark.compl
+def test_completion_get_probe(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("completion", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["get", "probe"])
+    assert completions == [
+        "db-live",
+        "db-ready",
+    ], "Expected get probe completion"

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -225,7 +225,7 @@ def test_load_config(mocker: MockerFixture):
     assert config.staging_area.images_path == "${test_path}/sa_images"
     assert config.envs[0].status.archived is False
     assert config.envs[0].status.active is True
-    assert config.envs[0].status.triggered_config is None
+    assert config.envs[0].status.rendered_config is None
 
 
 @pytest.mark.cfg

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -113,7 +113,7 @@ services:
   status:
     active: true
     archived: false
-    triggered_config: null
+    rendered_config: null
 - template: default
   factory: docker
   tag: test-2
@@ -150,7 +150,7 @@ services:
   status:
     active: true
     archived: false
-    triggered_config: null
+    rendered_config: null
 probes: []
 networks:
 - tag: default
@@ -171,7 +171,7 @@ volumes:
 status:
   active: true
   archived: false
-  triggered_config: null
+  rendered_config: null
 """
 
     y1: str = yaml.dump(yaml.safe_load(result.output), sort_keys=True)
@@ -236,7 +236,7 @@ services:
   status:
     active: true
     archived: false
-    triggered_config: null
+    rendered_config: null
 - template: default
   factory: docker
   tag: test-2
@@ -273,7 +273,7 @@ services:
   status:
     active: true
     archived: false
-    triggered_config: null
+    rendered_config: null
 probes: []
 networks:
 - tag: default
@@ -294,7 +294,7 @@ volumes:
 status:
   active: true
   archived: false
-  triggered_config: null
+  rendered_config: null
 """
 
     y1: str = yaml.dump(yaml.safe_load(result.output), sort_keys=True)
@@ -561,7 +561,7 @@ def test_start_env(
     assert env
     assert env.status.active is True
     assert env.status.archived is False
-    assert env.status.triggered_config
+    assert env.status.rendered_config
 
 
 @pytest.mark.docker
@@ -607,7 +607,7 @@ def test_stop_env(
     assert env
     assert env.status.active is True
     assert env.status.archived is False
-    assert env.status.triggered_config is None
+    assert env.status.rendered_config is None
 
 
 @pytest.mark.docker
@@ -653,7 +653,7 @@ def test_reload_env(
     assert env
     assert env.status.active is True
     assert env.status.archived is False
-    assert env.status.triggered_config
+    assert env.status.rendered_config
 
 
 @pytest.mark.docker

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -368,3 +368,212 @@ def test_cli_status_env(
     result = runner.invoke(cli, ["status", "env"])
     assert result.exit_code == 0
     mock_status.assert_called_once()
+
+
+# probe tests
+
+
+@pytest.mark.shpd
+def test_cli_get_probe_no_args(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    render_probes = mocker.patch.object(EnvironmentMng, "render_probes")
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["get", "probe"])
+    assert result.exit_code == 0
+    render_probes.assert_called_once()
+
+
+@pytest.mark.shpd
+def test_cli_get_probe_flag_output(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    render_probes = mocker.patch.object(EnvironmentMng, "render_probes")
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["get", "probe", "--output", "json"])
+    assert result.exit_code == 0
+    render_probes.assert_called_once()
+
+
+@pytest.mark.shpd
+def test_cli_get_probe_flag_target(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    render_probes = mocker.patch.object(EnvironmentMng, "render_probes")
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(
+        cli, ["get", "probe", "--output", "json", "--target"]
+    )
+    assert result.exit_code == 0
+    render_probes.assert_called_once()
+
+
+@pytest.mark.shpd
+def test_cli_get_probe_flag_resolved(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    render_probes = mocker.patch.object(EnvironmentMng, "render_probes")
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(
+        cli, ["get", "probe", "--output", "json", "--resolved"]
+    )
+    assert result.exit_code == 0
+    render_probes.assert_called_once()
+
+
+@pytest.mark.shpd
+def test_cli_get_probe_flag_all(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    render_probes = mocker.patch.object(EnvironmentMng, "render_probes")
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["get", "probe", "--all"])
+    assert result.exit_code == 0
+    render_probes.assert_called_once()
+
+
+@pytest.mark.shpd
+def test_cli_get_probe_flag_all_with_probe_tag(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    render_probes = mocker.patch.object(EnvironmentMng, "render_probes")
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["get", "probe", "db-ready", "--all"])
+    assert result.exit_code == 0
+    render_probes.assert_called_once()
+
+
+@pytest.mark.shpd
+def test_cli_get_probe_with_probe_tag(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    render_probes = mocker.patch.object(EnvironmentMng, "render_probes")
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["get", "probe", "db-ready"])
+    assert result.exit_code == 0
+    render_probes.assert_called_once()
+
+
+@pytest.mark.shpd
+def test_cli_check_probe_no_args(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    check_probes = mocker.patch.object(
+        EnvironmentMng, "check_probes", return_value=0
+    )
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["check", "probe"])
+    assert result.exit_code == 0
+    check_probes.assert_called_once()
+
+
+@pytest.mark.shpd
+def test_cli_check_probe_with_probe_tag(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    check_probes = mocker.patch.object(
+        EnvironmentMng, "check_probes", return_value=0
+    )
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["check", "probe", "db-ready"])
+    assert result.exit_code == 0
+    check_probes.assert_called_once()
+
+
+@pytest.mark.shpd
+def test_cli_check_probe_with_probe_tag_failed(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    check_probes = mocker.patch.object(
+        EnvironmentMng, "check_probes", return_value=1
+    )
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["check", "probe", "db-ready"])
+    assert result.exit_code == 1
+    check_probes.assert_called_once()
+
+
+@pytest.mark.shpd
+def test_cli_check_probe_flag_all(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    check_probes = mocker.patch.object(
+        EnvironmentMng, "check_probes", return_value=0
+    )
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["check", "probe", "--all"])
+    assert result.exit_code == 0
+    check_probes.assert_called_once()
+
+
+@pytest.mark.shpd
+def test_cli_check_probe_flag_all_with_probe_tag(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    check_probes = mocker.patch.object(
+        EnvironmentMng, "check_probes", return_value=0
+    )
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["check", "probe", "db-ready", "--all"])
+    assert result.exit_code == 0
+    check_probes.assert_called_once()

--- a/src/tests/test_svc_docker_compose.py
+++ b/src/tests/test_svc_docker_compose.py
@@ -111,7 +111,7 @@ def test_svc_render_default_compose_service(
         "status:\n"
         "  active: true\n"
         "  archived: false\n"
-        "  triggered_config: null\n\n"
+        "  rendered_config: null\n\n"
     )
 
     y1: str = yaml.dump(yaml.safe_load(result.output), sort_keys=True)
@@ -174,7 +174,7 @@ def test_svc_render_default_compose_service_resolved(
         "status:\n"
         "  active: true\n"
         "  archived: false\n"
-        "  triggered_config: null\n\n"
+        "  rendered_config: null\n\n"
     )
 
     y1: str = yaml.dump(yaml.safe_load(result.output), sort_keys=True)

--- a/src/util/util.py
+++ b/src/util/util.py
@@ -278,16 +278,6 @@ class Util:
             )
 
     @staticmethod
-    def truncate_lines(s: str, max_lines: int = 1) -> str:
-        s = (s or "").strip("\n")
-        if not s:
-            return ""
-        lines = s.splitlines()
-        if len(lines) <= max_lines:
-            return s
-        return "\n".join(lines[:max_lines]) + " …"
-
-    @staticmethod
     def render_kv_summary(items: list[tuple[str, str]]) -> None:
         # generic compact line: "Summary: OK: 1  FAILED: 0  TIMEOUT: 0"
         parts = ["Summary:"]


### PR DESCRIPTION
This PR introduces initial probe support in Shepherd by adding two new CLI commands:

* `shepctl get probe` to inspect probe definitions without executing them
* `shepctl check probe` to explicitly run probes, report results, and return a CI-friendly exit code

This is a first iteration focused on probe execution and observability only; probes are not yet integrated into automatic service lifecycle management.

Fixes: #149 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
to change)
- [ ] Change or update to the documentation (with no functional changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
