### PR TITLE
up/halt environment visual improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,12 +21,12 @@ repos:
       - id: codespell
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.18.1
+    rev: v0.20.0
     hooks:
       - id: markdownlint-cli2
 
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.1.0
     hooks:
       - id: black
         args:
@@ -38,7 +38,7 @@ repos:
             "--check",
           ]
   - repo: https://github.com/PyCQA/isort
-    rev: 6.0.1
+    rev: 7.0.0
     hooks:
       - id: isort
         args: ["--sp", "src/pyproject.toml", "--check-only"]
@@ -51,7 +51,7 @@ repos:
         args: ["--config", "src/.flake8"]
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.403
+    rev: v1.1.408
     hooks:
       - id: pyright
         args: ["--project", "src/pyproject.toml"]

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -9,7 +9,7 @@ versions of Shepherd.
   - **Binary Download (Recommended)**: Download the pre-built binary from the
       [GitHub Releases page](https://github.com/orhun/git-cliff/releases) and add
       it to your PATH.
-  - **Pip**: `pip install git-cliff` (convenient if you are already in a Python environment).
+  - **Pip**: `pip install git-cliff` (if you are already in a Python environment).
   - **Cargo**: `cargo install git-cliff` (if you have Rust installed).
   - **npm**: `npm install -g git-cliff` (if you have Node.js installed).
 - **Push Access**: You need write access to the main repository to push tags.

--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -41,9 +41,10 @@ class DockerComposeEnv(Environment):
         config: ConfigMng,
         svcFactory: ServiceFactory,
         envCfg: EnvironmentCfg,
+        cli_flags: Optional[dict[str, bool]] = None,
     ):
         """Initialize a Docker Compose environment."""
-        super().__init__(config, svcFactory, envCfg)
+        super().__init__(config, svcFactory, envCfg, cli_flags=cli_flags)
 
     @override
     def ensure_resources_impl(self):
@@ -71,6 +72,7 @@ class DockerComposeEnv(Environment):
             self.configMng,
             self.svcFactory,
             clonedCfg,
+            cli_flags=self.cli_flags,
         )
         return clonedEnv
 

--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
 from typing import Any, Optional, override
 
@@ -398,6 +399,16 @@ class DockerComposeEnv(Environment):
                 if obj:
                     services.append(obj)
             except json.JSONDecodeError:
+                logging.debug(
+                    "Ignoring non-JSON docker compose ps line for env '%s': %r",
+                    self.envCfg.tag,
+                    line,
+                )
                 continue
 
+        logging.debug(
+            "Collected %d docker compose status row(s) for env '%s'.",
+            len(services),
+            self.envCfg.tag,
+        )
         return services

--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -86,6 +86,7 @@ class DockerComposeEnv(Environment):
                 "up",
                 "-d",
                 project_name=self.envCfg.tag,
+                capture=not self._is_verbose(),
             )
 
     @override
@@ -94,7 +95,10 @@ class DockerComposeEnv(Environment):
         rendered_map = self.envCfg.status.rendered_config
         if rendered_map and "ungated" in rendered_map:
             run_compose(
-                rendered_map["ungated"], "down", project_name=self.envCfg.tag
+                rendered_map["ungated"],
+                "down",
+                project_name=self.envCfg.tag,
+                capture=not self._is_verbose(),
             )
 
     @override
@@ -103,7 +107,10 @@ class DockerComposeEnv(Environment):
         rendered_map = self.envCfg.status.rendered_config
         if rendered_map and "ungated" in rendered_map:
             run_compose(
-                rendered_map["ungated"], "restart", project_name=self.envCfg.tag
+                rendered_map["ungated"],
+                "restart",
+                project_name=self.envCfg.tag,
+                capture=not self._is_verbose(),
             )
 
     @override

--- a/src/docker/docker_compose_svc.py
+++ b/src/docker/docker_compose_svc.py
@@ -83,6 +83,7 @@ class DockerComposeSvc(Service):
     @override
     def build_impl(self, cnt_tag: Optional[str] = None) -> None:
         """Build the service."""
+        verbose = self._is_verbose() or not self._is_quiet()
         if cnt_tag:
             container = self.svcCfg.get_container_by_tag(cnt_tag)
             if not container:
@@ -91,18 +92,19 @@ class DockerComposeSvc(Service):
                     f"container named '{cnt_tag}'."
                 )
             if container:
-                build_container(container)
+                build_container(container, verbose=verbose)
             return
 
         containers = self.svcCfg.containers or []
         for container in containers:
-            build_container(container)
+            build_container(container, verbose=verbose)
 
     @override
     def start_impl(self, cnt_tag: Optional[str] = None):
         """Start the service."""
         rendered_map = self.envCfg.status.rendered_config
         rendered = rendered_map.get("ungated") if rendered_map else None
+        verbose = self._is_verbose()
 
         if rendered and self.svcCfg.containers:
             if cnt_tag:
@@ -119,6 +121,7 @@ class DockerComposeSvc(Service):
                         "-d",
                         container.run_container_name or "",
                         project_name=self.envCfg.tag,
+                        capture=not verbose,
                     )
                 return
 
@@ -129,6 +132,7 @@ class DockerComposeSvc(Service):
                     "-d",
                     container.run_container_name or "",
                     project_name=self.envCfg.tag,
+                    capture=not verbose,
                 )
         else:
             Util.print_error_and_die(
@@ -140,6 +144,7 @@ class DockerComposeSvc(Service):
         """Stop the service."""
         rendered_map = self.envCfg.status.rendered_config
         rendered = rendered_map.get("ungated") if rendered_map else None
+        verbose = self._is_verbose()
 
         if rendered and self.svcCfg.containers:
             if cnt_tag:
@@ -155,6 +160,7 @@ class DockerComposeSvc(Service):
                         "stop",
                         container.run_container_name or "",
                         project_name=self.envCfg.tag,
+                        capture=not verbose,
                     )
                 return
 
@@ -164,6 +170,7 @@ class DockerComposeSvc(Service):
                     "stop",
                     container.run_container_name or "",
                     project_name=self.envCfg.tag,
+                    capture=not verbose,
                 )
         else:
             Util.print_error_and_die(
@@ -175,6 +182,7 @@ class DockerComposeSvc(Service):
         """Reload the service."""
         rendered_map = self.envCfg.status.rendered_config
         rendered = rendered_map.get("ungated") if rendered_map else None
+        verbose = self._is_verbose()
 
         if rendered and self.svcCfg.containers:
             if cnt_tag:
@@ -190,6 +198,7 @@ class DockerComposeSvc(Service):
                         "restart",
                         container.run_container_name or "",
                         project_name=self.envCfg.tag,
+                        capture=not verbose,
                     )
                 return
 
@@ -199,6 +208,7 @@ class DockerComposeSvc(Service):
                     "restart",
                     container.run_container_name or "",
                     project_name=self.envCfg.tag,
+                    capture=not verbose,
                 )
         else:
             Util.print_error_and_die(
@@ -210,6 +220,7 @@ class DockerComposeSvc(Service):
         """Show the service stdout."""
         rendered_map = self.envCfg.status.rendered_config
         rendered = rendered_map.get("ungated") if rendered_map else None
+        capture = self._is_quiet() and not self._is_verbose()
 
         if rendered:
             if cnt_tag:
@@ -225,6 +236,7 @@ class DockerComposeSvc(Service):
                         "logs",
                         container.run_container_name or "",
                         project_name=self.envCfg.tag,
+                        capture=capture,
                     )
             elif self.svcCfg.containers and len(self.svcCfg.containers) == 1:
                 run_compose(
@@ -232,6 +244,7 @@ class DockerComposeSvc(Service):
                     "logs",
                     self.svcCfg.containers[0].run_container_name or "",
                     project_name=self.envCfg.tag,
+                    capture=capture,
                 )
             else:
                 Util.print_error_and_die(
@@ -248,6 +261,7 @@ class DockerComposeSvc(Service):
         """Get a shell session for the service."""
         rendered_map = self.envCfg.status.rendered_config
         rendered = rendered_map.get("ungated") if rendered_map else None
+        capture = self._is_quiet() and not self._is_verbose()
 
         if rendered:
             if cnt_tag:
@@ -264,6 +278,7 @@ class DockerComposeSvc(Service):
                         container.run_container_name or "",
                         "sh",
                         project_name=self.envCfg.tag,
+                        capture=capture,
                     )
             elif self.svcCfg.containers and len(self.svcCfg.containers) == 1:
                 run_compose(
@@ -272,6 +287,7 @@ class DockerComposeSvc(Service):
                     self.svcCfg.containers[0].run_container_name or "",
                     "sh",
                     project_name=self.envCfg.tag,
+                    capture=capture,
                 )
             else:
                 Util.print_error_and_die(

--- a/src/docker/docker_compose_svc.py
+++ b/src/docker/docker_compose_svc.py
@@ -32,10 +32,14 @@ from .docker_compose_util import build_container, render_container, run_compose
 class DockerComposeSvc(Service):
 
     def __init__(
-        self, config: ConfigMng, envCfg: EnvironmentCfg, svcCfg: ServiceCfg
+        self,
+        config: ConfigMng,
+        envCfg: EnvironmentCfg,
+        svcCfg: ServiceCfg,
+        cli_flags: Optional[dict[str, bool]] = None,
     ):
         """Initialize a Docker service."""
-        super().__init__(config, envCfg, svcCfg)
+        super().__init__(config, envCfg, svcCfg, cli_flags=cli_flags)
 
     @override
     def render_target_impl(self, resolved: bool) -> str:

--- a/src/docker/docker_compose_util.py
+++ b/src/docker/docker_compose_util.py
@@ -120,7 +120,11 @@ def run_compose(
 
 
 def build_docker_image(
-    dockerfile_path: Path, context_path: Path, tag: str
+    dockerfile_path: Path,
+    context_path: Path,
+    tag: str,
+    *,
+    verbose: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     """
     Build a Docker image using the specified Dockerfile and context
@@ -158,13 +162,22 @@ def build_docker_image(
     logging.info(f"Building Docker image '{tag}'")
     logging.debug(f"Docker build command: {' '.join(cmd)}")
 
-    process = subprocess.run(
-        cmd,
-        check=False,
-        text=True,
-        stdout=None,
-        stderr=None,
-    )
+    if verbose:
+        process = subprocess.run(
+            cmd,
+            check=False,
+            text=True,
+            stdout=None,
+            stderr=None,
+        )
+    else:
+        process = subprocess.run(
+            cmd,
+            check=False,
+            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
 
     if process.returncode != 0:
         logging.warning(
@@ -206,7 +219,7 @@ def render_container(
     return container_def
 
 
-def build_container(container: ContainerCfg) -> None:
+def build_container(container: ContainerCfg, *, verbose: bool = False) -> None:
     """Build a container."""
     if not container.build:
         Util.print_error_and_die(
@@ -233,4 +246,5 @@ def build_container(container: ContainerCfg) -> None:
                 Path(build.dockerfile_path),
                 Path(build.context_path),
                 container.image or "",
+                verbose=verbose,
             )

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -26,7 +26,9 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
+from rich import box
 from rich.live import Live
+from rich.table import Table
 
 from config import ConfigMng, EnvironmentCfg, EnvironmentTemplateCfg
 from service import Service, ServiceFactory
@@ -74,6 +76,9 @@ class Environment(ABC):
 
     def _is_quiet(self) -> bool:
         return bool(self.cli_flags.get("quiet", False))
+
+    def _is_details(self) -> bool:
+        return bool(self.cli_flags.get("details", False))
 
     @abstractmethod
     def clone_impl(self, dst_env_tag: str) -> Environment:
@@ -355,6 +360,9 @@ class EnvironmentMng:
 
     def _is_quiet(self) -> bool:
         return bool(self.cli_flags.get("quiet", False))
+
+    def _is_details(self) -> bool:
+        return bool(self.cli_flags.get("details", False))
 
     def get_environment_from_tag(
         self, env_tag: Optional[str]
@@ -773,6 +781,26 @@ class EnvironmentMng:
                 return all_running and not in_action()
             return (not any_running) and not in_action()
 
+        required_gate_tags = self._get_required_gate_tags(env)
+        gate_status: dict[str, Optional[bool]] = {
+            tag: None for tag in required_gate_tags
+        }
+        next_gate_eval_at = time.monotonic() + max(
+            1.0, self._status_poll_seconds * 2
+        )
+
+        def get_gate_status() -> Optional[dict[str, Optional[bool]]]:
+            nonlocal gate_status, next_gate_eval_at
+            if not wait_until_up or not required_gate_tags:
+                return None
+            now = time.monotonic()
+            if now < next_gate_eval_at:
+                return gate_status
+            gate_status = self._evaluate_gate_status(env, required_gate_tags)
+            # Avoid running probes on every visual refresh tick.
+            next_gate_eval_at = now + max(1.0, self._status_poll_seconds * 2)
+            return gate_status
+
         started = time.monotonic()
         logging.debug(
             "wait_for_env_%s started for env='%s' (timeout=%s, terminal=%s)",
@@ -796,8 +824,12 @@ class EnvironmentMng:
                 time.sleep(self._status_poll_seconds)
 
             raise_action_error()
+            current_gate_status = get_gate_status()
             grouped, all_running, any_running, has_containers = (
-                self._collect_env_status(env)
+                self._collect_env_status(
+                    env,
+                    gate_status=current_gate_status,
+                )
             )
             remaining = self._remaining_timeout_seconds(
                 started, timeout_seconds
@@ -840,8 +872,12 @@ class EnvironmentMng:
         ) as live:
             while True:
                 raise_action_error()
+                current_gate_status = get_gate_status()
                 grouped, all_running, any_running, has_containers = (
-                    self._collect_env_status(env)
+                    self._collect_env_status(
+                        env,
+                        gate_status=current_gate_status,
+                    )
                 )
                 remaining = self._remaining_timeout_seconds(
                     started, timeout_seconds
@@ -911,15 +947,39 @@ class EnvironmentMng:
         title = f"[white]{env_tag}[/white]"
         if remaining_seconds is not None:
             title = f"{title} " f"[dim](Time left: {remaining_seconds}s)[/dim]"
-        return Util.build_grouped_table(
+        table = Table(
             title=title,
-            group_column_header="Service",
-            item_columns=[
-                {"header": "Container", "style": "white"},
-                {"header": "State"},
-            ],
-            groups=grouped,
+            box=box.SIMPLE,
+            title_justify="left",
+            title_style="bold",
         )
+        table.add_column("Gates", style="cyan", no_wrap=True)
+        table.add_column("Service", style="cyan", no_wrap=True)
+        table.add_column("Container", style="white", no_wrap=True)
+        table.add_column("State", no_wrap=True)
+        if self._is_details():
+            table.add_column("Probes", style="white")
+
+        for service, items in grouped.items():
+            for idx, item in enumerate(items):
+                gate_details = ""
+                if self._is_details():
+                    gates, container, state, gate_details = item
+                else:
+                    gates, container, state = item
+                is_last = idx == len(items) - 1
+                branch = "└─" if is_last else "├─"
+                row: list[str] = [
+                    gates if idx == 0 else "",
+                    f"[bold]{service}[/bold]" if idx == 0 else "",
+                    f"{branch} {container}",
+                    state,
+                ]
+                if self._is_details():
+                    row.append(gate_details if idx == 0 else "")
+                table.add_row(*row)
+
+        return table
 
     def _remaining_timeout_seconds(
         self, started_at: float, timeout_seconds: Optional[int]
@@ -931,7 +991,9 @@ class EnvironmentMng:
         return remaining if remaining > 0 else 0
 
     def _collect_env_status(
-        self, env: Environment
+        self,
+        env: Environment,
+        gate_status: Optional[dict[str, Optional[bool]]] = None,
     ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
         env_status = env.status()
         services: list[Service] = env.get_services()
@@ -946,7 +1008,15 @@ class EnvironmentMng:
 
         for svc in services:
             rows: list[list[str]] = []
-            for container in svc.svcCfg.containers or []:
+            service_gates = self._format_service_gate_glyphs(
+                svc,
+                gate_status=gate_status,
+            )
+            service_gate_details = self._format_service_gate_details(
+                svc,
+                gate_status=gate_status,
+            )
+            for idx, container in enumerate(svc.svcCfg.containers or []):
                 has_containers = True
                 cnt_name = container.run_container_name or ""
                 cnt_info = status_by_service.get(cnt_name)
@@ -967,7 +1037,11 @@ class EnvironmentMng:
                 if state != "running":
                     all_running = False
 
-                rows.append([container.tag, state_colored])
+                gates_cell = service_gates if idx == 0 else ""
+                row = [gates_cell, container.tag, state_colored]
+                if self._is_details():
+                    row.append(service_gate_details if idx == 0 else "")
+                rows.append(row)
 
             if rows:
                 grouped[svc.svcCfg.tag] = rows
@@ -976,6 +1050,99 @@ class EnvironmentMng:
             all_running = False
 
         return grouped, all_running, any_running, has_containers
+
+    def _format_service_gate_glyphs(
+        self,
+        svc: Service,
+        gate_status: Optional[dict[str, Optional[bool]]] = None,
+    ) -> str:
+        when_probes = (
+            svc.svcCfg.start.when_probes
+            if svc.svcCfg.start and svc.svcCfg.start.when_probes
+            else None
+        )
+        if not when_probes:
+            return "[dim]-[/dim]"
+        if gate_status is None:
+            return "".join("[dim]○[/dim]" for _ in when_probes)
+
+        glyphs: list[str] = []
+        for probe_tag in when_probes:
+            probe_ok = gate_status.get(probe_tag)
+            if probe_ok is True:
+                glyphs.append("[bold green]●[/bold green]")
+            elif probe_ok is False:
+                glyphs.append("[bold red]●[/bold red]")
+            else:
+                glyphs.append("[dim]○[/dim]")
+        return "".join(glyphs)
+
+    def _format_service_gate_details(
+        self,
+        svc: Service,
+        gate_status: Optional[dict[str, Optional[bool]]] = None,
+    ) -> str:
+        when_probes = (
+            svc.svcCfg.start.when_probes
+            if svc.svcCfg.start and svc.svcCfg.start.when_probes
+            else None
+        )
+        if not when_probes:
+            return "[dim]-[/dim]"
+
+        probe_tags = sorted(when_probes)
+        parts: list[str] = []
+        for probe_tag in probe_tags:
+            if gate_status is None:
+                parts.append(f"[dim]{probe_tag}[/dim]")
+                continue
+            probe_ok = gate_status.get(probe_tag)
+            if probe_ok is True:
+                parts.append(f"[bold green]{probe_tag}[/bold green]")
+            elif probe_ok is False:
+                parts.append(f"[bold red]{probe_tag}[/bold red]")
+            else:
+                parts.append(f"[dim]{probe_tag}[/dim]")
+        return ", ".join(parts)
+
+    def _get_required_gate_tags(self, env: Environment) -> set[str]:
+        required: set[str] = set()
+        for svc in env.get_services():
+            when_probes = (
+                svc.svcCfg.start.when_probes
+                if svc.svcCfg.start and svc.svcCfg.start.when_probes
+                else None
+            )
+            if when_probes:
+                required.update(when_probes)
+        return required
+
+    def _evaluate_gate_status(
+        self,
+        env: Environment,
+        required_gate_tags: set[str],
+    ) -> dict[str, Optional[bool]]:
+        status: dict[str, Optional[bool]] = {
+            tag: None for tag in required_gate_tags
+        }
+        if not required_gate_tags:
+            return status
+        try:
+            results = env.check_probes(
+                probe_tag=None,
+                fail_fast=False,
+                timeout_seconds=10,
+            )
+        except Exception as e:
+            logging.debug(
+                "Gate evaluation failed for env '%s': %s", env.envCfg.tag, e
+            )
+            return status
+
+        for r in results:
+            if r.tag in status:
+                status[r.tag] = (r.exit_code == 0) and not r.timed_out
+        return status
 
     def add_service(
         self,

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -47,13 +47,17 @@ class Environment(ABC):
         configMng: ConfigMng,
         svcFactory: ServiceFactory,
         envCfg: EnvironmentCfg,
+        cli_flags: Optional[dict[str, bool]] = None,
     ):
         self.configMng = configMng
         self.svcFactory = svcFactory
         self.envCfg = envCfg
+        self.cli_flags = cli_flags or {}
         self.services = (
             [
-                self.svcFactory.new_service_from_cfg(envCfg, svcCfg)
+                self.svcFactory.new_service_from_cfg(
+                    envCfg, svcCfg, cli_flags=self.cli_flags
+                )
                 for svcCfg in envCfg.services
             ]
             if envCfg.services
@@ -279,8 +283,11 @@ class EnvironmentFactory(ABC):
     Factory class for environments.
     """
 
-    def __init__(self, config: ConfigMng):
+    def __init__(
+        self, config: ConfigMng, cli_flags: Optional[dict[str, bool]] = None
+    ):
         self.config = config
+        self.cli_flags = cli_flags or {}
 
     def new_environment(
         self,
@@ -743,7 +750,9 @@ class EnvironmentMng:
                 )
 
             try:
-                service = self.svcFactory.new_service_from_cfg(envCfg, svcCfg)
+                service = self.svcFactory.new_service_from_cfg(
+                    envCfg, svcCfg, cli_flags=self.cli_flags
+                )
                 env.add_service(service)
                 Util.print(
                     f"Service '{service.svcCfg.tag}' added to "

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -497,7 +497,7 @@ class EnvironmentMng:
     def stop_env(self, envCfg: EnvironmentCfg):
         """Halt an environment."""
         env = self.get_environment_from_cfg(envCfg)
-        env.stop()
+        self.wait_for_env_down(env, stop_action=env.stop)
         env.envCfg.status.rendered_config = None
         env.sync_config()
         Util.print(f"Halted environment: {env.envCfg.tag}")
@@ -692,7 +692,7 @@ class EnvironmentMng:
     def status_env(self, envCfg: EnvironmentCfg):
         """Get environment status."""
         env = self.get_environment_from_cfg(envCfg)
-        grouped, _, has_containers = self._collect_env_status(env)
+        grouped, _, _, has_containers = self._collect_env_status(env)
         if not has_containers or not grouped:
             Util.console.print(
                 f"[yellow]No services found for "
@@ -707,48 +707,83 @@ class EnvironmentMng:
         timeout_seconds: Optional[int] = None,
         start_action: Optional[Callable[[], Any]] = None,
     ):
+        self._wait_for_env_state(
+            env,
+            timeout_seconds=timeout_seconds,
+            action=start_action,
+            wait_until_up=True,
+        )
+
+    def wait_for_env_down(
+        self,
+        env: Environment,
+        timeout_seconds: Optional[int] = None,
+        stop_action: Optional[Callable[[], Any]] = None,
+    ):
+        self._wait_for_env_state(
+            env,
+            timeout_seconds=timeout_seconds,
+            action=stop_action,
+            wait_until_up=False,
+        )
+
+    def _wait_for_env_state(
+        self,
+        env: Environment,
+        timeout_seconds: Optional[int],
+        action: Optional[Callable[[], Any]],
+        wait_until_up: bool,
+    ):
+        phase = "up" if wait_until_up else "down"
+        phase_gerund = "starting" if wait_until_up else "stopping"
+        timeout_target = "up" if wait_until_up else "down"
+
         if self._is_quiet():
-            if start_action:
-                start_action()
+            if action:
+                action()
             return
 
-        start_error: Optional[BaseException] = None
-        start_done = threading.Event()
+        action_error: Optional[BaseException] = None
+        action_done = threading.Event()
 
-        if start_action:
+        if action:
 
-            def run_start():
-                nonlocal start_error
+            def run_action():
+                nonlocal action_error
                 try:
-                    start_action()
+                    action()
                 except BaseException as e:
-                    start_error = e
+                    action_error = e
                 finally:
-                    start_done.set()
+                    action_done.set()
 
-            threading.Thread(target=run_start, daemon=True).start()
+            threading.Thread(target=run_action, daemon=True).start()
         else:
-            start_done.set()
+            action_done.set()
 
-        def raise_start_error():
-            if start_error is not None:
-                raise start_error
+        def raise_action_error():
+            if action_error is not None:
+                raise action_error
 
-        def in_startup() -> bool:
-            return not start_done.is_set()
+        def in_action() -> bool:
+            return not action_done.is_set()
+
+        def condition_met(all_running: bool, any_running: bool) -> bool:
+            if wait_until_up:
+                return all_running and not in_action()
+            return (not any_running) and not in_action()
 
         started = time.monotonic()
         logging.debug(
-            "wait_for_env_up started for env='%s' (timeout=%s, terminal=%s)",
+            "wait_for_env_%s started for env='%s' (timeout=%s, terminal=%s)",
+            phase,
             env.envCfg.tag,
             timeout_seconds,
             Util.console.is_terminal,
         )
         if not Util.console.is_terminal:
-            # In non-interactive mode (tests/CI/pipes) avoid long polling loops:
-            # wait for start to complete, then render one snapshot.
-            while in_startup():
-                raise_start_error()
+            while in_action():
+                raise_action_error()
                 remaining = self._remaining_timeout_seconds(
                     started, timeout_seconds
                 )
@@ -756,22 +791,27 @@ class EnvironmentMng:
                     if remaining <= 0:
                         Util.print_error_and_die(
                             "Timed out waiting for environment "
-                            f"'{env.envCfg.tag}' to be up."
+                            f"'{env.envCfg.tag}' to be {timeout_target}."
                         )
                 time.sleep(self._status_poll_seconds)
 
-            raise_start_error()
-            grouped, all_running, has_containers = self._collect_env_status(env)
+            raise_action_error()
+            grouped, all_running, any_running, has_containers = (
+                self._collect_env_status(env)
+            )
             remaining = self._remaining_timeout_seconds(
                 started, timeout_seconds
             )
             logging.debug(
-                "wait_for_env_up non-terminal snapshot env='%s': "
-                "groups=%d has_containers=%s all_running=%s remaining=%s",
+                "wait_for_env_%s non-terminal snapshot env='%s': "
+                "groups=%d has_containers=%s all_running=%s any_running=%s "
+                "remaining=%s",
+                phase,
                 env.envCfg.tag,
                 len(grouped),
                 has_containers,
                 all_running,
+                any_running,
                 remaining,
             )
             if not has_containers or not grouped:
@@ -799,34 +839,36 @@ class EnvironmentMng:
             screen=False,
         ) as live:
             while True:
-                raise_start_error()
-                grouped, all_running, has_containers = self._collect_env_status(
-                    env
+                raise_action_error()
+                grouped, all_running, any_running, has_containers = (
+                    self._collect_env_status(env)
                 )
                 remaining = self._remaining_timeout_seconds(
                     started, timeout_seconds
                 )
                 logging.debug(
-                    "wait_for_env_up poll env='%s': groups=%d "
-                    "has_containers=%s all_running=%s in_startup=%s "
-                    "remaining=%s",
+                    "wait_for_env_%s poll env='%s': groups=%d "
+                    "has_containers=%s all_running=%s any_running=%s "
+                    "in_action=%s remaining=%s",
+                    phase,
                     env.envCfg.tag,
                     len(grouped),
                     has_containers,
                     all_running,
-                    in_startup(),
+                    any_running,
+                    in_action(),
                     remaining,
                 )
 
                 if not has_containers or not grouped:
-                    if in_startup():
+                    if in_action():
                         title = f"[white]{env.envCfg.tag}[/white]"
                         if remaining is not None:
                             title = (
                                 f"{title} "
                                 f"[dim](Time left: {remaining}s)[/dim]"
                             )
-                        live.update(f"{title} [dim](starting...)[/dim]")
+                        live.update(f"{title} [dim]({phase_gerund}...)[/dim]")
                     else:
                         live.stop()
                         Util.console.print(
@@ -843,9 +885,11 @@ class EnvironmentMng:
                         )
                     )
 
-                if all_running and not in_startup():
+                if condition_met(all_running, any_running):
                     logging.debug(
-                        "wait_for_env_up complete env='%s'", env.envCfg.tag
+                        "wait_for_env_%s complete env='%s'",
+                        phase,
+                        env.envCfg.tag,
                     )
                     return
 
@@ -854,7 +898,7 @@ class EnvironmentMng:
                         live.stop()
                         Util.print_error_and_die(
                             "Timed out waiting for environment "
-                            f"'{env.envCfg.tag}' to be up."
+                            f"'{env.envCfg.tag}' to be {timeout_target}."
                         )
                 time.sleep(self._status_poll_seconds)
 
@@ -888,7 +932,7 @@ class EnvironmentMng:
 
     def _collect_env_status(
         self, env: Environment
-    ) -> tuple[dict[str, list[list[str]]], bool, bool]:
+    ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
         env_status = env.status()
         services: list[Service] = env.get_services()
         status_by_service = {
@@ -897,6 +941,7 @@ class EnvironmentMng:
 
         grouped: dict[str, list[list[str]]] = {}
         all_running = True
+        any_running = False
         has_containers = False
 
         for svc in services:
@@ -912,6 +957,7 @@ class EnvironmentMng:
                 )
 
                 if state == "running":
+                    any_running = True
                     state_colored = "[bold green]● running[/bold green]"
                 elif state == "stopped":
                     state_colored = "[bold red]● stopped[/bold red]"
@@ -929,7 +975,7 @@ class EnvironmentMng:
         if not has_containers:
             all_running = False
 
-        return grouped, all_running, has_containers
+        return grouped, all_running, any_running, has_containers
 
     def add_service(
         self,

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -18,10 +18,15 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import threading
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Callable, Optional
+
+from rich.live import Live
 
 from config import ConfigMng, EnvironmentCfg, EnvironmentTemplateCfg
 from service import Service, ServiceFactory
@@ -343,6 +348,13 @@ class EnvironmentMng:
         self.configMng = configMng
         self.envFactory = envFactory
         self.svcFactory = svcFactory
+        self._status_poll_seconds = 1.0
+
+    def _is_verbose(self) -> bool:
+        return bool(self.cli_flags.get("verbose", False))
+
+    def _is_quiet(self) -> bool:
+        return bool(self.cli_flags.get("quiet", False))
 
     def get_environment_from_tag(
         self, env_tag: Optional[str]
@@ -464,12 +476,22 @@ class EnvironmentMng:
             f"{len(envs)} environment(s) found.", highlight=False
         )
 
-    def start_env(self, envCfg: EnvironmentCfg):
+    def start_env(
+        self, envCfg: EnvironmentCfg, timeout_seconds: Optional[int] = 60
+    ):
         """Start an environment."""
+        if timeout_seconds is not None and timeout_seconds < 0:
+            Util.print_error_and_die(
+                "Timeout must be greater than or equal to 0."
+            )
         env = self.get_environment_from_cfg(envCfg)
         env.envCfg.status.rendered_config = env.render_target(True)
         env.sync_config()
-        env.start()
+        self.wait_for_env_up(
+            env,
+            timeout_seconds=timeout_seconds,
+            start_action=env.start,
+        )
         Util.print(f"Started environment: {env.envCfg.tag}")
 
     def stop_env(self, envCfg: EnvironmentCfg):
@@ -670,18 +692,217 @@ class EnvironmentMng:
     def status_env(self, envCfg: EnvironmentCfg):
         """Get environment status."""
         env = self.get_environment_from_cfg(envCfg)
-        env_status = env.status()
+        grouped, _, has_containers = self._collect_env_status(env)
+        if not has_containers or not grouped:
+            Util.console.print(
+                f"[yellow]No services found for "
+                f"environment '{envCfg.tag}'[/yellow]"
+            )
+            return
+        Util.console.print(self._build_env_status_table(envCfg.tag, grouped))
 
+    def wait_for_env_up(
+        self,
+        env: Environment,
+        timeout_seconds: Optional[int] = None,
+        start_action: Optional[Callable[[], Any]] = None,
+    ):
+        if self._is_quiet():
+            if start_action:
+                start_action()
+            return
+
+        start_error: Optional[BaseException] = None
+        start_done = threading.Event()
+
+        if start_action:
+
+            def run_start():
+                nonlocal start_error
+                try:
+                    start_action()
+                except BaseException as e:
+                    start_error = e
+                finally:
+                    start_done.set()
+
+            threading.Thread(target=run_start, daemon=True).start()
+        else:
+            start_done.set()
+
+        def raise_start_error():
+            if start_error is not None:
+                raise start_error
+
+        def in_startup() -> bool:
+            return not start_done.is_set()
+
+        started = time.monotonic()
+        logging.debug(
+            "wait_for_env_up started for env='%s' (timeout=%s, terminal=%s)",
+            env.envCfg.tag,
+            timeout_seconds,
+            Util.console.is_terminal,
+        )
+        if not Util.console.is_terminal:
+            # In non-interactive mode (tests/CI/pipes) avoid long polling loops:
+            # wait for start to complete, then render one snapshot.
+            while in_startup():
+                raise_start_error()
+                remaining = self._remaining_timeout_seconds(
+                    started, timeout_seconds
+                )
+                if timeout_seconds is not None and remaining is not None:
+                    if remaining <= 0:
+                        Util.print_error_and_die(
+                            "Timed out waiting for environment "
+                            f"'{env.envCfg.tag}' to be up."
+                        )
+                time.sleep(self._status_poll_seconds)
+
+            raise_start_error()
+            grouped, all_running, has_containers = self._collect_env_status(env)
+            remaining = self._remaining_timeout_seconds(
+                started, timeout_seconds
+            )
+            logging.debug(
+                "wait_for_env_up non-terminal snapshot env='%s': "
+                "groups=%d has_containers=%s all_running=%s remaining=%s",
+                env.envCfg.tag,
+                len(grouped),
+                has_containers,
+                all_running,
+                remaining,
+            )
+            if not has_containers or not grouped:
+                Util.console.print(
+                    f"[yellow]No services found for "
+                    f"environment '{env.envCfg.tag}'[/yellow]"
+                )
+                return
+            Util.console.print(
+                self._build_env_status_table(
+                    env.envCfg.tag,
+                    grouped,
+                    remaining_seconds=remaining,
+                )
+            )
+            return
+
+        live_refresh_per_second = max(
+            4, int(1 / max(self._status_poll_seconds, 0.001))
+        )
+        with Live(
+            refresh_per_second=live_refresh_per_second,
+            console=Util.console,
+            transient=True,
+            screen=False,
+        ) as live:
+            while True:
+                raise_start_error()
+                grouped, all_running, has_containers = self._collect_env_status(
+                    env
+                )
+                remaining = self._remaining_timeout_seconds(
+                    started, timeout_seconds
+                )
+                logging.debug(
+                    "wait_for_env_up poll env='%s': groups=%d "
+                    "has_containers=%s all_running=%s in_startup=%s "
+                    "remaining=%s",
+                    env.envCfg.tag,
+                    len(grouped),
+                    has_containers,
+                    all_running,
+                    in_startup(),
+                    remaining,
+                )
+
+                if not has_containers or not grouped:
+                    if in_startup():
+                        title = f"[white]{env.envCfg.tag}[/white]"
+                        if remaining is not None:
+                            title = (
+                                f"{title} "
+                                f"[dim](Time left: {remaining}s)[/dim]"
+                            )
+                        live.update(f"{title} [dim](starting...)[/dim]")
+                    else:
+                        live.stop()
+                        Util.console.print(
+                            f"[yellow]No services found for "
+                            f"environment '{env.envCfg.tag}'[/yellow]"
+                        )
+                        return
+                else:
+                    live.update(
+                        self._build_env_status_table(
+                            env.envCfg.tag,
+                            grouped,
+                            remaining_seconds=remaining,
+                        )
+                    )
+
+                if all_running and not in_startup():
+                    logging.debug(
+                        "wait_for_env_up complete env='%s'", env.envCfg.tag
+                    )
+                    return
+
+                if timeout_seconds is not None and remaining is not None:
+                    if remaining <= 0:
+                        live.stop()
+                        Util.print_error_and_die(
+                            "Timed out waiting for environment "
+                            f"'{env.envCfg.tag}' to be up."
+                        )
+                time.sleep(self._status_poll_seconds)
+
+    def _build_env_status_table(
+        self,
+        env_tag: str,
+        grouped: dict[str, list[list[str]]],
+        remaining_seconds: Optional[int] = None,
+    ):
+        title = f"[white]{env_tag}[/white]"
+        if remaining_seconds is not None:
+            title = f"{title} " f"[dim](Time left: {remaining_seconds}s)[/dim]"
+        return Util.build_grouped_table(
+            title=title,
+            group_column_header="Service",
+            item_columns=[
+                {"header": "Container", "style": "white"},
+                {"header": "State"},
+            ],
+            groups=grouped,
+        )
+
+    def _remaining_timeout_seconds(
+        self, started_at: float, timeout_seconds: Optional[int]
+    ) -> Optional[int]:
+        if timeout_seconds is None:
+            return None
+        elapsed = int(time.monotonic() - started_at)
+        remaining = timeout_seconds - elapsed
+        return remaining if remaining > 0 else 0
+
+    def _collect_env_status(
+        self, env: Environment
+    ) -> tuple[dict[str, list[list[str]]], bool, bool]:
+        env_status = env.status()
         services: list[Service] = env.get_services()
         status_by_service = {
             row.get("Service"): row for row in env_status if row.get("Service")
         }
 
         grouped: dict[str, list[list[str]]] = {}
+        all_running = True
+        has_containers = False
 
         for svc in services:
             rows: list[list[str]] = []
             for container in svc.svcCfg.containers or []:
+                has_containers = True
                 cnt_name = container.run_container_name or ""
                 cnt_info = status_by_service.get(cnt_name)
                 state = (
@@ -697,27 +918,18 @@ class EnvironmentMng:
                 else:
                     state_colored = f"[yellow]● {state}[/yellow]"
 
+                if state != "running":
+                    all_running = False
+
                 rows.append([container.tag, state_colored])
 
             if rows:
                 grouped[svc.svcCfg.tag] = rows
 
-        if not grouped:
-            Util.console.print(
-                f"[yellow]No services found for "
-                f"environment '{envCfg.tag}'[/yellow]"
-            )
-            return
+        if not has_containers:
+            all_running = False
 
-        Util.render_grouped_table(
-            title=f"[white]{envCfg.tag}[/white]",
-            group_column_header="Service",
-            item_columns=[
-                {"header": "Container", "style": "white"},
-                {"header": "State"},
-            ],
-            groups=grouped,
-        )
+        return grouped, all_running, has_containers
 
     def add_service(
         self,

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -64,6 +64,12 @@ class Environment(ABC):
             else []
         )
 
+    def _is_verbose(self) -> bool:
+        return bool(self.cli_flags.get("verbose", False))
+
+    def _is_quiet(self) -> bool:
+        return bool(self.cli_flags.get("quiet", False))
+
     @abstractmethod
     def clone_impl(self, dst_env_tag: str) -> Environment:
         """Clone the environment."""

--- a/src/factory/shpd_env_factory.py
+++ b/src/factory/shpd_env_factory.py
@@ -27,9 +27,15 @@ from util import Constants
 
 class ShpdEnvironmentFactory(EnvironmentFactory):
 
-    def __init__(self, configMng: ConfigMng, svcFactory: ServiceFactory):
+    def __init__(
+        self,
+        configMng: ConfigMng,
+        svcFactory: ServiceFactory,
+        cli_flags: dict[str, bool] | None = None,
+    ):
         self.configMng = configMng
         self.svcFactory = svcFactory
+        self.cli_flags = cli_flags or {}
 
     @override
     def new_environment_impl(
@@ -46,6 +52,7 @@ class ShpdEnvironmentFactory(EnvironmentFactory):
                     self.configMng,
                     self.svcFactory,
                     self.configMng.env_cfg_from_tag(env_tmpl_cfg, env_tag),
+                    cli_flags=self.cli_flags,
                 )
             case _:
                 raise ValueError(
@@ -59,7 +66,12 @@ class ShpdEnvironmentFactory(EnvironmentFactory):
         """
         match envCfg.factory:
             case Constants.ENV_FACTORY_DEFAULT:
-                return DockerComposeEnv(self.configMng, self.svcFactory, envCfg)
+                return DockerComposeEnv(
+                    self.configMng,
+                    self.svcFactory,
+                    envCfg,
+                    cli_flags=self.cli_flags,
+                )
             case _:
                 raise ValueError(
                     f"Unknown environment factory: {envCfg.factory}"

--- a/src/factory/shpd_svc_factory.py
+++ b/src/factory/shpd_svc_factory.py
@@ -50,7 +50,5 @@ class ShpdServiceFactory(ServiceFactory):
                     self.configMng, envCfg, svcCfg, cli_flags=cli_flags
                 )
             case _:
-                raise ValueError(
-                    f"""Unknown service type: {svcCfg.template},
-                    plugins not supported yet!"""
-                )
+                raise ValueError(f"""Unknown service type: {svcCfg.template},
+                    plugins not supported yet!""")

--- a/src/factory/shpd_svc_factory.py
+++ b/src/factory/shpd_svc_factory.py
@@ -36,14 +36,19 @@ class ShpdServiceFactory(ServiceFactory):
 
     @override
     def new_service_from_cfg_impl(
-        self, envCfg: EnvironmentCfg, svcCfg: ServiceCfg
+        self,
+        envCfg: EnvironmentCfg,
+        svcCfg: ServiceCfg,
+        cli_flags: dict[str, bool] | None = None,
     ) -> Service:
         """
         Get a service.
         """
         match svcCfg.factory:
             case Constants.SVC_FACTORY_DEFAULT:
-                return DockerComposeSvc(self.configMng, envCfg, svcCfg)
+                return DockerComposeSvc(
+                    self.configMng, envCfg, svcCfg, cli_flags=cli_flags
+                )
             case _:
                 raise ValueError(
                     f"""Unknown service type: {svcCfg.template},

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -39,6 +39,12 @@ class Service(ABC):
         self.name = self.canonical_name()
         self._generate_containers_names()
 
+    def _is_verbose(self) -> bool:
+        return bool(self.cli_flags.get("verbose", False))
+
+    def _is_quiet(self) -> bool:
+        return bool(self.cli_flags.get("quiet", False))
+
     def canonical_name(self) -> str:
         """
         Get the canonical name of the service.

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -26,11 +26,16 @@ from config import ConfigMng, EnvironmentCfg, ServiceCfg
 class Service(ABC):
 
     def __init__(
-        self, configMng: ConfigMng, envCfg: EnvironmentCfg, svcCfg: ServiceCfg
+        self,
+        configMng: ConfigMng,
+        envCfg: EnvironmentCfg,
+        svcCfg: ServiceCfg,
+        cli_flags: Optional[dict[str, bool]] = None,
     ):
         self.configMng = configMng
         self.envCfg = envCfg
         self.svcCfg = svcCfg
+        self.cli_flags = cli_flags or {}
         self.name = self.canonical_name()
         self._generate_containers_names()
 
@@ -166,12 +171,15 @@ class ServiceFactory(ABC):
         return cls.get_name_impl()
 
     def new_service_from_cfg(
-        self, envCfg: EnvironmentCfg, svcCfg: ServiceCfg
+        self,
+        envCfg: EnvironmentCfg,
+        svcCfg: ServiceCfg,
+        cli_flags: Optional[dict[str, bool]] = None,
     ) -> Service:
         """
         Create a new service.
         """
-        return self.new_service_from_cfg_impl(envCfg, svcCfg)
+        return self.new_service_from_cfg_impl(envCfg, svcCfg, cli_flags)
 
     @classmethod
     @abstractmethod
@@ -180,7 +188,10 @@ class ServiceFactory(ABC):
 
     @abstractmethod
     def new_service_from_cfg_impl(
-        self, envCfg: EnvironmentCfg, svcCfg: ServiceCfg
+        self,
+        envCfg: EnvironmentCfg,
+        svcCfg: ServiceCfg,
+        cli_flags: Optional[dict[str, bool]] = None,
     ) -> Service:
         """
         Create a new service.
@@ -205,7 +216,9 @@ class ServiceMng:
     ) -> Optional[Service]:
         """Get a service by environment tag and service tag."""
         if svcCfg := envCfg.get_service(svc_tag):
-            return self.svcFactory.new_service_from_cfg(envCfg, svcCfg)
+            return self.svcFactory.new_service_from_cfg(
+                envCfg, svcCfg, cli_flags=self.cli_flags
+            )
         else:
             return None
 

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -16,8 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import functools
 import builtins
+import functools
 import logging
 import os
 from typing import Any, Callable, List, Optional
@@ -81,17 +81,33 @@ def require_active_env(func: Callable[..., Any]) -> Callable[..., Any]:
 @click.option("-v", "--verbose", is_flag=True, help="Enable verbose mode.")
 @click.option("--quiet", is_flag=True, help="Suppress command output.")
 @click.option(
+    "--details",
+    is_flag=True,
+    help="Show additional details in status tables.",
+)
+@click.option(
     "-y",
     "--yes",
     is_flag=True,
     help="Automatic yes to prompts; run non-interactively.",
 )
 @click.pass_context
-def cli(ctx: click.Context, verbose: bool, quiet: bool, yes: bool):
+def cli(
+    ctx: click.Context,
+    verbose: bool,
+    quiet: bool,
+    details: bool,
+    yes: bool,
+):
     """Shepherd CLI:
     A tool to manage your environments, services, and databases.
     """
-    cli_flags = {"verbose": verbose, "quiet": quiet, "yes": yes}
+    cli_flags = {
+        "verbose": verbose,
+        "quiet": quiet,
+        "details": details,
+        "yes": yes,
+    }
 
     if ctx.obj is None:
         ctx.obj = ShepherdMng(cli_flags)
@@ -118,9 +134,7 @@ def complete(shepherd: ShepherdMng, args: Any):
     This command disables Click’s usual option parsing
     to treat all arguments as raw strings.
     """
-    completions = shepherd.completionMng.get_completions(
-        builtins.list(args)
-    )
+    completions = shepherd.completionMng.get_completions(builtins.list(args))
     for c in completions:
         click.echo(c)
 

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -78,6 +78,7 @@ def require_active_env(func: Callable[..., Any]) -> Callable[..., Any]:
 
 @click.group()
 @click.option("-v", "--verbose", is_flag=True, help="Enable verbose mode.")
+@click.option("--quiet", is_flag=True, help="Suppress command output.")
 @click.option(
     "-y",
     "--yes",
@@ -85,11 +86,11 @@ def require_active_env(func: Callable[..., Any]) -> Callable[..., Any]:
     help="Automatic yes to prompts; run non-interactively.",
 )
 @click.pass_context
-def cli(ctx: click.Context, verbose: bool, yes: bool):
+def cli(ctx: click.Context, verbose: bool, quiet: bool, yes: bool):
     """Shepherd CLI:
     A tool to manage your environments, services, and databases.
     """
-    cli_flags = {"verbose": verbose, "yes": yes}
+    cli_flags = {"verbose": verbose, "quiet": quiet, "yes": yes}
 
     if ctx.obj is None:
         ctx.obj = ShepherdMng(cli_flags)

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -332,22 +332,44 @@ def list(shepherd: ShepherdMng):
 # UP
 # =====================================================
 @cli.group(invoke_without_command=True)
+@click.option(
+    "--timeout",
+    type=int,
+    default=60,
+    show_default=True,
+    help="Maximum seconds to wait for all containers to be running.",
+)
 @click.pass_obj
 @require_active_env
-def up(shepherd: ShepherdMng, envCfg: EnvironmentCfg):
+def up(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    timeout: Optional[int],
+):
     """Start resources."""
     # If no subcommand is given, default to "env"
     ctx = click.get_current_context()
     if ctx.invoked_subcommand is None:
-        shepherd.environmentMng.start_env(envCfg)
+        shepherd.environmentMng.start_env(envCfg, timeout_seconds=timeout)
 
 
 @up.command(name="env")
+@click.option(
+    "--timeout",
+    type=int,
+    default=60,
+    show_default=True,
+    help="Maximum seconds to wait for all containers to be running.",
+)
 @click.pass_obj
 @require_active_env
-def up_env(shepherd: ShepherdMng, envCfg: EnvironmentCfg):
+def up_env(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    timeout: Optional[int],
+):
     """Start environment."""
-    shepherd.environmentMng.start_env(envCfg)
+    shepherd.environmentMng.start_env(envCfg, timeout_seconds=timeout)
 
 
 @up.command(name="svc")

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -17,6 +17,7 @@
 
 
 import functools
+import builtins
 import logging
 import os
 from typing import Any, Callable, List, Optional
@@ -109,7 +110,7 @@ def empty():
 )
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 @click.pass_obj
-def complete(shepherd: ShepherdMng, args: list[str]):
+def complete(shepherd: ShepherdMng, args: Any):
     """
     Internal shell completion entrypoint.
     Usage: shepctl __complete <args...>
@@ -117,7 +118,9 @@ def complete(shepherd: ShepherdMng, args: list[str]):
     This command disables Click’s usual option parsing
     to treat all arguments as raw strings.
     """
-    completions = shepherd.completionMng.get_completions(args)
+    completions = shepherd.completionMng.get_completions(
+        builtins.list(args)
+    )
     for c in completions:
         click.echo(c)
 

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -53,7 +53,7 @@ class ShepherdMng:
         self.completionMng = CompletionMng(self.cli_flags, self.configMng)
         self.svcFactory = ShpdServiceFactory(self.configMng)
         self.envFactory = ShpdEnvironmentFactory(
-            self.configMng, self.svcFactory
+            self.configMng, self.svcFactory, cli_flags=self.cli_flags
         )
         self.environmentMng = EnvironmentMng(
             self.cli_flags, self.configMng, self.envFactory, self.svcFactory

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -672,7 +672,11 @@ def test_stop_env(
 
     result = runner.invoke(cli, ["halt", "env"])
     assert result.exit_code == 0
-    mock_subproc.assert_called_once()
+    assert mock_subproc.call_count == 2
+    assert any(
+        "ps" in (call.args[0] if call.args else [])
+        for call in mock_subproc.call_args_list
+    )
 
     sm = ShepherdMng()
     env = sm.configMng.get_environment("test-1")

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -622,7 +622,11 @@ def test_start_env(
 
     result = runner.invoke(cli, ["up", "env"])
     assert result.exit_code == 0
-    mock_subproc.assert_called_once()
+    assert mock_subproc.call_count == 2
+    assert any(
+        "ps" in (call.args[0] if call.args else [])
+        for call in mock_subproc.call_args_list
+    )
 
     sm = ShepherdMng()
     env = sm.configMng.get_environment("test-1")

--- a/src/tests/test_environment_mng_wait.py
+++ b/src/tests/test_environment_mng_wait.py
@@ -21,15 +21,18 @@ import time
 from types import SimpleNamespace
 from typing import Any, cast
 
+import pytest
 from pytest_mock import MockerFixture
 
-from environment.environment import EnvironmentMng
+from environment.environment import EnvironmentMng, ProbeRunResult
 from util.util import Util
 
 
-def _new_environment_mng(mocker: MockerFixture) -> EnvironmentMng:
+def _new_environment_mng(
+    mocker: MockerFixture, cli_flags: dict[str, bool] | None = None
+) -> EnvironmentMng:
     return EnvironmentMng(
-        cli_flags={},
+        cli_flags=cli_flags or {},
         configMng=mocker.Mock(),
         envFactory=mocker.Mock(),
         svcFactory=mocker.Mock(),
@@ -88,6 +91,7 @@ def test_wait_for_env_up_does_not_exit_while_starting(mocker: MockerFixture):
 
     def collect_status(
         _env: Any,
+        gate_status: Any = None,
     ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
         idx = min(status_idx["value"], len(status_samples) - 1)
         status_idx["value"] += 1
@@ -101,6 +105,7 @@ def test_wait_for_env_up_does_not_exit_while_starting(mocker: MockerFixture):
 
     fake_console = mocker.Mock()
     fake_console.is_terminal = False
+    env.get_services.return_value = []
     mocker.patch.object(Util, "console", fake_console)
     mocker.patch.object(mng, "_collect_env_status", side_effect=collect_status)
     mocker.patch.object(mng, "_build_env_status_table", return_value="table")
@@ -112,3 +117,271 @@ def test_wait_for_env_up_does_not_exit_while_starting(mocker: MockerFixture):
     fake_console.print.assert_called_once_with(
         "[yellow]No services found for environment 'test-env'[/yellow]"
     )
+
+
+def test_wait_for_env_up_propagates_action_error(mocker: MockerFixture):
+    mng = _new_environment_mng(mocker)
+    setattr(mng, "_status_poll_seconds", 0.001)
+
+    env = mocker.Mock()
+    env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_services.return_value = []
+    mocker.patch.object(
+        mng, "_collect_env_status", return_value=({}, False, False, False)
+    )
+
+    fake_console = mocker.Mock()
+    fake_console.is_terminal = False
+    mocker.patch.object(Util, "console", fake_console)
+
+    def start_action():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        mng.wait_for_env_up(env, timeout_seconds=2, start_action=start_action)
+
+
+def test_wait_for_env_up_timeout_calls_print_error(mocker: MockerFixture):
+    mng = _new_environment_mng(mocker)
+    setattr(mng, "_status_poll_seconds", 0.001)
+
+    env = mocker.Mock()
+    env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_services.return_value = []
+
+    fake_console = mocker.Mock()
+    fake_console.is_terminal = False
+    mocker.patch.object(Util, "console", fake_console)
+    print_error = mocker.patch.object(
+        Util, "print_error_and_die", side_effect=RuntimeError("timeout")
+    )
+
+    def start_action():
+        time.sleep(0.05)
+
+    with pytest.raises(RuntimeError, match="timeout"):
+        mng.wait_for_env_up(env, timeout_seconds=0, start_action=start_action)
+
+    print_error.assert_called_once()
+
+
+def test_wait_for_env_down_timeout_calls_print_error(mocker: MockerFixture):
+    mng = _new_environment_mng(mocker)
+    setattr(mng, "_status_poll_seconds", 0.001)
+
+    env = mocker.Mock()
+    env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_services.return_value = []
+
+    fake_console = mocker.Mock()
+    fake_console.is_terminal = False
+    mocker.patch.object(Util, "console", fake_console)
+    print_error = mocker.patch.object(
+        Util, "print_error_and_die", side_effect=RuntimeError("timeout")
+    )
+
+    def stop_action():
+        time.sleep(0.05)
+
+    with pytest.raises(RuntimeError, match="timeout"):
+        mng.wait_for_env_down(env, timeout_seconds=0, stop_action=stop_action)
+
+    print_error.assert_called_once()
+
+
+def test_format_service_gate_glyphs_states(mocker: MockerFixture):
+    mng = _new_environment_mng(mocker)
+    mng_any = cast(Any, mng)
+
+    gated = SimpleNamespace(
+        svcCfg=SimpleNamespace(start=SimpleNamespace(when_probes=["p2", "p1"]))
+    )
+    ungated = SimpleNamespace(svcCfg=SimpleNamespace(start=None))
+
+    assert (
+        mng_any._format_service_gate_glyphs(cast(Any, ungated))
+        == "[dim]-[/dim]"
+    )
+    assert (
+        mng_any._format_service_gate_glyphs(cast(Any, gated))
+        == "[dim]○[/dim][dim]○[/dim]"
+    )
+
+    glyphs = mng_any._format_service_gate_glyphs(
+        cast(Any, gated),
+        gate_status={"p1": True, "p2": False},
+    )
+    assert "[bold red]●[/bold red]" in glyphs
+    assert "[bold green]●[/bold green]" in glyphs
+
+
+def test_format_service_gate_details_sorted_and_colored(mocker: MockerFixture):
+    mng = _new_environment_mng(mocker)
+    mng_any = cast(Any, mng)
+
+    gated = SimpleNamespace(
+        svcCfg=SimpleNamespace(
+            start=SimpleNamespace(when_probes=["zeta", "alpha", "beta"])
+        )
+    )
+    ungated = SimpleNamespace(svcCfg=SimpleNamespace(start=None))
+
+    assert (
+        mng_any._format_service_gate_details(cast(Any, ungated))
+        == "[dim]-[/dim]"
+    )
+
+    details = mng_any._format_service_gate_details(
+        cast(Any, gated),
+        gate_status={"alpha": True, "beta": False, "zeta": None},
+    )
+    assert details.find("alpha") < details.find("beta") < details.find("zeta")
+    assert "[bold green]alpha[/bold green]" in details
+    assert "[bold red]beta[/bold red]" in details
+    assert "[dim]zeta[/dim]" in details
+
+
+def test_evaluate_gate_status_success_and_exception(mocker: MockerFixture):
+    mng = _new_environment_mng(mocker)
+    mng_any = cast(Any, mng)
+    env = mocker.Mock()
+    env.envCfg = SimpleNamespace(tag="test-env")
+
+    env.check_probes.return_value = [
+        ProbeRunResult(tag="a", exit_code=0, timed_out=False),
+        ProbeRunResult(tag="b", exit_code=1, timed_out=False),
+        ProbeRunResult(tag="c", exit_code=0, timed_out=True),
+    ]
+
+    status = mng_any._evaluate_gate_status(env, {"a", "b", "c", "d"})
+    assert status["a"] is True
+    assert status["b"] is False
+    assert status["c"] is False
+    assert status["d"] is None
+
+    env.check_probes.side_effect = RuntimeError("probe error")
+    status_err = mng_any._evaluate_gate_status(env, {"a", "b"})
+    assert status_err == {"a": None, "b": None}
+
+
+def test_build_env_status_table_includes_details_column_when_enabled(
+    mocker: MockerFixture,
+):
+    mng = _new_environment_mng(mocker, cli_flags={"details": True})
+    mng_any = cast(Any, mng)
+    grouped = {
+        "svc-1": [
+            [
+                "[dim]-[/dim]",
+                "cnt-1",
+                "[bold green]● running[/bold green]",
+                "[dim]a[/dim], [dim]b[/dim]",
+            ]
+        ]
+    }
+    table = mng_any._build_env_status_table("env-1", grouped)
+    headers = [c.header for c in table.columns]
+    assert headers == ["Gates", "Service", "Container", "State", "Probes"]
+
+
+def test_collect_env_status_details_row_shape(mocker: MockerFixture):
+    mng = _new_environment_mng(mocker, cli_flags={"details": True})
+    mng_any = cast(Any, mng)
+
+    container = SimpleNamespace(tag="cnt-a", run_container_name="svc-a-cnt")
+    svc = SimpleNamespace(
+        svcCfg=SimpleNamespace(
+            tag="svc-a",
+            containers=[container],
+            start=SimpleNamespace(when_probes=["p1", "p2"]),
+        )
+    )
+    env = mocker.Mock()
+    env.status.return_value = [{"Service": "svc-a-cnt", "State": "running"}]
+    env.get_services.return_value = [svc]
+
+    grouped, all_running, any_running, has_containers = (
+        mng_any._collect_env_status(
+            env,
+            gate_status={"p1": True, "p2": None},
+        )
+    )
+    assert all_running is True
+    assert any_running is True
+    assert has_containers is True
+    row = grouped["svc-a"][0]
+    assert len(row) == 4
+    assert row[1] == "cnt-a"
+
+
+def test_wait_for_env_down_terminal_main_loop(mocker: MockerFixture):
+    mng = _new_environment_mng(mocker)
+    setattr(mng, "_status_poll_seconds", 0.001)
+
+    env = mocker.Mock()
+    env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_services.return_value = []
+
+    status_samples: list[
+        tuple[dict[str, list[list[str]]], bool, bool, bool]
+    ] = [
+        (
+            {"svc": [["-", "cnt", "[bold green]● running[/bold green]"]]},
+            False,
+            True,
+            True,
+        ),
+        (
+            {"svc": [["-", "cnt", "[bold red]● stopped[/bold red]"]]},
+            False,
+            False,
+            True,
+        ),
+    ]
+    idx = {"value": 0}
+
+    def collect_status(
+        _env: Any, gate_status: Any = None
+    ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
+        i = min(idx["value"], len(status_samples) - 1)
+        idx["value"] += 1
+        return status_samples[i]
+
+    fake_console = mocker.Mock()
+    fake_console.is_terminal = True
+    mocker.patch.object(Util, "console", fake_console)
+    mocker.patch.object(mng, "_collect_env_status", side_effect=collect_status)
+    mocker.patch.object(mng, "_build_env_status_table", return_value="table")
+
+    live_updates: list[Any] = []
+    live_stops = {"count": 0}
+
+    class FakeLive:
+        def __init__(self, *args: Any, **kwargs: Any):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+            return False
+
+        def update(self, renderable: Any):
+            live_updates.append(renderable)
+
+        def stop(self):
+            live_stops["count"] += 1
+
+    mocker.patch("environment.environment.Live", FakeLive)
+
+    stop_calls = {"count": 0}
+
+    def stop_action():
+        stop_calls["count"] += 1
+
+    mng.wait_for_env_down(env, timeout_seconds=2, stop_action=stop_action)
+
+    assert stop_calls["count"] == 1
+    assert idx["value"] >= 2
+    assert live_updates
+    assert live_stops["count"] == 0

--- a/src/tests/test_environment_mng_wait.py
+++ b/src/tests/test_environment_mng_wait.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2025 Moony Fringers
+#
+# This file is part of Shepherd Core Stack
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from typing import Any, cast
+
+from pytest_mock import MockerFixture
+
+from environment.environment import EnvironmentMng
+from util.util import Util
+
+
+def _new_environment_mng(mocker: MockerFixture) -> EnvironmentMng:
+    return EnvironmentMng(
+        cli_flags={},
+        configMng=mocker.Mock(),
+        envFactory=mocker.Mock(),
+        svcFactory=mocker.Mock(),
+    )
+
+
+def test_start_env_wraps_start_with_wait_loop(mocker: MockerFixture):
+    mng = _new_environment_mng(mocker)
+
+    env_cfg = cast(
+        Any,
+        SimpleNamespace(
+            tag="test-env",
+            status=SimpleNamespace(rendered_config=None),
+        ),
+    )
+    env = mocker.Mock()
+    env.envCfg = env_cfg
+    env.render_target.return_value = {"ungated": "yaml"}
+
+    mocker.patch.object(mng, "get_environment_from_cfg", return_value=env)
+    wait_for_env_up = mocker.patch.object(mng, "wait_for_env_up")
+
+    mng.start_env(env_cfg, timeout_seconds=15)
+
+    assert env.start.call_count == 0
+    wait_for_env_up.assert_called_once_with(
+        env,
+        timeout_seconds=15,
+        start_action=env.start,
+    )
+    env.sync_config.assert_called_once()
+    assert env.envCfg.status.rendered_config == {"ungated": "yaml"}
+
+
+def test_wait_for_env_up_does_not_exit_while_starting(mocker: MockerFixture):
+    mng = _new_environment_mng(mocker)
+    setattr(mng, "_status_poll_seconds", 0.001)
+
+    env = mocker.Mock()
+    env.envCfg = SimpleNamespace(tag="test-env")
+
+    status_samples: list[tuple[dict[str, list[list[str]]], bool, bool]] = [
+        ({}, False, False),
+        ({}, False, False),
+        ({"svc": [["cnt", "[bold green]● running[/bold green]"]]}, True, True),
+    ]
+    status_idx = {"value": 0}
+
+    def collect_status(
+        _env: Any,
+    ) -> tuple[dict[str, list[list[str]]], bool, bool]:
+        idx = min(status_idx["value"], len(status_samples) - 1)
+        status_idx["value"] += 1
+        return status_samples[idx]
+
+    start_calls = {"count": 0}
+
+    def start_action():
+        start_calls["count"] += 1
+        time.sleep(0.02)
+
+    fake_console = mocker.Mock()
+    fake_console.is_terminal = False
+    mocker.patch.object(Util, "console", fake_console)
+    mocker.patch.object(mng, "_collect_env_status", side_effect=collect_status)
+    mocker.patch.object(mng, "_build_env_status_table", return_value="table")
+
+    mng.wait_for_env_up(env, timeout_seconds=2, start_action=start_action)
+
+    assert start_calls["count"] == 1
+    assert status_idx["value"] == 1
+    fake_console.print.assert_called_once_with(
+        "[yellow]No services found for environment 'test-env'[/yellow]"
+    )

--- a/src/tests/test_environment_mng_wait.py
+++ b/src/tests/test_environment_mng_wait.py
@@ -72,16 +72,23 @@ def test_wait_for_env_up_does_not_exit_while_starting(mocker: MockerFixture):
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
 
-    status_samples: list[tuple[dict[str, list[list[str]]], bool, bool]] = [
-        ({}, False, False),
-        ({}, False, False),
-        ({"svc": [["cnt", "[bold green]● running[/bold green]"]]}, True, True),
+    status_samples: list[
+        tuple[dict[str, list[list[str]]], bool, bool, bool]
+    ] = [
+        ({}, False, False, False),
+        ({}, False, False, False),
+        (
+            {"svc": [["cnt", "[bold green]● running[/bold green]"]]},
+            True,
+            True,
+            True,
+        ),
     ]
     status_idx = {"value": 0}
 
     def collect_status(
         _env: Any,
-    ) -> tuple[dict[str, list[list[str]]], bool, bool]:
+    ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
         idx = min(status_idx["value"], len(status_samples) - 1)
         status_idx["value"] += 1
         return status_samples[idx]

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -109,7 +109,7 @@ def test_cli_flags_no_flags(
 
     assert result.exit_code == 0
     mock_init.assert_called_once_with(
-        {"verbose": False, "quiet": False, "yes": False}
+        {"verbose": False, "quiet": False, "details": False, "yes": False}
     )
 
 
@@ -121,7 +121,7 @@ def test_cli_flags_verbose(
 
     result = runner.invoke(cli, ["--verbose", "test"])
 
-    flags = {"verbose": True, "quiet": False, "yes": False}
+    flags = {"verbose": True, "quiet": False, "details": False, "yes": False}
 
     assert result.exit_code == 0
     mock_init.assert_called_once_with(flags)
@@ -140,7 +140,7 @@ def test_cli_flags_yes(
 
     result = runner.invoke(cli, ["--yes", "test"])
 
-    flags = {"verbose": False, "quiet": False, "yes": True}
+    flags = {"verbose": False, "quiet": False, "details": False, "yes": True}
 
     assert result.exit_code == 0
     mock_init.assert_called_once_with(flags)
@@ -149,6 +149,20 @@ def test_cli_flags_yes(
 
     assert result.exit_code == 0
     mock_init.assert_called_with(flags)
+
+
+@pytest.mark.shpd
+def test_cli_flags_details(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    mock_init = mocker.patch.object(ShepherdMng, "__init__", return_value=None)
+
+    result = runner.invoke(cli, ["--details", "test"])
+
+    flags = {"verbose": False, "quiet": False, "details": True, "yes": False}
+
+    assert result.exit_code == 0
+    mock_init.assert_called_once_with(flags)
 
 
 # completion tests

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -325,6 +325,23 @@ def test_cli_start_env(
 
 
 @pytest.mark.shpd
+def test_cli_start_env_with_timeout(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    mock_start = mocker.patch.object(EnvironmentMng, "start_env")
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["up", "env", "--timeout", "30"])
+    assert result.exit_code == 0
+    mock_start.assert_called_once()
+    assert mock_start.call_args.kwargs == {"timeout_seconds": 30}
+
+
+@pytest.mark.shpd
 def test_cli_stop_env(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -108,7 +108,9 @@ def test_cli_flags_no_flags(
     result = runner.invoke(cli, ["test"])
 
     assert result.exit_code == 0
-    mock_init.assert_called_once_with({"verbose": False, "yes": False})
+    mock_init.assert_called_once_with(
+        {"verbose": False, "quiet": False, "yes": False}
+    )
 
 
 @pytest.mark.shpd
@@ -119,7 +121,7 @@ def test_cli_flags_verbose(
 
     result = runner.invoke(cli, ["--verbose", "test"])
 
-    flags = {"verbose": True, "yes": False}
+    flags = {"verbose": True, "quiet": False, "yes": False}
 
     assert result.exit_code == 0
     mock_init.assert_called_once_with(flags)
@@ -138,7 +140,7 @@ def test_cli_flags_yes(
 
     result = runner.invoke(cli, ["--yes", "test"])
 
-    flags = {"verbose": False, "yes": True}
+    flags = {"verbose": False, "quiet": False, "yes": True}
 
     assert result.exit_code == 0
     mock_init.assert_called_once_with(flags)

--- a/src/util/util.py
+++ b/src/util/util.py
@@ -82,20 +82,16 @@ class Util:
                 else:
                     os.link(src_item, dest_item)
         except OSError as e:
-            Util.print_error_and_die(
-                f"""Failed to copy directory:
-                {src_path} to {dest_path}\nError: {e}"""
-            )
+            Util.print_error_and_die(f"""Failed to copy directory:
+                {src_path} to {dest_path}\nError: {e}""")
 
     @staticmethod
     def move_dir(src_path: str, dest_path: str):
         try:
             os.rename(src_path, dest_path)
         except OSError as e:
-            Util.print_error_and_die(
-                f"""Failed to move directory:
-                {src_path} to {dest_path}\nError: {e}"""
-            )
+            Util.print_error_and_die(f"""Failed to move directory:
+                {src_path} to {dest_path}\nError: {e}""")
 
     @staticmethod
     def remove_dir(dir_path: str):

--- a/src/util/util.py
+++ b/src/util/util.py
@@ -170,7 +170,7 @@ class Util:
         Util.console.print(table)
 
     @staticmethod
-    def render_grouped_table(
+    def build_grouped_table(
         title: Optional[str],
         group_column_header: str,
         item_columns: list[dict[str, str]],
@@ -181,9 +181,9 @@ class Util:
         group_style: str = "bold",
         group_col_style: str = "cyan",
         box_style: box.Box = box.SIMPLE,
-    ) -> None:
+    ) -> Table:
         """
-        Render a grouped table using rich.
+        Build a grouped table using rich.
 
         Args:
             title: Table title (None for no title).
@@ -222,8 +222,7 @@ class Util:
             )
 
         if not groups:
-            Util.console.print("[yellow]No data.[/yellow]")
-            return
+            return table
 
         for group_label in sorted(groups.keys()):
             items = groups[group_label] or []
@@ -252,6 +251,60 @@ class Util:
                         *[""] * (len(item_columns) - 1),
                         end_section=is_last,
                     )
+
+        return table
+
+    @staticmethod
+    def render_grouped_table(
+        title: Optional[str],
+        group_column_header: str,
+        item_columns: list[dict[str, str]],
+        groups: dict[str, list[list[str]]],
+        *,
+        branch_glyph_mid: str = "├─",
+        branch_glyph_last: str = "└─",
+        group_style: str = "bold",
+        group_col_style: str = "cyan",
+        box_style: box.Box = box.SIMPLE,
+    ) -> None:
+        """
+        Render a grouped table using rich.
+
+        Args:
+            title: Table title (None for no title).
+            group_column_header: header for the left-most "group"
+            column (e.g., "Service").
+
+            item_columns: like in render_table, list of dicts with keys:
+                         - "header" (required)
+                         - "style" (optional)
+
+            groups: mapping from group label -> list of item rows
+            (each list[str] must match item_columns length)
+
+            branch_glyph_mid: glyph used before non-last items
+            (visual nesting).
+
+            branch_glyph_last: glyph used before the last item in a group.
+            group_style: style applied to the group label row.
+            group_col_style: style for the group column.
+            box_style: rich box style.
+        """
+        table = Util.build_grouped_table(
+            title,
+            group_column_header,
+            item_columns,
+            groups,
+            branch_glyph_mid=branch_glyph_mid,
+            branch_glyph_last=branch_glyph_last,
+            group_style=group_style,
+            group_col_style=group_col_style,
+            box_style=box_style,
+        )
+
+        if not groups:
+            Util.console.print("[yellow]No data.[/yellow]")
+            return
 
         Util.console.print(table)
 


### PR DESCRIPTION
- Added gate visualization:
      - compact glyph-only Gates first column (Gates | Service | Container | State | Probes)
      - optional Probes details column via --details
  - Unified env lifecycle rendering so both up env and halt env use the same live status loop.
  - Gate states update live during startup:
      - pending (dim), pass (green), fail (red)
      - probe names in details are alphabetically sorted
  - Improved startup UX by rendering the table immediately, then updating gate states as probes evaluate.
  - Validation: checks pass, full test suite passes.

<img width="746" height="330" alt="image" src="https://github.com/user-attachments/assets/90025269-a1d1-4c7b-bf4e-92bfad202dc9" />

Fixes: #152 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
to change)
- [ ] Change or update to the documentation (with no functional changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
