### PR TITLE
refactor(cli): move core commands to scope-verb layout

### DIFF
--- a/docs/shepctl.md
+++ b/docs/shepctl.md
@@ -13,31 +13,19 @@ These options apply to every command:
 
 ## Command Overview
 
-Top-level commands currently available:
+Top-level scopes currently available:
 
-- `add`
-- `build`
-- `check`
-- `checkout`
-- `clone`
-- `delete`
-- `get`
-- `halt`
-- `list`
-- `logs`
-- `reload`
-- `rename`
-- `shell`
-- `status`
-- `up`
+- `env`
+- `probe`
+- `svc`
 
 ## Commands
 
-### `get`
+### `env`
 
-Read configuration data without changing runtime state.
+Manage environments.
 
-#### `get env [TAG]`
+#### `env get [TAG]`
 
 Get environment configuration.
 
@@ -48,7 +36,82 @@ Options:
 - `--by-gate`: group target configuration by gate, requires `--target`
 - `-r`, `--resolved`: return resolved configuration
 
-#### `get probe [PROBE_TAG]`
+#### `env add TEMPLATE TAG`
+
+Create a new environment from an environment template.
+
+#### `env clone SRC_TAG DST_TAG`
+
+Clone an environment.
+
+#### `env rename SRC_TAG DST_TAG`
+
+Rename an environment.
+
+#### `env checkout TAG`
+
+Set the active environment.
+
+#### `env delete TAG`
+
+Delete an environment.
+
+#### `env list`
+
+List environments.
+
+#### `env up`
+
+Start the active environment.
+
+Shared environment options:
+
+- `--show-commands`: show recent command history in status panels
+- `--show-commands-limit INTEGER`: number of commands to display
+- `--timeout INTEGER`: max seconds to wait for containers to be running
+- `-w`, `--watch`: keep updating output until interrupted
+
+Requires an active environment.
+
+#### `env halt`
+
+Stop the active environment.
+
+Options:
+
+- `--no-wait`: return immediately after sending the stop command
+
+Requires an active environment.
+
+#### `env reload`
+
+Reload the active environment.
+
+Options:
+
+- `--show-commands`: show recent command history in status panels
+- `--show-commands-limit INTEGER`: number of commands to display
+- `-w`, `--watch`: keep updating output until interrupted
+
+Requires an active environment.
+
+#### `env status`
+
+Show status for the active environment.
+
+Options:
+
+- `--show-commands`: show recent command history in status panels
+- `--show-commands-limit INTEGER`: number of commands to display
+- `-w`, `--watch`: keep updating output until interrupted
+
+Requires an active environment.
+
+### `probe`
+
+Manage probes.
+
+#### `probe get [PROBE_TAG]`
 
 Get probe configuration for the active environment.
 
@@ -61,7 +124,22 @@ Options:
 
 Requires an active environment.
 
-#### `get svc TAG`
+#### `probe check [PROBE_TAG]`
+
+Run probes for the active environment and exit with a probe-based status
+code.
+
+Options:
+
+- `-a`, `--all`: run all probes
+
+Requires an active environment.
+
+### `svc`
+
+Manage services.
+
+#### `svc get TAG`
 
 Get service configuration for the active environment.
 
@@ -73,176 +151,52 @@ Options:
 
 Requires an active environment.
 
-### `add`
-
-Create resources.
-
-#### `add env TEMPLATE TAG`
-
-Create a new environment from an environment template.
-
-#### `add svc SVC_TEMPLATE SVC_TAG [SVC_CLASS]`
+#### `svc add SVC_TEMPLATE SVC_TAG [SVC_CLASS]`
 
 Add a service to the active environment.
 
 Requires an active environment.
 
-### `clone`
-
-#### `clone env SRC_TAG DST_TAG`
-
-Clone an environment.
-
-### `rename`
-
-#### `rename env SRC_TAG DST_TAG`
-
-Rename an environment.
-
-### `checkout TAG`
-
-Set the active environment.
-
-### `delete`
-
-#### `delete env TAG`
-
-Delete an environment.
-
-### `list`
-
-List environments.
-
-### `up`
-
-Start resources.
-
-When used without a subcommand, `up` behaves like `up env` for the active
-environment.
-
-Shared environment options:
-
-- `--details`: show extra details in status tables
-- `--show-commands`: show recent command history in status panels
-- `--show-commands-limit INTEGER`: number of commands to display
-- `--timeout INTEGER`: max seconds to wait for containers to be running
-- `-w`, `--watch`: keep updating output until interrupted
-
-#### `up env`
-
-Start the active environment explicitly.
-
-Requires an active environment.
-
-#### `up svc SVC_TAG [CNT_TAG]`
+#### `svc up SVC_TAG [CNT_TAG]`
 
 Start a service, optionally targeting one container.
 
 Requires an active environment.
 
-### `halt`
-
-Stop resources.
-
-When used without a subcommand, `halt` behaves like `halt env` for the
-active environment.
-
-Shared environment options:
-
-- `--no-wait`: return immediately after sending the stop command
-
-#### `halt env`
-
-Stop the active environment explicitly.
-
-Requires an active environment.
-
-#### `halt svc SVC_TAG [CNT_TAG]`
+#### `svc halt SVC_TAG [CNT_TAG]`
 
 Stop a service, optionally targeting one container.
 
 Requires an active environment.
 
-### `reload`
-
-Reload resources.
-
-#### `reload env`
-
-Reload the active environment.
-
-Options:
-
-- `--details`: show extra details in status tables
-- `--show-commands`: show recent command history in status panels
-- `--show-commands-limit INTEGER`: number of commands to display
-- `-w`, `--watch`: keep updating output until interrupted
-
-Requires an active environment.
-
-#### `reload svc SVC_TAG [CNT_TAG]`
+#### `svc reload SVC_TAG [CNT_TAG]`
 
 Reload a service, optionally targeting one container.
 
 Requires an active environment.
 
-### `build SVC_TAG [CNT_TAG]`
+#### `svc build SVC_TAG [CNT_TAG]`
 
 Build a service, optionally targeting one container.
 
 Requires an active environment.
 
-### `logs SVC_TAG [CNT_TAG]`
+#### `svc logs SVC_TAG [CNT_TAG]`
 
 Show service logs, optionally for a specific container.
 
 Requires an active environment.
 
-### `shell SVC_TAG [CNT_TAG]`
+#### `svc shell SVC_TAG [CNT_TAG]`
 
 Open a shell for a service, optionally for a specific container.
 
 Requires an active environment.
 
-### `status`
-
-Show resource status.
-
-When used without a subcommand, `status` behaves like `status env` for the
-active environment.
-
-Shared environment options:
-
-- `--details`: show extra details in status tables
-- `--show-commands`: show recent command history in status panels
-- `--show-commands-limit INTEGER`: number of commands to display
-- `-w`, `--watch`: keep updating output until interrupted
-
-#### `status env`
-
-Show status for the active environment explicitly.
-
-Requires an active environment.
-
-### `check`
-
-Run validation commands.
-
-#### `check probe [PROBE_TAG]`
-
-Run probes for the active environment and exit with a probe-based status
-code.
-
-Options:
-
-- `-a`, `--all`: run all probes
-
-Requires an active environment.
-
 ## Notes
 
-- Many commands operate on the active environment selected with `checkout`.
+- Many commands operate on the active environment selected with `env checkout`.
 - Commands that manage environment runtime state are centered around
-  `up`, `halt`, `reload`, and `status`.
-- Service-oriented commands (`build`, `logs`, `shell`, `up svc`,
-  `halt svc`, `reload svc`) all target the active environment.
+  `env up`, `env halt`, `env reload`, and `env status`.
+- Service-oriented commands (`svc build`, `svc logs`, `svc shell`,
+  `svc up`, `svc halt`, `svc reload`) all target the active environment.

--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -30,28 +30,26 @@ class CompletionMng(AbstractCompletionMng):
     """
     Top-level completion router.
 
-    It first resolves the command verb, then routes to a domain-specific
-    completion manager (`env`, `svc`, `probe`) based on either explicit
-    category tokens or implicit `auto-*` categories.
+    Completion is now routed by `scope` first and then by verb within that
+    scope, mirroring the Click command tree.
     """
 
-    # Mapping of verbs to valid categories
-    VERB_CATEGORIES = {
-        "get": ["env", "svc", "probe"],
-        "add": ["env", "svc"],
-        "clone": ["env"],
-        "rename": ["env"],
-        "checkout": ["auto-env"],
-        "delete": ["env"],
-        "list": ["auto-env"],
-        "up": ["env", "svc"],
-        "halt": ["env", "svc"],
-        "reload": ["env", "svc"],
-        "status": ["env"],
-        "logs": ["auto-svc"],
-        "shell": ["auto-svc"],
-        "build": ["auto-svc"],
-        "check": ["probe"],
+    SCOPE_VERBS = {
+        "env": [
+            "get",
+            "add",
+            "clone",
+            "rename",
+            "checkout",
+            "delete",
+            "list",
+            "up",
+            "halt",
+            "reload",
+            "status",
+        ],
+        "svc": ["get", "add", "up", "halt", "reload", "build", "logs", "shell"],
+        "probe": ["get", "check"],
     }
 
     @dataclass(frozen=True)
@@ -66,36 +64,24 @@ class CompletionMng(AbstractCompletionMng):
         OptionSpec(tokens=("-y", "--yes")),
     )
     CONTEXT_OPTIONS = {
-        ("up", None): (
+        ("env", "up"): (
             OptionSpec(tokens=("--show-commands",)),
             OptionSpec(tokens=("--show-commands-limit",), takes_value=True),
             OptionSpec(tokens=("--timeout",), takes_value=True),
             OptionSpec(tokens=("-w", "--watch")),
         ),
-        ("up", "env"): (
-            OptionSpec(tokens=("--show-commands",)),
-            OptionSpec(tokens=("--show-commands-limit",), takes_value=True),
-            OptionSpec(tokens=("--timeout",), takes_value=True),
-            OptionSpec(tokens=("-w", "--watch")),
-        ),
-        ("halt", None): (OptionSpec(tokens=("--no-wait",)),),
-        ("halt", "env"): (OptionSpec(tokens=("--no-wait",)),),
-        ("reload", "env"): (
+        ("env", "halt"): (OptionSpec(tokens=("--no-wait",)),),
+        ("env", "reload"): (
             OptionSpec(tokens=("--show-commands",)),
             OptionSpec(tokens=("--show-commands-limit",), takes_value=True),
             OptionSpec(tokens=("-w", "--watch")),
         ),
-        ("status", None): (
+        ("env", "status"): (
             OptionSpec(tokens=("--show-commands",)),
             OptionSpec(tokens=("--show-commands-limit",), takes_value=True),
             OptionSpec(tokens=("-w", "--watch")),
         ),
-        ("status", "env"): (
-            OptionSpec(tokens=("--show-commands",)),
-            OptionSpec(tokens=("--show-commands-limit",), takes_value=True),
-            OptionSpec(tokens=("-w", "--watch")),
-        ),
-        ("get", "env"): (
+        ("env", "get"): (
             OptionSpec(
                 tokens=("-o", "--output"),
                 takes_value=True,
@@ -106,7 +92,7 @@ class CompletionMng(AbstractCompletionMng):
             OptionSpec(tokens=("-r", "--resolved")),
             OptionSpec(tokens=("--details",)),
         ),
-        ("get", "probe"): (
+        ("probe", "get"): (
             OptionSpec(
                 tokens=("-o", "--output"),
                 takes_value=True,
@@ -116,7 +102,7 @@ class CompletionMng(AbstractCompletionMng):
             OptionSpec(tokens=("-r", "--resolved")),
             OptionSpec(tokens=("-a", "--all")),
         ),
-        ("get", "svc"): (
+        ("svc", "get"): (
             OptionSpec(
                 tokens=("-o", "--output"),
                 takes_value=True,
@@ -126,7 +112,7 @@ class CompletionMng(AbstractCompletionMng):
             OptionSpec(tokens=("-r", "--resolved")),
             OptionSpec(tokens=("--details",)),
         ),
-        ("check", "probe"): (OptionSpec(tokens=("-a", "--all")),),
+        ("probe", "check"): (OptionSpec(tokens=("-a", "--all")),),
     }
 
     def __init__(self, cli_flags: dict[str, Any], configMng: ConfigMng):
@@ -145,69 +131,33 @@ class CompletionMng(AbstractCompletionMng):
                     self._option_by_token[token] = spec
 
     @property
-    def VERBS(self) -> list[str]:
-        """return all verbs from the mapping."""
-        return list(self.VERB_CATEGORIES.keys())
+    def SCOPES(self) -> list[str]:
+        return list(self.SCOPE_VERBS.keys())
+
+    def is_scope_chosen(self, args: list[str]) -> bool:
+        return bool(args) and args[0] in self.SCOPES
 
     def is_verb_chosen(self, args: list[str]) -> bool:
-        if not args or len(args) < 1:
+        if len(args) < 2:
             return False
-        return args[0] in self.VERBS
-
-    def is_category_chosen(self, args: list[str]) -> bool:
-        if not args or len(args) < 2:
-            return False
-        verb = args[0]
-        category = args[1]
-        return category in self.VERB_CATEGORIES.get(verb, [])
-
-    def get_auto_category(self, args: list[str]) -> Optional[str]:
-        """
-        Resolve implicit category for verbs that do not expose it in argv.
-
-        Example: `logs <svc>` maps to `auto-svc`, so completion is delegated
-        directly to the service completion manager.
-        """
-        if not args:
-            return None
-        verb = args[0]
-        if self.VERB_CATEGORIES.get(verb, [])[0].startswith("auto-"):
-            return self.VERB_CATEGORIES[verb][0].split("-")[1]
-        else:
-            return None
+        return args[1] in self.SCOPE_VERBS.get(args[0], [])
 
     def get_completion_manager(
-        self, args: list[str], auto_category: Optional[str] = None
+        self, scope: Optional[str]
     ) -> Optional[AbstractCompletionMng]:
-        """Select the concrete completion manager for the resolved category."""
-        # Priority: use auto_category if provided, otherwise try args[1]
-        category = auto_category or (args[1] if len(args) > 1 else None)
-        if not category:
-            return None
-
-        if category == "env":
+        if scope == "env":
             return self.completionEnvMng
-        if category == "svc":
+        if scope == "svc":
             return self.completionSvcMng
-        if category == "probe":
+        if scope == "probe":
             return self.completionProbeMng
-
         return None
 
     def _match_option(self, token: str) -> Optional[OptionSpec]:
-        """
-        Resolve one raw argv token to a known option spec.
-
-        The matcher accepts:
-        - exact flag tokens like `--watch`
-        - long options with inline values like `--output=yaml`
-        - compact short options with inline values like `-oyaml`
-        """
         spec = self._option_by_token.get(token)
         if spec:
             return spec
         if token.startswith("--") and "=" in token:
-            # Support long-form inline values like `--output=yaml`.
             name, _, _value = token.partition("=")
             return self._option_by_token.get(name)
         for name, candidate in self._option_by_token.items():
@@ -218,7 +168,6 @@ class CompletionMng(AbstractCompletionMng):
                 and token.startswith(name)
                 and token != name
             ):
-                # Support compact short-form values like `-oyaml`.
                 return candidate
         return None
 
@@ -227,44 +176,17 @@ class CompletionMng(AbstractCompletionMng):
     ) -> tuple[
         list[str], Optional[str], Optional[str], set[str], Optional[OptionSpec]
     ]:
-        """
-        Split raw argv into positional routing tokens and option state.
-
-        Completion needs more than a simple "strip flags" pass because shell
-        completion usually sends the argument currently being edited as the
-        final token in `args`. For value-taking options this means the last
-        token can be:
-        - the option name itself: `--output`
-        - an empty current arg after a space: `--output ""`
-        - a partial value: `--output y`
-        - a fully typed value: `--output yaml`
-
-        This parser returns:
-        - `sanitized`: argv with option tokens and consumed option values
-          removed, used for verb/category/positional completion routing
-        - `verb` / `category`: resolved command context from positional tokens
-        - `used_options`: flags already present, so we do not keep suggesting
-          them
-        - `expect_value_for`: the option that still owns the current final
-          token when that token is an empty or partial value
-        """
         sanitized: list[str] = []
+        scope: Optional[str] = None
         verb: Optional[str] = None
-        category: Optional[str] = None
         used_options: set[str] = set()
         expect_value_for: Optional[CompletionMng.OptionSpec] = None
 
         for idx, token in enumerate(args):
             if expect_value_for is not None:
                 if idx == len(args) - 1:
-                    # Shell completion often passes the "current" argument as
-                    # the final token. Keep the option in a pending state for
-                    # empty or partial values so `get_completions_impl` can
-                    # suggest the option's allowed choices.
                     if token == "" or token not in expect_value_for.choices:
                         break
-                    # A fully matched final token (e.g. `yaml`) is treated as
-                    # consumed so completion can move on to the next argument.
                 expect_value_for = None
                 continue
 
@@ -280,40 +202,27 @@ class CompletionMng(AbstractCompletionMng):
                         if name.startswith("-") and not name.startswith("--")
                     ):
                         continue
-                    # Defer the next raw token to the option-value parser.
                     expect_value_for = option
                 continue
 
             sanitized.append(token)
-            if verb is None and token in self.VERBS:
-                verb = token
+            if scope is None and token in self.SCOPES:
+                scope = token
                 continue
-            if (
-                verb is not None
-                and category is None
-                and token in self.VERB_CATEGORIES.get(verb, [])
-            ):
-                category = token
+            if verb is None and scope is not None:
+                if token in self.SCOPE_VERBS.get(scope, []):
+                    verb = token
 
-        return sanitized, verb, category, used_options, expect_value_for
+        return sanitized, scope, verb, used_options, expect_value_for
 
     def _get_context_options(
-        self, verb: Optional[str], category: Optional[str]
+        self, scope: Optional[str], verb: Optional[str]
     ) -> list[OptionSpec]:
-        if verb is None:
+        if scope is None:
             return list(self.GLOBAL_OPTIONS)
-        if category is None:
-            options = list(self.CONTEXT_OPTIONS.get((verb, None), ()))
-        else:
-            options = list(self.CONTEXT_OPTIONS.get((verb, category), ()))
-        seen: set[tuple[str, ...]] = set()
-        deduped: list[CompletionMng.OptionSpec] = []
-        for spec in options:
-            if spec.tokens in seen:
-                continue
-            seen.add(spec.tokens)
-            deduped.append(spec)
-        return deduped
+        if verb is None:
+            return []
+        return list(self.CONTEXT_OPTIONS.get((scope, verb), ()))
 
     def _get_option_suggestions(
         self,
@@ -337,21 +246,14 @@ class CompletionMng(AbstractCompletionMng):
 
     @override
     def get_completions_impl(self, args: list[str]) -> list[str]:
-        """
-        Completion flow:
-        1. parse raw argv into positional routing tokens plus option state
-        2. if a value-taking option owns the current token, complete values
-        3. otherwise complete verbs / categories / positional args by context
-        4. merge in context-appropriate flag suggestions
-        """
-        sanitized_args, verb, category, used_options, expect_value_for = (
+        sanitized_args, scope, verb, used_options, expect_value_for = (
             self._parse_args(args)
         )
         last_token = args[-1] if args else ""
         last_option = self._match_option(last_token) if last_token else None
-        option_prefix: Optional[str] = None
-        if last_token.startswith("-"):
-            option_prefix = last_token
+        option_prefix: Optional[str] = (
+            last_token if last_token.startswith("-") else None
+        )
 
         if expect_value_for is not None:
             if last_token in expect_value_for.tokens:
@@ -363,17 +265,16 @@ class CompletionMng(AbstractCompletionMng):
                     if not last_token or choice.startswith(last_token)
                 ]
 
-        if not verb:
+        if not scope:
             if option_prefix is not None:
                 return self._get_option_suggestions(
                     list(self.GLOBAL_OPTIONS),
                     used_options=used_options,
                     prefix=option_prefix,
                 )
-            return list(self.VERBS)
+            return list(self.SCOPES)
 
-        auto_category = self.get_auto_category(sanitized_args)
-        context_options = self._get_context_options(verb, category)
+        context_options = self._get_context_options(scope, verb)
 
         if option_prefix is not None and not (
             last_option is not None
@@ -386,9 +287,8 @@ class CompletionMng(AbstractCompletionMng):
                 prefix=option_prefix,
             )
 
-        if not auto_category and not self.is_category_chosen(sanitized_args):
-            # suggest only valid categories for this verb
-            suggestions = list(self.VERB_CATEGORIES.get(verb, []))
+        if not verb:
+            suggestions = list(self.SCOPE_VERBS.get(scope, []))
             if not suggestions:
                 suggestions.extend(
                     self._get_option_suggestions(
@@ -397,9 +297,7 @@ class CompletionMng(AbstractCompletionMng):
                 )
             return self._unique(suggestions)
 
-        completion_manager = self.get_completion_manager(
-            sanitized_args, auto_category
-        )
+        completion_manager = self.get_completion_manager(scope)
         if completion_manager:
             suggestions = completion_manager.get_completions(sanitized_args)
             if option_prefix is not None:

--- a/src/completion/completion_env.py
+++ b/src/completion/completion_env.py
@@ -36,8 +36,10 @@ class CompletionEnvMng(AbstractCompletionMng):
 
     @override
     def get_completions_impl(self, args: list[str]) -> list[str]:
-        """Dispatch completion by verb using command-specific arg offsets."""
-        command = args[0]
+        """Dispatch completion by verb using scope-local arg offsets."""
+        if len(args) < 2:
+            return []
+        command = args[1]
         match command:
             case "add":
                 return self.get_add_completions(args[2:])
@@ -46,11 +48,11 @@ class CompletionEnvMng(AbstractCompletionMng):
             case "rename":
                 return self.get_rename_completions(args[2:])
             case "checkout":
-                return self.get_checkout_completions(args[1:])
+                return self.get_checkout_completions(args[2:])
             case "delete":
                 return self.get_delete_completions(args[2:])
             case "list":
-                return self.get_list_completions(args[1:])
+                return self.get_list_completions(args[2:])
             case "up":
                 return self.get_start_completions(args[2:])
             case "halt":

--- a/src/completion/completion_probe.py
+++ b/src/completion/completion_probe.py
@@ -23,7 +23,7 @@ from config import ConfigMng
 
 
 class CompletionProbeMng(AbstractCompletionMng):
-    """Probe argument completer for `get probe` and `check probe` flows."""
+    """Probe argument completer for `probe get` and `probe check` flows."""
 
     def __init__(self, cli_flags: dict[str, Any], configMng: ConfigMng):
         self.cli_flags = cli_flags
@@ -31,8 +31,10 @@ class CompletionProbeMng(AbstractCompletionMng):
 
     @override
     def get_completions_impl(self, args: list[str]) -> list[str]:
-        """Dispatch probe completion by verb using command-specific offsets."""
-        command = args[0]
+        """Dispatch probe completion by verb using scope-local offsets."""
+        if len(args) < 2:
+            return []
+        command = args[1]
         match command:
             case "get":
                 return self.get_render_completions(args[2:])

--- a/src/completion/completion_svc.py
+++ b/src/completion/completion_svc.py
@@ -36,21 +36,23 @@ class CompletionSvcMng(AbstractCompletionMng):
 
     @override
     def get_completions_impl(self, args: list[str]) -> list[str]:
-        """Dispatch completion by verb using command-specific arg offsets."""
-        command = args[0]
+        """Dispatch completion by verb using scope-local arg offsets."""
+        if len(args) < 2:
+            return []
+        command = args[1]
         match command:
             case "add":
                 return self.get_add_completions(args[2:])
             case "build":
-                return self.get_build_completions(args[1:])
+                return self.get_build_completions(args[2:])
             case "up":
                 return self.get_start_completions(args[2:])
             case "halt":
                 return self.get_stop_completions(args[2:])
             case "logs":
-                return self.get_logs_completions(args[1:])
+                return self.get_logs_completions(args[2:])
             case "shell":
-                return self.get_shell_completions(args[1:])
+                return self.get_shell_completions(args[2:])
             case "get":
                 return self.get_render_completions(args[2:])
             case "reload":

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -164,15 +164,15 @@ def complete(shepherd: ShepherdMng, args: Any):
 
 
 # =====================================================
-# GET
+# ENV
 # =====================================================
 @cli.group()
-def get():
-    """Get resources."""
+def env():
+    """Manage environments."""
     pass
 
 
-@get.command(name="env")
+@env.command(name="get")
 @click.argument("tag", required=False)
 @click.option("-o", "--output", type=click.Choice(["yaml", "json"]))
 @click.option(
@@ -215,85 +215,7 @@ def get_env(
     shepherd.environmentMng.describe_env(tag)
 
 
-@get.command(name="probe")
-@click.argument("probe_tag", required=False)
-@click.option(
-    "-o", "--output", type=click.Choice(["yaml", "json"]), default="yaml"
-)
-@click.option(
-    "-t", "--target", is_flag=True, help="Get the target configuration."
-)
-@click.option(
-    "-r", "--resolved", is_flag=True, help="Get the resolved configuration."
-)
-@click.option("-a", "--all", is_flag=True, help="Get all probes.")
-@click.pass_obj
-@require_active_env
-def get_probe(
-    shepherd: ShepherdMng,
-    envCfg: EnvironmentCfg,
-    probe_tag: Optional[str],
-    output: Optional[str],
-    target: bool,
-    resolved: bool,
-    all: bool,
-):
-    """Get probe details."""
-    if all:
-        probe_tag = None
-    if output:
-        click.echo(
-            shepherd.environmentMng.render_probes(
-                envCfg, probe_tag, target, resolved
-            )
-        )
-
-
-@get.command(name="svc")
-@click.argument("tag", required=True)
-@click.option("-o", "--output", type=click.Choice(["yaml", "json"]))
-@click.option(
-    "-t", "--target", is_flag=True, help="Get the target configuration."
-)
-@click.option(
-    "-r", "--resolved", is_flag=True, help="Get the resolved configuration."
-)
-@click.option("--details", is_flag=True, help="Show container details.")
-@click.pass_obj
-@require_active_env
-def get_svc(
-    shepherd: ShepherdMng,
-    envCfg: EnvironmentCfg,
-    tag: str,
-    output: Optional[str],
-    target: bool,
-    resolved: bool,
-    details: bool,
-):
-    """Get service details or config."""
-    if (target or resolved) and not output:
-        raise click.UsageError("--target and --resolved require --output")
-    _apply_details_flag(shepherd, details)
-    if output:
-        click.echo(
-            shepherd.serviceMng.render_svc(
-                envCfg, tag, target, resolved, output=output
-            )
-        )
-        return
-    shepherd.serviceMng.describe_svc(envCfg, tag)
-
-
-# =====================================================
-# ADD
-# =====================================================
-@cli.group()
-def add():
-    """Add resources."""
-    pass
-
-
-@add.command(name="env")
+@env.command(name="add")
 @click.argument("template", required=True)
 @click.argument("tag", required=True)
 @click.pass_obj
@@ -302,35 +224,7 @@ def add_env(shepherd: ShepherdMng, template: str, tag: str):
     shepherd.environmentMng.add_env(template, tag)
 
 
-@add.command(name="svc")
-@click.argument("svc_template", required=True)
-@click.argument("svc_tag", required=True)
-@click.argument("svc_class", required=False)
-@click.pass_obj
-@require_active_env
-def add_svc(
-    shepherd: ShepherdMng,
-    envCfg: EnvironmentCfg,
-    svc_template: str,
-    svc_tag: str,
-    svc_class: Optional[str] = None,
-):
-    """Add a new service."""
-    shepherd.environmentMng.add_service(
-        envCfg.tag, svc_tag, svc_template, svc_class
-    )
-
-
-# =====================================================
-# CLONE
-# =====================================================
-@cli.group()
-def clone():
-    """Clone resources."""
-    pass
-
-
-@clone.command(name="env")
+@env.command(name="clone")
 @click.argument("src_tag", required=True)
 @click.argument("dst_tag", required=True)
 @click.pass_obj
@@ -339,16 +233,7 @@ def clone_env(shepherd: ShepherdMng, src_tag: str, dst_tag: str):
     shepherd.environmentMng.clone_env(src_tag, dst_tag)
 
 
-# =====================================================
-# RENAME
-# =====================================================
-@cli.group()
-def rename():
-    """Rename resources."""
-    pass
-
-
-@rename.command(name="env")
+@env.command(name="rename")
 @click.argument("src_tag", required=True)
 @click.argument("dst_tag", required=True)
 @click.pass_obj
@@ -360,7 +245,7 @@ def rename_env(shepherd: ShepherdMng, src_tag: str, dst_tag: str):
 # =====================================================
 # CHECKOUT
 # =====================================================
-@cli.command(name="checkout")
+@env.command(name="checkout")
 @click.argument("tag", required=True)
 @click.pass_obj
 def checkout(shepherd: ShepherdMng, tag: str):
@@ -371,13 +256,7 @@ def checkout(shepherd: ShepherdMng, tag: str):
 # =====================================================
 # DELETE
 # =====================================================
-@cli.group()
-def delete():
-    """Delete resources."""
-    pass
-
-
-@delete.command(name="env")
+@env.command(name="delete")
 @click.argument("tag", required=True)
 @click.pass_obj
 def delete_env(shepherd: ShepherdMng, tag: str):
@@ -388,7 +267,7 @@ def delete_env(shepherd: ShepherdMng, tag: str):
 # =====================================================
 # LIST
 # =====================================================
-@cli.command(name="list")
+@env.command(name="list")
 @click.pass_obj
 def list(shepherd: ShepherdMng):
     """List environments."""
@@ -398,58 +277,7 @@ def list(shepherd: ShepherdMng):
 # =====================================================
 # UP
 # =====================================================
-@cli.group(invoke_without_command=True)
-@click.option(
-    "--show-commands",
-    is_flag=True,
-    help="Show recent commands in status panels.",
-)
-@click.option(
-    "--show-commands-limit",
-    type=int,
-    default=DEFAULT_COMPOSE_COMMAND_LOG_LIMIT,
-    show_default=True,
-    help="Number of recent commands to display.",
-)
-@click.option(
-    "--timeout",
-    type=int,
-    default=60,
-    show_default=True,
-    help="Maximum seconds to wait for all containers to be running.",
-)
-@click.option(
-    "-w",
-    "--watch",
-    is_flag=True,
-    help="Keep updating the output until interrupted.",
-)
-@click.pass_obj
-@require_active_env
-def up(
-    shepherd: ShepherdMng,
-    envCfg: EnvironmentCfg,
-    show_commands: bool,
-    show_commands_limit: int,
-    timeout: Optional[int],
-    watch: bool,
-):
-    """
-    Start resources.
-
-    `up` is an umbrella group: when called without a subcommand it behaves as
-    `up env`, while `up svc ...` routes to direct service-level startup.
-    """
-    # If no subcommand is given, default to environment startup.
-    ctx = click.get_current_context()
-    if ctx.invoked_subcommand is None:
-        _apply_show_commands_flags(shepherd, show_commands, show_commands_limit)
-        shepherd.environmentMng.start_env(
-            envCfg, timeout_seconds=timeout, watch=watch
-        )
-
-
-@up.command(name="env")
+@env.command(name="up")
 @click.option(
     "--show-commands",
     is_flag=True,
@@ -492,46 +320,10 @@ def up_env(
     )
 
 
-@up.command(name="svc")
-@click.argument("svc_tag", required=True)
-@click.argument("cnt_tag", required=False)
-@click.pass_obj
-@require_active_env
-def up_svc(
-    shepherd: ShepherdMng,
-    envCfg: EnvironmentCfg,
-    svc_tag: str,
-    cnt_tag: Optional[str] = None,
-):
-    """Start service."""
-    shepherd.serviceMng.start_svc(envCfg, svc_tag, cnt_tag)
-
-
 # =====================================================
-# STOP
+# HALT
 # =====================================================
-@cli.group(invoke_without_command=True)
-@click.option(
-    "--no-wait",
-    is_flag=True,
-    help="Return after issuing the stop command without waiting.",
-)
-@click.pass_obj
-@require_active_env
-def halt(shepherd: ShepherdMng, envCfg: EnvironmentCfg, no_wait: bool):
-    """
-    Stop resources.
-
-    `stop` (wired to `halt`) defaults to stopping the active environment when
-    no subcommand is provided.
-    """
-    # If no subcommand is given, default to environment stop.
-    ctx = click.get_current_context()
-    if ctx.invoked_subcommand is None:
-        shepherd.environmentMng.stop_env(envCfg, wait=not no_wait)
-
-
-@halt.command(name="env")
+@env.command(name="halt")
 @click.option(
     "--no-wait",
     is_flag=True,
@@ -544,31 +336,10 @@ def halt_env(shepherd: ShepherdMng, envCfg: EnvironmentCfg, no_wait: bool):
     shepherd.environmentMng.stop_env(envCfg, wait=not no_wait)
 
 
-@halt.command(name="svc")
-@click.argument("svc_tag", required=True)
-@click.argument("cnt_tag", required=False)
-@click.pass_obj
-@require_active_env
-def halt_svc(
-    shepherd: ShepherdMng,
-    envCfg: EnvironmentCfg,
-    svc_tag: str,
-    cnt_tag: Optional[str] = None,
-):
-    """Stop service."""
-    shepherd.serviceMng.stop_svc(envCfg, svc_tag, cnt_tag)
-
-
 # =====================================================
 # RELOAD
 # =====================================================
-@cli.group()
-def reload():
-    """Reload resources."""
-    pass
-
-
-@reload.command(name="env")
+@env.command(name="reload")
 @click.option(
     "--show-commands",
     is_flag=True,
@@ -601,122 +372,10 @@ def reload_env(
     shepherd.environmentMng.reload_env(envCfg, watch=watch)
 
 
-@reload.command(name="svc")
-@click.argument("svc_tag", required=True)
-@click.argument("cnt_tag", required=False)
-@click.pass_obj
-@require_active_env
-def reload_svc(
-    shepherd: ShepherdMng,
-    envCfg: EnvironmentCfg,
-    svc_tag: str,
-    cnt_tag: Optional[str] = None,
-):
-    """Reload service."""
-    shepherd.serviceMng.reload_svc(envCfg, svc_tag, cnt_tag)
-
-
-# =====================================================
-# BUILD
-# =====================================================
-@cli.command(name="build")
-@click.argument("svc_tag", required=True)
-@click.argument("cnt_tag", required=False)
-@click.pass_obj
-@require_active_env
-def build(
-    shepherd: ShepherdMng,
-    envCfg: EnvironmentCfg,
-    svc_tag: str,
-    cnt_tag: Optional[str] = None,
-):
-    """Build service."""
-    shepherd.serviceMng.build_svc(envCfg, svc_tag, cnt_tag)
-
-
-# =====================================================
-# LOGS
-# =====================================================
-@cli.command(name="logs")
-@click.argument("svc_tag", required=True)
-@click.argument("cnt_tag", required=False)
-@click.pass_obj
-@require_active_env
-def logs(
-    shepherd: ShepherdMng,
-    envCfg: EnvironmentCfg,
-    svc_tag: str,
-    cnt_tag: Optional[str] = None,
-):
-    """Show service logs."""
-    shepherd.serviceMng.logs_svc(envCfg, svc_tag, cnt_tag)
-
-
-# =====================================================
-# SHELL
-# =====================================================
-@cli.command(name="shell")
-@click.argument("svc_tag", required=True)
-@click.argument("cnt_tag", required=False)
-@click.pass_obj
-@require_active_env
-def shell(
-    shepherd: ShepherdMng,
-    envCfg: EnvironmentCfg,
-    svc_tag: str,
-    cnt_tag: Optional[str] = None,
-):
-    """Get a shell session for a service."""
-    shepherd.serviceMng.shell_svc(envCfg, svc_tag, cnt_tag)
-
-
 # =====================================================
 # STATUS
 # =====================================================
-@cli.group(invoke_without_command=True)
-@click.option(
-    "--show-commands",
-    is_flag=True,
-    help="Show recent commands in status panels.",
-)
-@click.option(
-    "--show-commands-limit",
-    type=int,
-    default=DEFAULT_COMPOSE_COMMAND_LOG_LIMIT,
-    show_default=True,
-    help="Number of recent commands to display.",
-)
-@click.option(
-    "-w",
-    "--watch",
-    is_flag=True,
-    help="Keep updating the output until interrupted.",
-)
-@click.pass_obj
-@require_active_env
-def status(
-    shepherd: ShepherdMng,
-    envCfg: EnvironmentCfg,
-    show_commands: bool,
-    show_commands_limit: int,
-    watch: bool,
-):
-    """
-    Show status of resources.
-
-    Like `up`, this group defaults to environment status when no subcommand is
-    provided; subcommands can offer narrower views.
-    """
-    ctx = click.get_current_context()
-    if ctx.invoked_subcommand is not None:
-        return
-
-    _apply_show_commands_flags(shepherd, show_commands, show_commands_limit)
-
-    shepherd.environmentMng.status_env(envCfg, watch=watch)
-
-
-@status.command(name="env")
+@env.command(name="status")
 @click.option(
     "--show-commands",
     is_flag=True,
@@ -750,15 +409,202 @@ def status_env(
 
 
 # =====================================================
-# CHECK
+# SVC
 # =====================================================
 @cli.group()
-def check():
-    """Check resources."""
+def svc():
+    """Manage services."""
     pass
 
 
-@check.command(name="probe")
+@svc.command(name="get")
+@click.argument("tag", required=True)
+@click.option("-o", "--output", type=click.Choice(["yaml", "json"]))
+@click.option(
+    "-t", "--target", is_flag=True, help="Get the target configuration."
+)
+@click.option(
+    "-r", "--resolved", is_flag=True, help="Get the resolved configuration."
+)
+@click.option("--details", is_flag=True, help="Show container details.")
+@click.pass_obj
+@require_active_env
+def get_svc(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    tag: str,
+    output: Optional[str],
+    target: bool,
+    resolved: bool,
+    details: bool,
+):
+    """Get service details or config."""
+    if (target or resolved) and not output:
+        raise click.UsageError("--target and --resolved require --output")
+    _apply_details_flag(shepherd, details)
+    if output:
+        click.echo(
+            shepherd.serviceMng.render_svc(
+                envCfg, tag, target, resolved, output=output
+            )
+        )
+        return
+    shepherd.serviceMng.describe_svc(envCfg, tag)
+
+
+@svc.command(name="add")
+@click.argument("svc_template", required=True)
+@click.argument("svc_tag", required=True)
+@click.argument("svc_class", required=False)
+@click.pass_obj
+@require_active_env
+def add_svc(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    svc_template: str,
+    svc_tag: str,
+    svc_class: Optional[str] = None,
+):
+    """Add a new service."""
+    shepherd.environmentMng.add_service(
+        envCfg.tag, svc_tag, svc_template, svc_class
+    )
+
+
+@svc.command(name="up")
+@click.argument("svc_tag", required=True)
+@click.argument("cnt_tag", required=False)
+@click.pass_obj
+@require_active_env
+def up_svc(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    svc_tag: str,
+    cnt_tag: Optional[str] = None,
+):
+    """Start service."""
+    shepherd.serviceMng.start_svc(envCfg, svc_tag, cnt_tag)
+
+
+@svc.command(name="halt")
+@click.argument("svc_tag", required=True)
+@click.argument("cnt_tag", required=False)
+@click.pass_obj
+@require_active_env
+def halt_svc(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    svc_tag: str,
+    cnt_tag: Optional[str] = None,
+):
+    """Stop service."""
+    shepherd.serviceMng.stop_svc(envCfg, svc_tag, cnt_tag)
+
+
+@svc.command(name="reload")
+@click.argument("svc_tag", required=True)
+@click.argument("cnt_tag", required=False)
+@click.pass_obj
+@require_active_env
+def reload_svc(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    svc_tag: str,
+    cnt_tag: Optional[str] = None,
+):
+    """Reload service."""
+    shepherd.serviceMng.reload_svc(envCfg, svc_tag, cnt_tag)
+
+
+@svc.command(name="build")
+@click.argument("svc_tag", required=True)
+@click.argument("cnt_tag", required=False)
+@click.pass_obj
+@require_active_env
+def build(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    svc_tag: str,
+    cnt_tag: Optional[str] = None,
+):
+    """Build service."""
+    shepherd.serviceMng.build_svc(envCfg, svc_tag, cnt_tag)
+
+
+@svc.command(name="logs")
+@click.argument("svc_tag", required=True)
+@click.argument("cnt_tag", required=False)
+@click.pass_obj
+@require_active_env
+def logs(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    svc_tag: str,
+    cnt_tag: Optional[str] = None,
+):
+    """Show service logs."""
+    shepherd.serviceMng.logs_svc(envCfg, svc_tag, cnt_tag)
+
+
+@svc.command(name="shell")
+@click.argument("svc_tag", required=True)
+@click.argument("cnt_tag", required=False)
+@click.pass_obj
+@require_active_env
+def shell(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    svc_tag: str,
+    cnt_tag: Optional[str] = None,
+):
+    """Get a shell session for a service."""
+    shepherd.serviceMng.shell_svc(envCfg, svc_tag, cnt_tag)
+
+
+# =====================================================
+# PROBE
+# =====================================================
+@cli.group()
+def probe():
+    """Manage probes."""
+    pass
+
+
+@probe.command(name="get")
+@click.argument("probe_tag", required=False)
+@click.option(
+    "-o", "--output", type=click.Choice(["yaml", "json"]), default="yaml"
+)
+@click.option(
+    "-t", "--target", is_flag=True, help="Get the target configuration."
+)
+@click.option(
+    "-r", "--resolved", is_flag=True, help="Get the resolved configuration."
+)
+@click.option("-a", "--all", is_flag=True, help="Get all probes.")
+@click.pass_obj
+@require_active_env
+def get_probe(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    probe_tag: Optional[str],
+    output: Optional[str],
+    target: bool,
+    resolved: bool,
+    all: bool,
+):
+    """Get probe details."""
+    if all:
+        probe_tag = None
+    if output:
+        click.echo(
+            shepherd.environmentMng.render_probes(
+                envCfg, probe_tag, target, resolved
+            )
+        )
+
+
+@probe.command(name="check")
 @click.argument("probe_tag", required=False)
 @click.option("-a", "--all", is_flag=True, help="Check all probes.")
 @click.pass_obj
@@ -769,8 +615,7 @@ def check_probe(
     probe_tag: Optional[str],
     all: bool,
 ):
-    """Run probe checks and return a process exit code based on
-    probe results."""
+    """Run probe checks and return a process exit code based on results."""
     if all:
         probe_tag = None
     exit_code = shepherd.environmentMng.check_probes(envCfg, probe_tag)

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -55,7 +55,7 @@ def test_completion_no_args(
 ):
     sm = ShepherdMng()
     completions = sm.completionMng.get_completions([])
-    assert completions == sm.completionMng.VERBS, "Expected verbs only"
+    assert completions == sm.completionMng.SCOPES, "Expected scopes only"
 
 
 @pytest.mark.compl
@@ -67,6 +67,19 @@ def test_completion_global_flags_prefix(
     sm = ShepherdMng()
     completions = sm.completionMng.get_completions(["--q"])
     assert completions == ["--quiet"], "Expected filtered global flag"
+
+
+@pytest.mark.compl
+@pytest.mark.parametrize("args", [["env", "-"], ["svc", "-"], ["probe", "-"]])
+def test_completion_scope_prefix_does_not_suggest_root_flags(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+    args: list[str],
+):
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(args)
+    assert completions == [], "Expected no root flags after choosing a scope"
 
 
 @pytest.mark.compl
@@ -83,10 +96,10 @@ def test_completion_add(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["add"])
+    completions = sm.completionMng.get_completions(["env"])
     assert (
-        completions == sm.completionMng.VERB_CATEGORIES["add"]
-    ), "Expected add completion"
+        completions == sm.completionMng.SCOPE_VERBS["env"]
+    ), "Expected env verbs"
 
 
 @pytest.mark.compl
@@ -102,7 +115,7 @@ def test_completion_add_env(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["add", "env"])
+    completions = sm.completionMng.get_completions(["env", "add"])
     assert (
         completions == sm.configMng.get_environment_template_tags()
     ), "Expected add-env completion"
@@ -121,7 +134,7 @@ def test_completion_add_svc_1(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["add", "svc"])
+    completions = sm.completionMng.get_completions(["svc", "add"])
     assert completions == ["t1", "t2"], "Expected add svc -1- completion"
 
 
@@ -138,7 +151,7 @@ def test_completion_add_svc_2(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["add", "svc", "t1"])
+    completions = sm.completionMng.get_completions(["svc", "add", "t1"])
     assert completions == [], "Expected add svc -2- completion"
 
 
@@ -156,7 +169,7 @@ def test_completion_add_svc_3(
 
     sm = ShepherdMng()
     completions = sm.completionMng.get_completions(
-        ["add", "svc", "t1", "svc-tag"]
+        ["svc", "add", "t1", "svc-tag"]
     )
     assert completions == ["foo-class"], "Expected add svc -3- completion"
 
@@ -174,10 +187,10 @@ def test_completion_clone(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["clone"])
+    completions = sm.completionMng.get_completions(["env"])
     assert (
-        completions == sm.completionMng.VERB_CATEGORIES["clone"]
-    ), "Expected clone completion"
+        completions == sm.completionMng.SCOPE_VERBS["env"]
+    ), "Expected env verbs"
 
 
 @pytest.mark.compl
@@ -193,7 +206,7 @@ def test_completion_clone_env(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["clone", "env"])
+    completions = sm.completionMng.get_completions(["env", "clone"])
     assert completions == ["test-1", "test-2"], "Expected env clone completion"
 
 
@@ -210,10 +223,10 @@ def test_completion_rename(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["rename"])
+    completions = sm.completionMng.get_completions(["env"])
     assert (
-        completions == sm.completionMng.VERB_CATEGORIES["rename"]
-    ), "Expected rename completion"
+        completions == sm.completionMng.SCOPE_VERBS["env"]
+    ), "Expected env verbs"
 
 
 @pytest.mark.compl
@@ -229,7 +242,7 @@ def test_completion_rename_env(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["rename", "env"])
+    completions = sm.completionMng.get_completions(["env", "rename"])
     assert completions == ["test-1", "test-2"], "Expected env rename completion"
 
 
@@ -246,7 +259,7 @@ def test_completion_checkout_env(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["checkout"])
+    completions = sm.completionMng.get_completions(["env", "checkout"])
     assert completions == [
         "test-2",
     ], "Expected env checkout completion"
@@ -265,10 +278,10 @@ def test_completion_delete(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["delete"])
+    completions = sm.completionMng.get_completions(["env"])
     assert (
-        completions == sm.completionMng.VERB_CATEGORIES["delete"]
-    ), "Expected delete completion"
+        completions == sm.completionMng.SCOPE_VERBS["env"]
+    ), "Expected env verbs"
 
 
 @pytest.mark.compl
@@ -284,7 +297,7 @@ def test_completion_delete_env(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["delete", "env"])
+    completions = sm.completionMng.get_completions(["env", "delete"])
     assert completions == [
         "test-1",
         "test-2",
@@ -304,7 +317,7 @@ def test_completion_list(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["list"])
+    completions = sm.completionMng.get_completions(["env", "list"])
     assert completions == [], "Expected list completion"
 
 
@@ -321,10 +334,10 @@ def test_completion_start(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["up"])
+    completions = sm.completionMng.get_completions(["env"])
     assert (
-        completions == sm.completionMng.VERB_CATEGORIES["up"]
-    ), "Expected up categories only"
+        completions == sm.completionMng.SCOPE_VERBS["env"]
+    ), "Expected env verbs"
 
 
 @pytest.mark.compl
@@ -340,7 +353,7 @@ def test_completion_start_env(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["up", "env"])
+    completions = sm.completionMng.get_completions(["env", "up"])
     assert completions == [
         "--show-commands",
         "--show-commands-limit",
@@ -363,7 +376,7 @@ def test_completion_start_env_with_option_prefix(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["up", "env", "--sh"])
+    completions = sm.completionMng.get_completions(["env", "up", "--sh"])
     assert completions == [
         "--show-commands",
         "--show-commands-limit",
@@ -383,7 +396,7 @@ def test_completion_start_svc(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["up", "svc"])
+    completions = sm.completionMng.get_completions(["svc", "up"])
     assert completions == ["red", "white"], "Expected up svc completion"
 
 
@@ -400,7 +413,7 @@ def test_completion_start_svc_cnt_1(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["up", "svc", "red"])
+    completions = sm.completionMng.get_completions(["svc", "up", "red"])
     assert completions == [
         "container-1",
         "container-2",
@@ -420,10 +433,10 @@ def test_completion_stop(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["halt"])
+    completions = sm.completionMng.get_completions(["env"])
     assert (
-        completions == sm.completionMng.VERB_CATEGORIES["halt"]
-    ), "Expected halt categories only"
+        completions == sm.completionMng.SCOPE_VERBS["env"]
+    ), "Expected env verbs"
 
 
 @pytest.mark.compl
@@ -439,7 +452,7 @@ def test_completion_stop_env(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["halt", "env"])
+    completions = sm.completionMng.get_completions(["env", "halt"])
     assert completions == ["--no-wait"], "Expected env halt flags"
 
 
@@ -456,7 +469,7 @@ def test_completion_stop_svc(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["halt", "svc"])
+    completions = sm.completionMng.get_completions(["svc", "halt"])
     assert completions == ["red", "white"], "Expected halt svc completion"
 
 
@@ -473,7 +486,7 @@ def test_completion_stop_svc_cnt_1(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["halt", "svc", "red"])
+    completions = sm.completionMng.get_completions(["svc", "halt", "red"])
     assert completions == [
         "container-1",
         "container-2",
@@ -493,10 +506,10 @@ def test_completion_reload(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["reload"])
+    completions = sm.completionMng.get_completions(["env"])
     assert (
-        completions == sm.completionMng.VERB_CATEGORIES["reload"]
-    ), "Expected reload completion"
+        completions == sm.completionMng.SCOPE_VERBS["env"]
+    ), "Expected env verbs"
 
 
 @pytest.mark.compl
@@ -512,7 +525,7 @@ def test_completion_reload_env(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["reload", "env"])
+    completions = sm.completionMng.get_completions(["env", "reload"])
     assert completions == [
         "--show-commands",
         "--show-commands-limit",
@@ -534,7 +547,7 @@ def test_completion_reload_svc(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["reload", "svc"])
+    completions = sm.completionMng.get_completions(["svc", "reload"])
     assert completions == ["red", "white"], "Expected reload svc completion"
 
 
@@ -551,7 +564,7 @@ def test_completion_reload_svc_cnt_1(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["reload", "svc", "red"])
+    completions = sm.completionMng.get_completions(["svc", "reload", "red"])
     assert completions == [
         "container-1",
         "container-2",
@@ -562,9 +575,9 @@ def test_completion_reload_svc_cnt_1(
 @pytest.mark.parametrize(
     "args",
     [
-        ["up", "svc", "red", "container-1"],
-        ["halt", "svc", "red", "container-1"],
-        ["reload", "svc", "red", "container-1"],
+        ["svc", "up", "red", "container-1"],
+        ["svc", "halt", "red", "container-1"],
+        ["svc", "reload", "red", "container-1"],
     ],
 )
 def test_completion_svc_after_final_positional_has_no_more_suggestions(
@@ -597,10 +610,10 @@ def test_completion_get(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["get"])
+    completions = sm.completionMng.get_completions(["env"])
     assert (
-        completions == sm.completionMng.VERB_CATEGORIES["get"]
-    ), "Expected get completion"
+        completions == sm.completionMng.SCOPE_VERBS["env"]
+    ), "Expected env verbs"
 
 
 @pytest.mark.compl
@@ -616,7 +629,7 @@ def test_completion_get_env_oyaml(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["get", "env", "-oyaml"])
+    completions = sm.completionMng.get_completions(["env", "get", "-oyaml"])
     assert completions == [
         "test-1",
         "test-2",
@@ -636,7 +649,7 @@ def test_completion_get_env(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["get", "env"])
+    completions = sm.completionMng.get_completions(["env", "get"])
     assert completions == ["test-1", "test-2"], "Expected get env completion"
 
 
@@ -653,7 +666,7 @@ def test_completion_get_svc_oyaml(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["get", "svc", "-oyaml"])
+    completions = sm.completionMng.get_completions(["svc", "get", "-oyaml"])
     assert completions == ["red", "white"], "Expected get svc -oyaml completion"
 
 
@@ -670,7 +683,7 @@ def test_completion_build_svc(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["build"])
+    completions = sm.completionMng.get_completions(["svc", "build"])
     assert completions == ["red", "white"], "Expected build svc completion"
 
 
@@ -687,7 +700,7 @@ def test_completion_build_svc_cnt_1(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["build", "red"])
+    completions = sm.completionMng.get_completions(["svc", "build", "red"])
     assert completions == [
         "container-1",
         "container-2",
@@ -707,7 +720,7 @@ def test_completion_logs_svc(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["logs"])
+    completions = sm.completionMng.get_completions(["svc", "logs"])
     assert completions == ["red", "white"], "Expected logs svc completion"
 
 
@@ -724,7 +737,7 @@ def test_completion_logs_svc_cnt_1(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["logs", "red"])
+    completions = sm.completionMng.get_completions(["svc", "logs", "red"])
     assert completions == [
         "container-1",
         "container-2",
@@ -744,7 +757,7 @@ def test_completion_shell_svc(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["shell"])
+    completions = sm.completionMng.get_completions(["svc", "shell"])
     assert completions == ["red", "white"], "Expected shell svc completion"
 
 
@@ -761,7 +774,7 @@ def test_completion_shell_svc_cnt_1(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["shell", "red"])
+    completions = sm.completionMng.get_completions(["svc", "shell", "red"])
     assert completions == [
         "container-1",
         "container-2",
@@ -781,7 +794,7 @@ def test_completion_status_env(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["status", "env"])
+    completions = sm.completionMng.get_completions(["env", "status"])
     assert completions == [
         "--show-commands",
         "--show-commands-limit",
@@ -803,7 +816,7 @@ def test_completion_get_env_shows_tags_only(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["get", "env"])
+    completions = sm.completionMng.get_completions(["env", "get"])
     assert completions == ["test-1", "test-2"], "Expected get env tags only"
 
 
@@ -821,7 +834,7 @@ def test_completion_get_env_after_output_value_keeps_env_tags(
 
     sm = ShepherdMng()
     completions = sm.completionMng.get_completions(
-        ["get", "env", "--output", "yaml"]
+        ["env", "get", "--output", "yaml"]
     )
     assert completions == [
         "test-1",
@@ -834,7 +847,7 @@ def test_completion_get_env_after_output_value_keeps_env_tags(
     ("args", "expected"),
     [
         (
-            ["get", "env", "test-1"],
+            ["env", "get", "test-1"],
             [
                 "-o",
                 "--output",
@@ -847,7 +860,7 @@ def test_completion_get_env_after_output_value_keeps_env_tags(
             ],
         ),
         (
-            ["get", "svc", "red"],
+            ["svc", "get", "red"],
             [
                 "-o",
                 "--output",
@@ -859,7 +872,7 @@ def test_completion_get_env_after_output_value_keeps_env_tags(
             ],
         ),
         (
-            ["get", "probe", "db-live"],
+            ["probe", "get", "db-live"],
             [
                 "-o",
                 "--output",
@@ -898,7 +911,7 @@ def test_completion_get_env_output_value_choices(
     mocker: MockerFixture,
 ):
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["get", "env", "--output"])
+    completions = sm.completionMng.get_completions(["env", "get", "--output"])
     assert completions == ["yaml", "json"], "Expected output value choices"
 
 
@@ -910,7 +923,7 @@ def test_completion_get_svc_output_value_choices_with_empty_current_arg(
 ):
     sm = ShepherdMng()
     completions = sm.completionMng.get_completions(
-        ["get", "svc", "cache", "-o", ""]
+        ["svc", "get", "cache", "-o", ""]
     )
     assert completions == ["yaml", "json"], "Expected output choices after -o "
 
@@ -923,7 +936,7 @@ def test_completion_get_svc_output_value_choices_with_prefix(
 ):
     sm = ShepherdMng()
     completions = sm.completionMng.get_completions(
-        ["get", "svc", "cache", "-o", "y"]
+        ["svc", "get", "cache", "-o", "y"]
     )
     assert completions == ["yaml"], "Expected filtered output value choices"
 
@@ -933,7 +946,7 @@ def test_completion_get_svc_output_value_choices_with_prefix(
     ("args", "expected"),
     [
         (
-            ["get", "env", "-"],
+            ["env", "get", "-"],
             [
                 "-o",
                 "--output",
@@ -946,7 +959,7 @@ def test_completion_get_svc_output_value_choices_with_prefix(
             ],
         ),
         (
-            ["get", "svc", "-"],
+            ["svc", "get", "-"],
             [
                 "-o",
                 "--output",
@@ -958,7 +971,7 @@ def test_completion_get_svc_output_value_choices_with_prefix(
             ],
         ),
         (
-            ["get", "probe", "-"],
+            ["probe", "get", "-"],
             [
                 "-o",
                 "--output",
@@ -1003,7 +1016,7 @@ def test_completion_get_probe_oyaml(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["get", "probe", "-oyaml"])
+    completions = sm.completionMng.get_completions(["probe", "get", "-oyaml"])
     assert completions == [
         "db-live",
         "db-ready",
@@ -1023,7 +1036,7 @@ def test_completion_get_probe(
     shpd_yaml.write_text(shpd_config)
 
     sm = ShepherdMng()
-    completions = sm.completionMng.get_completions(["get", "probe"])
+    completions = sm.completionMng.get_completions(["probe", "get"])
     assert completions == [
         "db-live",
         "db-ready",

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -100,7 +100,7 @@ def test_env_render_compose_env_ext_net(
     shpd_config = read_fixture("env_docker", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "env", "test-1", "-oyaml"])
+    result = runner.invoke(cli, ["env", "get", "test-1", "-oyaml"])
     assert result.exit_code == 0
 
     expected = """
@@ -250,7 +250,7 @@ def test_env_render_compose_env_resolved(
     shpd_config = read_fixture("env_docker", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "env", "test-1", "-oyaml", "-r"])
+    result = runner.invoke(cli, ["env", "get", "test-1", "-oyaml", "-r"])
     assert result.exit_code == 0
 
     expected = """
@@ -400,7 +400,7 @@ def test_env_render_target_compose_env_ext_net(
     shpd_config = read_fixture("env_docker", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "env", "test-1", "-oyaml", "-t"])
+    result = runner.invoke(cli, ["env", "get", "test-1", "-oyaml", "-t"])
     assert result.exit_code == 0
 
     expected = (
@@ -472,7 +472,7 @@ def test_env_render_target_compose_env_resolved(
     shpd_config = read_fixture("env_docker", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "env", "test-1", "-oyaml", "-t", "-r"])
+    result = runner.invoke(cli, ["env", "get", "test-1", "-oyaml", "-t", "-r"])
     assert result.exit_code == 0
 
     expected = (
@@ -544,7 +544,7 @@ def test_env_render_target_compose_env_int_net(
     shpd_config = read_fixture("env_docker", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "env", "test-2", "-oyaml", "-t"])
+    result = runner.invoke(cli, ["env", "get", "test-2", "-oyaml", "-t"])
     assert result.exit_code == 0
 
     expected = (
@@ -629,7 +629,7 @@ def test_start_env(
     shpd_yaml.write_text(shpd_config)
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
     assert result.exit_code == 0
     assert mock_subproc.call_count >= 2
     assert any(
@@ -1344,7 +1344,7 @@ def test_stop_env(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -1356,7 +1356,7 @@ def test_stop_env(
         ),
     )
 
-    result = runner.invoke(cli, ["halt", "env"])
+    result = runner.invoke(cli, ["env", "halt"])
     assert result.exit_code == 0
     assert mock_subproc.call_count >= 2
     assert any(
@@ -1385,7 +1385,7 @@ def test_reload_env(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -1397,7 +1397,7 @@ def test_reload_env(
         ),
     )
 
-    result = runner.invoke(cli, ["reload", "env"])
+    result = runner.invoke(cli, ["env", "reload"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -1430,7 +1430,7 @@ def test_reload_env_env_not_started(
         ),
     )
 
-    result = runner.invoke(cli, ["reload", "env"])
+    result = runner.invoke(cli, ["env", "reload"])
     assert result.exit_code != 0
     mock_subproc.assert_not_called()
 
@@ -1457,7 +1457,7 @@ def test_status_env(
         ),
     )
 
-    result = runner.invoke(cli, ["status", "env"])
+    result = runner.invoke(cli, ["env", "status"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -1474,7 +1474,7 @@ def test_probe_render(
     shpd_config = read_fixture("env_docker", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "probe", "db-ready", "-oyaml"])
+    result = runner.invoke(cli, ["probe", "get", "db-ready", "-oyaml"])
     assert result.exit_code == 0
 
     expected = """
@@ -1515,7 +1515,7 @@ def test_probe_render_resolved(
     shpd_config = read_fixture("env_docker", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "probe", "db-ready", "-oyaml", "-r"])
+    result = runner.invoke(cli, ["probe", "get", "db-ready", "-oyaml", "-r"])
     assert result.exit_code == 0
 
     expected = """
@@ -1556,7 +1556,7 @@ def test_probe_render_target(
     shpd_config = read_fixture("env_docker", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "probe", "db-ready", "-oyaml", "-t"])
+    result = runner.invoke(cli, ["probe", "get", "db-ready", "-oyaml", "-t"])
     assert result.exit_code == 0
 
     expected = """
@@ -1589,7 +1589,7 @@ def test_probe_render_target_resolved(
     shpd_yaml.write_text(shpd_config)
 
     result = runner.invoke(
-        cli, ["get", "probe", "db-ready", "-oyaml", "-t", "-r"]
+        cli, ["probe", "get", "db-ready", "-oyaml", "-t", "-r"]
     )
     assert result.exit_code == 0
 
@@ -1624,7 +1624,7 @@ def test_check_probe(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
     assert result.exit_code == 0
 
     mock_subproc = mocker.patch(
@@ -1637,7 +1637,7 @@ def test_check_probe(
         ),
     )
 
-    result = runner.invoke(cli, ["check", "probe"])
+    result = runner.invoke(cli, ["probe", "check"])
     assert result.exit_code == 0
     mock_subproc.assert_called()
 
@@ -1664,7 +1664,7 @@ def test_check_prob_env_not_started(
         ),
     )
 
-    result = runner.invoke(cli, ["check", "probe"])
+    result = runner.invoke(cli, ["probe", "check"])
     assert result.exit_code != 0
     mock_subproc.assert_not_called()
 
@@ -1683,7 +1683,7 @@ def test_check_probe_flag_verbose(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
     assert result.exit_code == 0
 
     mock_subproc = mocker.patch(
@@ -1696,7 +1696,7 @@ def test_check_probe_flag_verbose(
         ),
     )
 
-    result = runner.invoke(cli, ["-v", "check", "probe"])
+    result = runner.invoke(cli, ["-v", "probe", "check"])
     assert result.exit_code == 0
     mock_subproc.assert_called()
 
@@ -1715,7 +1715,7 @@ def test_check_probe_with_probe_tag(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
     assert result.exit_code == 0
 
     mock_subproc = mocker.patch(
@@ -1728,7 +1728,7 @@ def test_check_probe_with_probe_tag(
         ),
     )
 
-    result = runner.invoke(cli, ["check", "probe", "db-ready"])
+    result = runner.invoke(cli, ["probe", "check", "db-ready"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -1747,7 +1747,7 @@ def test_check_probe_with_missing_probe_tag(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
     assert result.exit_code == 0
 
     mock_subproc = mocker.patch(
@@ -1760,7 +1760,7 @@ def test_check_probe_with_missing_probe_tag(
         ),
     )
 
-    result = runner.invoke(cli, ["check", "probe", "no-such-probe"])
+    result = runner.invoke(cli, ["probe", "check", "no-such-probe"])
     assert result.exit_code == 1
     assert "Probe 'no-such-probe' not found" in result.output
     mock_subproc.assert_not_called()
@@ -1779,7 +1779,7 @@ def test_check_probe_timeout(
 
     mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
     assert result.exit_code == 0
 
     # 2) "check probe" triggers timeout
@@ -1790,7 +1790,7 @@ def test_check_probe_timeout(
         ),
     )
 
-    result = runner.invoke(cli, ["check", "probe", "db-ready"])
+    result = runner.invoke(cli, ["probe", "check", "db-ready"])
 
     assert result.exit_code != 0
     mock_subproc.assert_called_once()

--- a/src/tests/test_environment.py
+++ b/src/tests/test_environment.py
@@ -55,7 +55,7 @@ def test_add_env(
     runner: CliRunner,
     mocker: MockerFixture,
 ):
-    result = runner.invoke(cli, ["add", "env", "default", "test-init-1"])
+    result = runner.invoke(cli, ["env", "add", "default", "test-init-1"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
@@ -75,11 +75,11 @@ def test_clone_env(
     runner: CliRunner,
     mocker: MockerFixture,
 ):
-    result = runner.invoke(cli, ["add", "env", "default", "test-clone-1"])
+    result = runner.invoke(cli, ["env", "add", "default", "test-clone-1"])
     assert result.exit_code == 0
 
     result = runner.invoke(
-        cli, ["clone", "env", "test-clone-1", "test-clone-2"]
+        cli, ["env", "clone", "test-clone-1", "test-clone-2"]
     )
     assert result.exit_code == 0
 
@@ -104,11 +104,11 @@ def test_rename_env(
     runner: CliRunner,
     mocker: MockerFixture,
 ):
-    result = runner.invoke(cli, ["add", "env", "default", "test-rename-1"])
+    result = runner.invoke(cli, ["env", "add", "default", "test-rename-1"])
     assert result.exit_code == 0
 
     result = runner.invoke(
-        cli, ["rename", "env", "test-rename-1", "test-rename-2"]
+        cli, ["env", "rename", "test-rename-1", "test-rename-2"]
     )
     assert result.exit_code == 0
 
@@ -133,17 +133,17 @@ def test_checkout_env(
     runner: CliRunner,
     mocker: MockerFixture,
 ):
-    result = runner.invoke(cli, ["add", "env", "default", "test-1"])
+    result = runner.invoke(cli, ["env", "add", "default", "test-1"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["add", "env", "default", "test-2"])
+    result = runner.invoke(cli, ["env", "add", "default", "test-2"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
     env = sm.configMng.get_active_environment()
     assert env is None
 
-    result = runner.invoke(cli, ["checkout", "test-1"])
+    result = runner.invoke(cli, ["env", "checkout", "test-1"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
@@ -151,7 +151,7 @@ def test_checkout_env(
     assert env is not None
     assert env.tag == "test-1"
 
-    result = runner.invoke(cli, ["checkout", "test-2"])
+    result = runner.invoke(cli, ["env", "checkout", "test-2"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
@@ -166,10 +166,10 @@ def test_list_env(
     runner: CliRunner,
     mocker: MockerFixture,
 ):
-    result = runner.invoke(cli, ["add", "env", "default", "test-1"])
+    result = runner.invoke(cli, ["env", "add", "default", "test-1"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["list"])
+    result = runner.invoke(cli, ["env", "list"])
     assert result.exit_code == 0
 
 
@@ -183,7 +183,7 @@ def test_get_env_json(
     shpd_config = read_fixture("env", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "env", "test-1", "--output", "json"])
+    result = runner.invoke(cli, ["env", "get", "test-1", "--output", "json"])
 
     assert result.exit_code == 0
 
@@ -201,18 +201,18 @@ def test_delete_env_yes(
 ):
     mocker.patch("builtins.input", return_value="y")
 
-    result = runner.invoke(cli, ["add", "env", "default", "test-1"])
+    result = runner.invoke(cli, ["env", "add", "default", "test-1"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["delete", "env", "test-1"])
+    result = runner.invoke(cli, ["env", "delete", "test-1"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["add", "env", "default", "test-1"])
+    result = runner.invoke(cli, ["env", "add", "default", "test-1"])
     assert result.exit_code == 0
 
     mocker.patch("builtins.input", return_value="y")
 
-    result = runner.invoke(cli, ["delete", "env", "test-1"])
+    result = runner.invoke(cli, ["env", "delete", "test-1"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
@@ -234,10 +234,10 @@ def test_delete_env_no(
 ):
     mocker.patch("builtins.input", return_value="n")
 
-    result = runner.invoke(cli, ["add", "env", "default", "test-1"])
+    result = runner.invoke(cli, ["env", "add", "default", "test-1"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["delete", "env", "test-1"])
+    result = runner.invoke(cli, ["env", "delete", "test-1"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
@@ -257,11 +257,11 @@ def test_add_nonexisting_service(
     runner: CliRunner,
     mocker: MockerFixture,
 ):
-    result = runner.invoke(cli, ["add", "env", "default", "test-svc-add"])
+    result = runner.invoke(cli, ["env", "add", "default", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["checkout", "test-svc-add"])
+    result = runner.invoke(cli, ["env", "checkout", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["add", "svc", "foo", "foo-1"])
+    result = runner.invoke(cli, ["svc", "add", "foo", "foo-1"])
     assert result.exit_code == 1

--- a/src/tests/test_service.py
+++ b/src/tests/test_service.py
@@ -58,13 +58,13 @@ def runner() -> CliRunner:
 def test_add_svc_one_default(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
-    result = runner.invoke(cli, ["add", "env", "default", "test-svc-add"])
+    result = runner.invoke(cli, ["env", "add", "default", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["checkout", "test-svc-add"])
+    result = runner.invoke(cli, ["env", "checkout", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["add", "svc", "default", "svc-1"])
+    result = runner.invoke(cli, ["svc", "add", "default", "svc-1"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
@@ -123,16 +123,16 @@ def test_add_svc_one_default(
 def test_add_svc_two_default(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
-    result = runner.invoke(cli, ["add", "env", "default", "test-svc-add"])
+    result = runner.invoke(cli, ["env", "add", "default", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["checkout", "test-svc-add"])
+    result = runner.invoke(cli, ["env", "checkout", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["add", "svc", "default", "svc-1"])
+    result = runner.invoke(cli, ["svc", "add", "default", "svc-1"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["add", "svc", "default", "svc-2"])
+    result = runner.invoke(cli, ["svc", "add", "default", "svc-2"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
@@ -188,16 +188,16 @@ def test_add_svc_two_default(
 def test_get_svc_json(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
-    result = runner.invoke(cli, ["add", "env", "default", "test-svc-json"])
+    result = runner.invoke(cli, ["env", "add", "default", "test-svc-json"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["checkout", "test-svc-json"])
+    result = runner.invoke(cli, ["env", "checkout", "test-svc-json"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["add", "svc", "default", "svc-1"])
+    result = runner.invoke(cli, ["svc", "add", "default", "svc-1"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["get", "svc", "svc-1", "--output", "json"])
+    result = runner.invoke(cli, ["svc", "get", "svc-1", "--output", "json"])
     assert result.exit_code == 0
 
     sm = ShepherdMng()
@@ -212,16 +212,16 @@ def test_get_svc_json(
 def test_add_svc_two_same_tag_default(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):
-    result = runner.invoke(cli, ["add", "env", "default", "test-svc-add"])
+    result = runner.invoke(cli, ["env", "add", "default", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["checkout", "test-svc-add"])
+    result = runner.invoke(cli, ["env", "checkout", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["add", "svc", "default", "svc-1"])
+    result = runner.invoke(cli, ["svc", "add", "default", "svc-1"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["add", "svc", "default", "svc-1"])
+    result = runner.invoke(cli, ["svc", "add", "default", "svc-1"])
     assert result.exit_code == 1
 
     sm = ShepherdMng()
@@ -261,13 +261,13 @@ def test_add_svc_one_with_template(
     shpd_config = read_fixture("svc", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["add", "env", "default", "test-svc-add"])
+    result = runner.invoke(cli, ["env", "add", "default", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["checkout", "test-svc-add"])
+    result = runner.invoke(cli, ["env", "checkout", "test-svc-add"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli, ["add", "svc", "postgres", "pg-1", "database"])
+    result = runner.invoke(cli, ["svc", "add", "postgres", "pg-1", "database"])
 
     # no 'postgres' factory, so this should fail
     assert result.exit_code == 1

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -193,7 +193,7 @@ def test_get_env_flags_details(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "env", "test-1", "--details"])
+    result = runner.invoke(cli, ["env", "get", "test-1", "--details"])
     assert result.exit_code == 0
 
 
@@ -219,7 +219,7 @@ def test_get_svc_flags_details(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "svc", "test", "--details"])
+    result = runner.invoke(cli, ["svc", "get", "test", "--details"])
     assert result.exit_code == 0
 
 
@@ -244,7 +244,7 @@ def test_status_flags_show_commands(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["status", "--show-commands"])
+    result = runner.invoke(cli, ["env", "status", "--show-commands"])
     assert result.exit_code == 0
 
 
@@ -269,7 +269,7 @@ def test_reload_flags_show_commands_limit(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["reload", "env", "--show-commands-limit", "8"])
+    result = runner.invoke(cli, ["env", "reload", "--show-commands-limit", "8"])
     assert result.exit_code == 0
 
 
@@ -279,7 +279,7 @@ def test_cli_get_env_by_gate_requires_output(
 ):
     mocker.patch.object(ShepherdMng, "__init__", return_value=None)
 
-    result = runner.invoke(cli, ["get", "env", "--by-gate"])
+    result = runner.invoke(cli, ["env", "get", "--by-gate"])
 
     assert result.exit_code != 0
     assert (
@@ -293,7 +293,7 @@ def test_cli_get_env_by_gate_requires_target_when_output_present(
 ):
     mocker.patch.object(ShepherdMng, "__init__", return_value=None)
 
-    result = runner.invoke(cli, ["get", "env", "--output", "yaml", "--by-gate"])
+    result = runner.invoke(cli, ["env", "get", "--output", "yaml", "--by-gate"])
 
     assert result.exit_code != 0
     assert "--by-gate requires --target" in result.output
@@ -304,15 +304,15 @@ def test_cli_get_env_by_gate_requires_target_when_output_present(
     ("args", "expected_message"),
     [
         (
-            ["get", "env", "test-1", "--target"],
+            ["env", "get", "test-1", "--target"],
             "--target, --resolved, and --by-gate require --output",
         ),
         (
-            ["get", "env", "test-1", "--resolved"],
+            ["env", "get", "test-1", "--resolved"],
             "--target, --resolved, and --by-gate require --output",
         ),
         (
-            ["get", "env", "test-1", "--target", "--by-gate"],
+            ["env", "get", "test-1", "--target", "--by-gate"],
             "--target, --resolved, and --by-gate require --output",
         ),
     ],
@@ -344,7 +344,7 @@ def test_cli_get_env_without_output_describes_env(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "env", "test-1"])
+    result = runner.invoke(cli, ["env", "get", "test-1"])
 
     assert result.exit_code == 0
     describe_env.assert_called_once_with("test-1")
@@ -365,7 +365,7 @@ def test_cli_get_env_with_output_renders_env(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "env", "test-1", "--output", "yaml"])
+    result = runner.invoke(cli, ["env", "get", "test-1", "--output", "yaml"])
 
     assert result.exit_code == 0
     assert "env-yaml" in result.output
@@ -400,7 +400,7 @@ def test_cli_build_svc(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["build", "service_tag"])
+    result = runner.invoke(cli, ["svc", "build", "service_tag"])
     assert result.exit_code == 0
     mock_build.assert_called_once()
 
@@ -417,7 +417,7 @@ def test_cli_get_svc_without_output_describes_svc(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "svc", "test"])
+    result = runner.invoke(cli, ["svc", "get", "test"])
 
     assert result.exit_code == 0
     describe_svc.assert_called_once()
@@ -428,8 +428,8 @@ def test_cli_get_svc_without_output_describes_svc(
 @pytest.mark.parametrize(
     "args",
     [
-        ["get", "svc", "test", "--target"],
-        ["get", "svc", "test", "--resolved"],
+        ["svc", "get", "test", "--target"],
+        ["svc", "get", "test", "--resolved"],
     ],
 )
 def test_cli_get_svc_render_flags_require_output(
@@ -464,7 +464,7 @@ def test_cli_get_svc_with_output_renders_svc(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "svc", "test", "--output", "yaml"])
+    result = runner.invoke(cli, ["svc", "get", "test", "--output", "yaml"])
 
     assert result.exit_code == 0
     assert "svc-yaml" in result.output
@@ -485,7 +485,7 @@ def test_cli_start_svc(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["up", "svc", "service_tag"])
+    result = runner.invoke(cli, ["svc", "up", "service_tag"])
     assert result.exit_code == 0
     mock_start.assert_called_once()
 
@@ -501,7 +501,7 @@ def test_cli_stop_svc(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["halt", "svc", "service_tag"])
+    result = runner.invoke(cli, ["svc", "halt", "service_tag"])
     assert result.exit_code == 0
     mock_stop.assert_called_once()
 
@@ -517,7 +517,7 @@ def test_cli_reload_svc(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["reload", "svc", "service_tag"])
+    result = runner.invoke(cli, ["svc", "reload", "service_tag"])
     assert result.exit_code == 0
     mock_reload.assert_called_once()
 
@@ -533,7 +533,7 @@ def test_cli_logs_svc(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["logs", "service_tag"])
+    result = runner.invoke(cli, ["svc", "logs", "service_tag"])
     assert result.exit_code == 0
     mock_logs.assert_called_once()
 
@@ -549,7 +549,7 @@ def test_cli_shell_svc(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["shell", "service_tag"])
+    result = runner.invoke(cli, ["svc", "shell", "service_tag"])
     assert result.exit_code == 0
     mock_shell.assert_called_once()
 
@@ -563,7 +563,7 @@ def test_cli_add_env(
 ):
     mock_add = mocker.patch.object(EnvironmentMng, "add_env")
 
-    result = runner.invoke(cli, ["add", "env", "docker-compose", "env_tag"])
+    result = runner.invoke(cli, ["env", "add", "docker-compose", "env_tag"])
     assert result.exit_code == 0
     mock_add.assert_called_once_with("docker-compose", "env_tag")
 
@@ -574,7 +574,7 @@ def test_cli_clone_env(
 ):
     mock_clone = mocker.patch.object(EnvironmentMng, "clone_env")
 
-    result = runner.invoke(cli, ["clone", "env", "src_env_tag", "dst_env_tag"])
+    result = runner.invoke(cli, ["env", "clone", "src_env_tag", "dst_env_tag"])
     assert result.exit_code == 0
     mock_clone.assert_called_once_with("src_env_tag", "dst_env_tag")
 
@@ -585,7 +585,7 @@ def test_cli_checkout_env(
 ):
     mock_checkout = mocker.patch.object(EnvironmentMng, "checkout_env")
 
-    result = runner.invoke(cli, ["checkout", "env_tag"])
+    result = runner.invoke(cli, ["env", "checkout", "env_tag"])
     assert result.exit_code == 0
     mock_checkout.assert_called_once_with("env_tag")
 
@@ -596,7 +596,7 @@ def test_cli_list_env(
 ):
     mock_list = mocker.patch.object(EnvironmentMng, "list_envs")
 
-    result = runner.invoke(cli, ["list"])
+    result = runner.invoke(cli, ["env", "list"])
     assert result.exit_code == 0
     mock_list.assert_called_once()
 
@@ -612,7 +612,7 @@ def test_cli_start_env(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
     assert result.exit_code == 0
     mock_start.assert_called_once_with(
         mocker.ANY, timeout_seconds=60, watch=False
@@ -630,7 +630,7 @@ def test_cli_start_env_watch(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["up", "env", "--watch"])
+    result = runner.invoke(cli, ["env", "up", "--watch"])
     assert result.exit_code == 0
     mock_start.assert_called_once_with(
         mocker.ANY, timeout_seconds=60, watch=True
@@ -648,7 +648,7 @@ def test_cli_start_env_with_timeout(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["up", "env", "--timeout", "30"])
+    result = runner.invoke(cli, ["env", "up", "--timeout", "30"])
     assert result.exit_code == 0
     mock_start.assert_called_once()
     assert mock_start.call_args.kwargs == {
@@ -668,7 +668,7 @@ def test_cli_stop_env(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["halt", "env"])
+    result = runner.invoke(cli, ["env", "halt"])
     assert result.exit_code == 0
     mock_stop.assert_called_once_with(mocker.ANY, wait=True)
 
@@ -684,7 +684,7 @@ def test_cli_stop_env_no_wait(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["halt", "env", "--no-wait"])
+    result = runner.invoke(cli, ["env", "halt", "--no-wait"])
     assert result.exit_code == 0
     mock_stop.assert_called_once_with(mocker.ANY, wait=False)
 
@@ -700,7 +700,7 @@ def test_cli_reload_env(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["reload", "env"])
+    result = runner.invoke(cli, ["env", "reload"])
     assert result.exit_code == 0
     mock_reload.assert_called_once_with(mocker.ANY, watch=False)
 
@@ -716,7 +716,7 @@ def test_cli_reload_env_watch(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["reload", "env", "--watch"])
+    result = runner.invoke(cli, ["env", "reload", "--watch"])
     assert result.exit_code == 0
     mock_reload.assert_called_once_with(mocker.ANY, watch=True)
 
@@ -732,7 +732,7 @@ def test_cli_status_env(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["status", "env"])
+    result = runner.invoke(cli, ["env", "status"])
     assert result.exit_code == 0
     mock_status.assert_called_once_with(mocker.ANY, watch=False)
 
@@ -748,7 +748,7 @@ def test_cli_status_env_watch(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["status", "env", "--watch"])
+    result = runner.invoke(cli, ["env", "status", "--watch"])
     assert result.exit_code == 0
     mock_status.assert_called_once_with(mocker.ANY, watch=True)
 
@@ -764,7 +764,7 @@ def test_cli_status_watch_default(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["status", "--watch"])
+    result = runner.invoke(cli, ["env", "status", "--watch"])
     assert result.exit_code == 0
     mock_status.assert_called_once_with(mocker.ANY, watch=True)
 
@@ -783,7 +783,7 @@ def test_cli_get_probe_no_args(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "probe"])
+    result = runner.invoke(cli, ["probe", "get"])
     assert result.exit_code == 0
     render_probes.assert_called_once()
 
@@ -799,7 +799,7 @@ def test_cli_get_probe_flag_output(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "probe", "--output", "json"])
+    result = runner.invoke(cli, ["probe", "get", "--output", "json"])
     assert result.exit_code == 0
     render_probes.assert_called_once()
 
@@ -816,7 +816,7 @@ def test_cli_get_probe_flag_target(
     shpd_yaml.write_text(shpd_config)
 
     result = runner.invoke(
-        cli, ["get", "probe", "--output", "json", "--target"]
+        cli, ["probe", "get", "--output", "json", "--target"]
     )
     assert result.exit_code == 0
     render_probes.assert_called_once()
@@ -834,7 +834,7 @@ def test_cli_get_probe_flag_resolved(
     shpd_yaml.write_text(shpd_config)
 
     result = runner.invoke(
-        cli, ["get", "probe", "--output", "json", "--resolved"]
+        cli, ["probe", "get", "--output", "json", "--resolved"]
     )
     assert result.exit_code == 0
     render_probes.assert_called_once()
@@ -851,7 +851,7 @@ def test_cli_get_probe_flag_all(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "probe", "--all"])
+    result = runner.invoke(cli, ["probe", "get", "--all"])
     assert result.exit_code == 0
     render_probes.assert_called_once()
 
@@ -867,7 +867,7 @@ def test_cli_get_probe_flag_all_with_probe_tag(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "probe", "db-ready", "--all"])
+    result = runner.invoke(cli, ["probe", "get", "db-ready", "--all"])
     assert result.exit_code == 0
     render_probes.assert_called_once()
 
@@ -883,7 +883,7 @@ def test_cli_get_probe_with_probe_tag(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "probe", "db-ready"])
+    result = runner.invoke(cli, ["probe", "get", "db-ready"])
     assert result.exit_code == 0
     render_probes.assert_called_once()
 
@@ -901,7 +901,7 @@ def test_cli_check_probe_no_args(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["check", "probe"])
+    result = runner.invoke(cli, ["probe", "check"])
     assert result.exit_code == 0
     check_probes.assert_called_once()
 
@@ -919,7 +919,7 @@ def test_cli_check_probe_with_probe_tag(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["check", "probe", "db-ready"])
+    result = runner.invoke(cli, ["probe", "check", "db-ready"])
     assert result.exit_code == 0
     check_probes.assert_called_once()
 
@@ -937,7 +937,7 @@ def test_cli_check_probe_with_probe_tag_failed(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["check", "probe", "db-ready"])
+    result = runner.invoke(cli, ["probe", "check", "db-ready"])
     assert result.exit_code == 1
     check_probes.assert_called_once()
 
@@ -955,7 +955,7 @@ def test_cli_check_probe_flag_all(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["check", "probe", "--all"])
+    result = runner.invoke(cli, ["probe", "check", "--all"])
     assert result.exit_code == 0
     check_probes.assert_called_once()
 
@@ -973,6 +973,6 @@ def test_cli_check_probe_flag_all_with_probe_tag(
     shpd_config = read_fixture("shpd", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["check", "probe", "db-ready", "--all"])
+    result = runner.invoke(cli, ["probe", "check", "db-ready", "--all"])
     assert result.exit_code == 0
     check_probes.assert_called_once()

--- a/src/tests/test_svc_docker_compose.py
+++ b/src/tests/test_svc_docker_compose.py
@@ -105,7 +105,7 @@ def test_svc_render_default_compose_service(
     shpd_config = read_fixture("svc_docker", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "svc", "test", "-oyaml"])
+    result = runner.invoke(cli, ["svc", "get", "test", "-oyaml"])
     assert result.exit_code == 0
 
     expected = (
@@ -164,7 +164,7 @@ def test_svc_render_default_compose_service_resolved(
     shpd_config = read_fixture("svc_docker", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "svc", "test", "-oyaml", "-r"])
+    result = runner.invoke(cli, ["svc", "get", "test", "-oyaml", "-r"])
     assert result.exit_code == 0
 
     expected = (
@@ -223,7 +223,7 @@ def test_svc_render_target_compose_service(
     shpd_config = read_fixture("svc_docker", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    result = runner.invoke(cli, ["get", "svc", "test", "-oyaml", "-t"])
+    result = runner.invoke(cli, ["svc", "get", "test", "-oyaml", "-t"])
     assert result.exit_code == 0
 
     expected = (
@@ -272,7 +272,7 @@ def test_start_svc(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -284,7 +284,7 @@ def test_start_svc(
         ),
     )
 
-    result = runner.invoke(cli, ["up", "svc", "test"])
+    result = runner.invoke(cli, ["svc", "up", "test"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -303,7 +303,7 @@ def test_start_svc_cnt_2(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -315,7 +315,7 @@ def test_start_svc_cnt_2(
         ),
     )
 
-    result = runner.invoke(cli, ["up", "svc", "test-1", "container-2"])
+    result = runner.invoke(cli, ["svc", "up", "test-1", "container-2"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -334,7 +334,7 @@ def test_stop_svc(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -346,7 +346,7 @@ def test_stop_svc(
         ),
     )
 
-    result = runner.invoke(cli, ["halt", "svc", "test"])
+    result = runner.invoke(cli, ["svc", "halt", "test"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -365,7 +365,7 @@ def test_stop_svc_cnt_2(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -377,7 +377,7 @@ def test_stop_svc_cnt_2(
         ),
     )
 
-    result = runner.invoke(cli, ["halt", "svc", "test-1", "container-2"])
+    result = runner.invoke(cli, ["svc", "halt", "test-1", "container-2"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -396,7 +396,7 @@ def test_reload_svc(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -408,7 +408,7 @@ def test_reload_svc(
         ),
     )
 
-    result = runner.invoke(cli, ["reload", "svc", "test"])
+    result = runner.invoke(cli, ["svc", "reload", "test"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -427,7 +427,7 @@ def test_reload_svc_cnt_2(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -439,7 +439,7 @@ def test_reload_svc_cnt_2(
         ),
     )
 
-    result = runner.invoke(cli, ["reload", "svc", "test-1", "container-2"])
+    result = runner.invoke(cli, ["svc", "reload", "test-1", "container-2"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -458,7 +458,7 @@ def test_logs_svc(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -470,7 +470,7 @@ def test_logs_svc(
         ),
     )
 
-    result = runner.invoke(cli, ["logs", "test"])
+    result = runner.invoke(cli, ["svc", "logs", "test"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -489,7 +489,7 @@ def test_logs_svc_cnt_2(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -501,7 +501,7 @@ def test_logs_svc_cnt_2(
         ),
     )
 
-    result = runner.invoke(cli, ["logs", "test-1", "container-2"])
+    result = runner.invoke(cli, ["svc", "logs", "test-1", "container-2"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -520,7 +520,7 @@ def test_shell_svc(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -532,7 +532,7 @@ def test_shell_svc(
         ),
     )
 
-    result = runner.invoke(cli, ["shell", "test"])
+    result = runner.invoke(cli, ["svc", "shell", "test"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -551,7 +551,7 @@ def test_shell_svc_cnt_2(
 
     mock_subproc = mock_subprocess_with_running_ps(mocker)
 
-    result = runner.invoke(cli, ["up", "env"])
+    result = runner.invoke(cli, ["env", "up"])
 
     mock_subproc = mocker.patch(
         "docker.docker_compose_util.subprocess.run",
@@ -563,7 +563,7 @@ def test_shell_svc_cnt_2(
         ),
     )
 
-    result = runner.invoke(cli, ["shell", "test-1", "container-2"])
+    result = runner.invoke(cli, ["svc", "shell", "test-1", "container-2"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -590,7 +590,7 @@ def test_build_svc(
         ),
     )
 
-    result = runner.invoke(cli, ["build", "test"])
+    result = runner.invoke(cli, ["svc", "build", "test"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -617,7 +617,7 @@ def test_build_svc_cnt_2(
         ),
     )
 
-    result = runner.invoke(cli, ["build", "test-1", "container-2"])
+    result = runner.invoke(cli, ["svc", "build", "test-1", "container-2"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
 
@@ -644,7 +644,7 @@ def test_build_svc_missing_build(
         ),
     )
 
-    result = runner.invoke(cli, ["build", "test-1"])
+    result = runner.invoke(cli, ["svc", "build", "test-1"])
     assert result.exit_code == 1
     mock_subproc.assert_not_called()
 
@@ -671,7 +671,7 @@ def test_build_svc_missing_build_dockerfile(
         ),
     )
 
-    result = runner.invoke(cli, ["build", "test-2"])
+    result = runner.invoke(cli, ["svc", "build", "test-2"])
     assert result.exit_code == 1
     mock_subproc.assert_not_called()
 
@@ -698,7 +698,7 @@ def test_build_svc_missing_build_context_path(
         ),
     )
 
-    result = runner.invoke(cli, ["build", "test-3"])
+    result = runner.invoke(cli, ["svc", "build", "test-3"])
     assert result.exit_code == 1
     mock_subproc.assert_not_called()
 
@@ -725,6 +725,6 @@ def test_build_svc_dockerfile_does_not_exist(
         ),
     )
 
-    result = runner.invoke(cli, ["build", "test-4"])
+    result = runner.invoke(cli, ["svc", "build", "test-4"])
     assert result.exit_code == 1
     mock_subproc.assert_not_called()


### PR DESCRIPTION
## Summary
- refactor the core CLI from verb-scope to scope-verb
- reshape completion routing around env, svc, and probe scopes
- update CLI docs and the full test suite to the new command paths

## Details
- move core Click commands under the env, svc, and probe scopes
- update the completion router and scope-specific completion managers to route by scope first
- migrate all CLI-facing tests and docs to the new command tree

## Testing
- .venv/bin/python src/shepctl.py --help
- .venv/bin/pytest src/tests/test_shepherd.py src/tests/test_completion.py
- cd src && ../.venv/bin/pytest

Fixes: #169