### PR TITLE
refactor: add impl methods for abstract bases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ convert.sh
 wiki
 shepctl.spec
 build
+AGENTS.md

--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -97,7 +97,7 @@ class CompletionMng(AbstractCompletionMng):
         return None
 
     @override
-    def get_completions(self, args: list[str]) -> list[str]:
+    def get_completions_impl(self, args: list[str]) -> list[str]:
         if not self.is_verb_chosen(args):
             return self.VERBS
 

--- a/src/completion/completion_env.py
+++ b/src/completion/completion_env.py
@@ -29,7 +29,7 @@ class CompletionEnvMng(AbstractCompletionMng):
         self.configMng = configMng
 
     @override
-    def get_completions(self, args: list[str]) -> list[str]:
+    def get_completions_impl(self, args: list[str]) -> list[str]:
         command = args[0]
         match command:
             case "add":

--- a/src/completion/completion_mng.py
+++ b/src/completion/completion_mng.py
@@ -31,6 +31,9 @@ class AbstractCompletionMng(ABC):
         self.cli_flags = cli_flags
         self.configMng = configMng
 
-    @abstractmethod
     def get_completions(self, args: list[str]) -> list[str]:
+        return self.get_completions_impl(args)
+
+    @abstractmethod
+    def get_completions_impl(self, args: list[str]) -> list[str]:
         pass

--- a/src/completion/completion_probe.py
+++ b/src/completion/completion_probe.py
@@ -29,7 +29,7 @@ class CompletionProbeMng(AbstractCompletionMng):
         self.configMng = configMng
 
     @override
-    def get_completions(self, args: list[str]) -> list[str]:
+    def get_completions_impl(self, args: list[str]) -> list[str]:
         command = args[0]
         match command:
             case "get":

--- a/src/completion/completion_svc.py
+++ b/src/completion/completion_svc.py
@@ -29,7 +29,7 @@ class CompletionSvcMng(AbstractCompletionMng):
         self.configMng = configMng
 
     @override
-    def get_completions(self, args: list[str]) -> list[str]:
+    def get_completions_impl(self, args: list[str]) -> list[str]:
         command = args[0]
         match command:
             case "add":

--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -46,9 +46,8 @@ class DockerComposeEnv(Environment):
         super().__init__(config, svcFactory, envCfg)
 
     @override
-    def ensure_resources(self):
+    def ensure_resources_impl(self):
         """Ensure the environment resources are available."""
-        super().ensure_resources()
         if self.envCfg.volumes:
             for vol in self.envCfg.volumes:
                 # Check if it's a host bind mount,
@@ -64,7 +63,7 @@ class DockerComposeEnv(Environment):
                         Util.ensure_dir(device_path, vol.tag)
 
     @override
-    def clone(self, dst_env_tag: str) -> DockerComposeEnv:
+    def clone_impl(self, dst_env_tag: str) -> DockerComposeEnv:
         """Clone the environment."""
         clonedCfg = self.configMng.env_cfg_from_other(self.to_config())
         clonedCfg.tag = dst_env_tag
@@ -76,9 +75,8 @@ class DockerComposeEnv(Environment):
         return clonedEnv
 
     @override
-    def start(self):
+    def start_impl(self):
         """Start the environment."""
-        super().start()
         rendered_map = self.envCfg.status.rendered_config
         if rendered_map and "ungated" in rendered_map:
             run_compose(
@@ -89,7 +87,7 @@ class DockerComposeEnv(Environment):
             )
 
     @override
-    def stop(self):
+    def stop_impl(self):
         """Halt the environment."""
         rendered_map = self.envCfg.status.rendered_config
         if rendered_map and "ungated" in rendered_map:
@@ -98,7 +96,7 @@ class DockerComposeEnv(Environment):
             )
 
     @override
-    def reload(self):
+    def reload_impl(self):
         """Reload the environment."""
         rendered_map = self.envCfg.status.rendered_config
         if rendered_map and "ungated" in rendered_map:
@@ -107,7 +105,7 @@ class DockerComposeEnv(Environment):
             )
 
     @override
-    def render_target(self, resolved: bool = False) -> dict[str, str]:
+    def render_target_impl(self, resolved: bool = False) -> dict[str, str]:
         """
         Render the full docker-compose YAML configuration for the environment.
 
@@ -232,7 +230,7 @@ class DockerComposeEnv(Environment):
         return svc
 
     @override
-    def render_probes_target(
+    def render_probes_target_impl(
         self, probe_tag: Optional[str], resolved: bool
     ) -> Optional[str]:
         was_resolved = self.envCfg.is_resolved()
@@ -363,7 +361,7 @@ class DockerComposeEnv(Environment):
 
         return results
 
-    def status(self) -> list[dict[str, str]]:
+    def status_impl(self) -> list[dict[str, str]]:
         """Get environment status (list of services with state)."""
 
         rendered_map = self.envCfg.status.rendered_config

--- a/src/docker/docker_compose_svc.py
+++ b/src/docker/docker_compose_svc.py
@@ -38,7 +38,7 @@ class DockerComposeSvc(Service):
         super().__init__(config, envCfg, svcCfg)
 
     @override
-    def render_target(self, resolved: bool) -> str:
+    def render_target_impl(self, resolved: bool) -> str:
         """
         Render the docker-compose service configuration for this service.
 
@@ -77,7 +77,7 @@ class DockerComposeSvc(Service):
                     self.envCfg.set_unresolved()
 
     @override
-    def build(self, cnt_tag: Optional[str] = None) -> None:
+    def build_impl(self, cnt_tag: Optional[str] = None) -> None:
         """Build the service."""
         if cnt_tag:
             container = self.svcCfg.get_container_by_tag(cnt_tag)
@@ -95,7 +95,7 @@ class DockerComposeSvc(Service):
             build_container(container)
 
     @override
-    def start(self, cnt_tag: Optional[str] = None):
+    def start_impl(self, cnt_tag: Optional[str] = None):
         """Start the service."""
         rendered_map = self.envCfg.status.rendered_config
         rendered = rendered_map.get("ungated") if rendered_map else None
@@ -132,7 +132,7 @@ class DockerComposeSvc(Service):
             )
 
     @override
-    def stop(self, cnt_tag: Optional[str] = None):
+    def stop_impl(self, cnt_tag: Optional[str] = None):
         """Stop the service."""
         rendered_map = self.envCfg.status.rendered_config
         rendered = rendered_map.get("ungated") if rendered_map else None
@@ -167,7 +167,7 @@ class DockerComposeSvc(Service):
             )
 
     @override
-    def reload(self, cnt_tag: Optional[str] = None):
+    def reload_impl(self, cnt_tag: Optional[str] = None):
         """Reload the service."""
         rendered_map = self.envCfg.status.rendered_config
         rendered = rendered_map.get("ungated") if rendered_map else None
@@ -202,7 +202,7 @@ class DockerComposeSvc(Service):
             )
 
     @override
-    def get_stdout(self, cnt_tag: Optional[str] = None):
+    def get_stdout_impl(self, cnt_tag: Optional[str] = None):
         """Show the service stdout."""
         rendered_map = self.envCfg.status.rendered_config
         rendered = rendered_map.get("ungated") if rendered_map else None
@@ -240,7 +240,7 @@ class DockerComposeSvc(Service):
             )
 
     @override
-    def get_shell(self, cnt_tag: Optional[str] = None):
+    def get_shell_impl(self, cnt_tag: Optional[str] = None):
         """Get a shell session for the service."""
         rendered_map = self.envCfg.status.rendered_config
         rendered = rendered_map.get("ungated") if rendered_map else None

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -61,34 +61,36 @@ class Environment(ABC):
         )
 
     @abstractmethod
-    def clone(self, dst_env_tag: str) -> Environment:
+    def clone_impl(self, dst_env_tag: str) -> Environment:
         """Clone the environment."""
         pass
+
+    def clone(self, dst_env_tag: str) -> Environment:
+        """Clone the environment."""
+        return self.clone_impl(dst_env_tag)
 
     def start(self):
         """Start the environment."""
         self.ensure_resources()
+        return self.start_impl()
 
-    @abstractmethod
     def stop(self):
         """Halt the environment."""
-        pass
+        return self.stop_impl()
 
-    @abstractmethod
     def reload(self):
         """Reload the environment."""
-        pass
+        return self.reload_impl()
 
     def render(self, resolved: bool) -> str:
         """Render the environment configuration."""
         return self.envCfg.get_yaml(resolved)
 
-    @abstractmethod
-    def render_target(self, resolved: bool) -> dict[str, str]:
+    def render_target(self, resolved: bool = False) -> dict[str, str]:
         """
         Render the environment configuration in the target system.
         """
-        pass
+        return self.render_target_impl(resolved)
 
     def render_probes(
         self, probe_tag: Optional[str], resolved: bool
@@ -98,14 +100,13 @@ class Environment(ABC):
         """
         return self.envCfg.get_probes_yaml(probe_tag, resolved)
 
-    @abstractmethod
     def render_probes_target(
         self, probe_tag: Optional[str], resolved: bool
     ) -> Optional[str]:
         """
         Render the environment probes configuration in the target system.
         """
-        pass
+        return self.render_probes_target_impl(probe_tag, resolved)
 
     def check_probes(
         self,
@@ -137,10 +138,9 @@ class Environment(ABC):
     ) -> list[ProbeRunResult]:
         pass
 
-    @abstractmethod
     def status(self) -> list[dict[str, str]]:
         """Get environment status."""
-        pass
+        return self.status_impl()
 
     def to_config(self) -> EnvironmentCfg:
         """To config"""
@@ -155,8 +155,48 @@ class Environment(ABC):
         """Return the directory for the environment with a given tag."""
         return os.path.join(self.configMng.config.envs_path, env_tag)
 
-    @abstractmethod
     def ensure_resources(self):
+        """Ensure the environment resources are available."""
+        return self.ensure_resources_impl()
+
+    @abstractmethod
+    def stop_impl(self):
+        """Halt the environment."""
+        pass
+
+    @abstractmethod
+    def start_impl(self):
+        """Start the environment."""
+        pass
+
+    @abstractmethod
+    def reload_impl(self):
+        """Reload the environment."""
+        pass
+
+    @abstractmethod
+    def render_target_impl(self, resolved: bool = False) -> dict[str, str]:
+        """
+        Render the environment configuration in the target system.
+        """
+        pass
+
+    @abstractmethod
+    def render_probes_target_impl(
+        self, probe_tag: Optional[str], resolved: bool
+    ) -> Optional[str]:
+        """
+        Render the environment probes configuration in the target system.
+        """
+        pass
+
+    @abstractmethod
+    def status_impl(self) -> list[dict[str, str]]:
+        """Get environment status."""
+        pass
+
+    @abstractmethod
+    def ensure_resources_impl(self):
         """Ensure the environment resources are available."""
         pass
 
@@ -242,8 +282,24 @@ class EnvironmentFactory(ABC):
     def __init__(self, config: ConfigMng):
         self.config = config
 
-    @abstractmethod
     def new_environment(
+        self,
+        env_tmpl_cfg: EnvironmentTemplateCfg,
+        env_tag: str,
+    ) -> Environment:
+        """
+        Create an environment.
+        """
+        return self.new_environment_impl(env_tmpl_cfg, env_tag)
+
+    def new_environment_cfg(self, envCfg: EnvironmentCfg) -> Environment:
+        """
+        Create an environment.
+        """
+        return self.new_environment_cfg_impl(envCfg)
+
+    @abstractmethod
+    def new_environment_impl(
         self,
         env_tmpl_cfg: EnvironmentTemplateCfg,
         env_tag: str,
@@ -254,7 +310,7 @@ class EnvironmentFactory(ABC):
         pass
 
     @abstractmethod
-    def new_environment_cfg(self, envCfg: EnvironmentCfg) -> Environment:
+    def new_environment_cfg_impl(self, envCfg: EnvironmentCfg) -> Environment:
         """
         Create an environment.
         """

--- a/src/factory/shpd_env_factory.py
+++ b/src/factory/shpd_env_factory.py
@@ -32,7 +32,7 @@ class ShpdEnvironmentFactory(EnvironmentFactory):
         self.svcFactory = svcFactory
 
     @override
-    def new_environment(
+    def new_environment_impl(
         self,
         env_tmpl_cfg: EnvironmentTemplateCfg,
         env_tag: str,
@@ -53,7 +53,7 @@ class ShpdEnvironmentFactory(EnvironmentFactory):
                 )
 
     @override
-    def new_environment_cfg(self, envCfg: EnvironmentCfg) -> Environment:
+    def new_environment_cfg_impl(self, envCfg: EnvironmentCfg) -> Environment:
         """
         Get an environment.
         """

--- a/src/factory/shpd_svc_factory.py
+++ b/src/factory/shpd_svc_factory.py
@@ -30,11 +30,12 @@ class ShpdServiceFactory(ServiceFactory):
         self.configMng = configMng
 
     @override
-    def get_name() -> str:
+    @classmethod
+    def get_name_impl(cls) -> str:
         return "shpd-svc-factory"
 
     @override
-    def new_service_from_cfg(
+    def new_service_from_cfg_impl(
         self, envCfg: EnvironmentCfg, svcCfg: ServiceCfg
     ) -> Service:
         """

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -82,40 +82,70 @@ class Service(ABC):
         """Render the service configuration."""
         return self.svcCfg.get_yaml(resolved)
 
-    @abstractmethod
     def render_target(self, resolved: bool) -> str:
+        """
+        Render the service configuration in the target system.
+        """
+        return self.render_target_impl(resolved)
+
+    def build(self, cnt_tag: Optional[str] = None):
+        """Build the service."""
+        return self.build_impl(cnt_tag)
+
+    def start(self, cnt_tag: Optional[str] = None):
+        """Start the service."""
+        return self.start_impl(cnt_tag)
+
+    def stop(self, cnt_tag: Optional[str] = None):
+        """Stop the service."""
+        return self.stop_impl(cnt_tag)
+
+    def reload(self, cnt_tag: Optional[str] = None):
+        """Reload the service."""
+        return self.reload_impl(cnt_tag)
+
+    def get_stdout(self, cnt_tag: Optional[str] = None):
+        """Show the service stdout."""
+        return self.get_stdout_impl(cnt_tag)
+
+    def get_shell(self, cnt_tag: Optional[str] = None):
+        """Get a shell session for the service."""
+        return self.get_shell_impl(cnt_tag)
+
+    @abstractmethod
+    def render_target_impl(self, resolved: bool) -> str:
         """
         Render the service configuration in the target system.
         """
         pass
 
     @abstractmethod
-    def build(self, cnt_tag: Optional[str] = None):
+    def build_impl(self, cnt_tag: Optional[str] = None):
         """Build the service."""
         pass
 
     @abstractmethod
-    def start(self, cnt_tag: Optional[str] = None):
+    def start_impl(self, cnt_tag: Optional[str] = None):
         """Start the service."""
         pass
 
     @abstractmethod
-    def stop(self, cnt_tag: Optional[str] = None):
+    def stop_impl(self, cnt_tag: Optional[str] = None):
         """Stop the service."""
         pass
 
     @abstractmethod
-    def reload(self, cnt_tag: Optional[str] = None):
+    def reload_impl(self, cnt_tag: Optional[str] = None):
         """Reload the service."""
         pass
 
     @abstractmethod
-    def get_stdout(self, cnt_tag: Optional[str] = None):
+    def get_stdout_impl(self, cnt_tag: Optional[str] = None):
         """Show the service stdout."""
         pass
 
     @abstractmethod
-    def get_shell(self, cnt_tag: Optional[str] = None):
+    def get_shell_impl(self, cnt_tag: Optional[str] = None):
         """Get a shell session for the service."""
         pass
 
@@ -131,12 +161,25 @@ class ServiceFactory(ABC):
     def __init__(self, config: ConfigMng):
         self.config = config
 
+    @classmethod
+    def get_name(cls) -> str:
+        return cls.get_name_impl()
+
+    def new_service_from_cfg(
+        self, envCfg: EnvironmentCfg, svcCfg: ServiceCfg
+    ) -> Service:
+        """
+        Create a new service.
+        """
+        return self.new_service_from_cfg_impl(envCfg, svcCfg)
+
+    @classmethod
     @abstractmethod
-    def get_name() -> str:
+    def get_name_impl(cls) -> str:
         pass
 
     @abstractmethod
-    def new_service_from_cfg(
+    def new_service_from_cfg_impl(
         self, envCfg: EnvironmentCfg, svcCfg: ServiceCfg
     ) -> Service:
         """


### PR DESCRIPTION
## Summary
- Refactor ABCs to delegate public methods to `*_impl` abstract methods.
- Update Docker Compose env/service and factories/completion managers accordingly.
- Add `start_impl` hook to `Environment` and adjust defaults.

## Testing
- `pytest`
- `pre-commit run --all-files`
- `black -v src`
- `isort src`

Fixes #150
