### PR TITLE
feat(config): add plugin config model and descriptor parsing

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,127 @@
+# Plugins
+
+This document describes the plugin model being introduced in Shepherd.
+
+The current implementation scope is limited to:
+
+- plugin descriptor format
+- plugin inventory persisted in the main Shepherd config
+- managed plugin installation directory layout
+
+Runtime loading, command extension, completion extension, and factory/template
+registration are introduced in later steps of the plugin rollout.
+
+For the architectural rationale and staged implementation plan, see
+[ADR 0004](decisions/0004-plugin-architecture-and-rollout-plan.md).
+
+## Managed Plugin Layout
+
+Plugins are not loaded from arbitrary filesystem paths.
+
+Shepherd reserves a managed plugin root under the local Shepherd home:
+
+```text
+~/.shpd/plugins/<plugin-id>/
+```
+
+The install directory is derived from the managed root and the plugin id. It is
+not persisted as a free-form path in the main config.
+
+This keeps plugin discovery deterministic and avoids config drift caused by
+external paths moving or disappearing.
+
+## Plugin Inventory In Config
+
+The main Shepherd config persists the plugin inventory and state.
+
+Example:
+
+```yaml
+plugins:
+  - id: acme
+    enabled: true
+    version: 1.2.3
+    config:
+      region: eu-west-1
+      enabled_feature: true
+```
+
+Fields:
+
+- `id`: stable plugin identifier
+- `enabled`: whether the plugin should be loaded at startup
+- `version`: installed plugin version
+- `config`: optional plugin-specific configuration stored in the main config
+
+`enabled` follows the same bool-like config handling used by other Shepherd
+config fields. YAML booleans are normalized, and placeholders such as
+`${PLUGIN_ENABLED}` are preserved until resolution time.
+
+## Plugin Descriptor
+
+Each installed plugin ships a descriptor that defines its metadata and
+entrypoint.
+
+Example:
+
+```yaml
+id: acme
+name: Acme Plugin
+version: 1.2.3
+plugin_api_version: 1
+description: Extra envs and services for Acme stacks
+entrypoint:
+  module: plugin.main
+  class: AcmePlugin
+capabilities:
+  templates: true
+  commands: true
+  completion: true
+  env_factories: true
+  svc_factories: true
+default_config:
+  region: eu-west-1
+```
+
+Required fields:
+
+- `id`
+- `name`
+- `version`
+- `plugin_api_version`
+- `entrypoint.module`
+- `entrypoint.class`
+
+Optional fields:
+
+- `description`
+- `capabilities`
+- `default_config`
+
+Capability flags must be real YAML booleans. String values such as `"false"` or
+`"0"` are rejected during descriptor validation.
+
+## Current Validation Rules
+
+The descriptor parser validates:
+
+- required metadata presence
+- entrypoint presence
+- capabilities as a mapping
+- capability values as actual booleans
+
+Invalid descriptors fail validation early, before runtime plugin loading is
+introduced.
+
+## Scope Of This Step
+
+This documentation matches the current implementation step. At this stage,
+Shepherd does not yet:
+
+- install plugin archives through `shepctl plugin ...`
+- import plugin Python entrypoints with `importlib`
+- load plugin commands into the CLI
+- load plugin completion providers
+- register plugin factories or templates at runtime
+
+Those capabilities are added in follow-up PRs from the plugin rollout plan.

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -21,17 +21,25 @@ from .config import (
     ConfigMng,
     EnvironmentCfg,
     EnvironmentTemplateCfg,
+    PluginCfg,
+    PluginDescriptorCfg,
     ServiceCfg,
     ServiceTemplateCfg,
     UpstreamCfg,
+    parse_config,
+    parse_plugin_descriptor,
 )
 
 __all__ = [
     "Config",
     "EnvironmentTemplateCfg",
     "EnvironmentCfg",
+    "PluginCfg",
+    "PluginDescriptorCfg",
     "ServiceTemplateCfg",
     "ServiceCfg",
     "UpstreamCfg",
     "ConfigMng",
+    "parse_config",
+    "parse_plugin_descriptor",
 ]

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -787,6 +787,41 @@ class StagingAreaCfg(Resolvable):
 
 
 @dataclass
+class PluginCfg(Resolvable):
+    """Represents one installed plugin entry in the main config."""
+
+    id: str
+    enabled: str = field(default="true", metadata={"boolify": True})
+    version: Optional[str] = None
+    config: Optional[dict[str, Any]] = None
+
+    def is_enabled(self) -> bool:
+        return str_to_bool(self.enabled)
+
+
+@dataclass
+class PluginEntrypointCfg(Resolvable):
+    """Represents the importable entrypoint declared by a plugin."""
+
+    module: str
+    class_name: str
+
+
+@dataclass
+class PluginDescriptorCfg(Resolvable):
+    """Represents the install-time plugin descriptor."""
+
+    id: str
+    name: str
+    version: str
+    plugin_api_version: int
+    entrypoint: PluginEntrypointCfg
+    description: Optional[str] = None
+    capabilities: Optional[dict[str, bool]] = None
+    default_config: Optional[dict[str, Any]] = None
+
+
+@dataclass
 class Config(Resolvable):
     """
     Represents the shepherd configuration.
@@ -798,7 +833,61 @@ class Config(Resolvable):
     staging_area: StagingAreaCfg
     env_templates: Optional[list[EnvironmentTemplateCfg]] = None
     service_templates: Optional[list[ServiceTemplateCfg]] = None
+    plugins: Optional[list[PluginCfg]] = None
     envs: list[EnvironmentCfg] = field(default_factory=list[EnvironmentCfg])
+
+
+def parse_plugin_descriptor(yaml_str: str) -> PluginDescriptorCfg:
+    """
+    Parse a plugin descriptor YAML into the strongly typed descriptor model.
+    """
+
+    data = yaml.safe_load(yaml_str)
+    if not isinstance(data, dict):
+        raise ValueError("Plugin descriptor must be a YAML mapping.")
+    descriptor = cast(dict[str, Any], data)
+
+    entrypoint = descriptor.get("entrypoint")
+    if not isinstance(entrypoint, dict):
+        raise ValueError("Plugin descriptor must declare an entrypoint.")
+    entrypoint_cfg = cast(dict[str, Any], entrypoint)
+
+    normalized_capabilities: Optional[dict[str, bool]]
+    capabilities = descriptor.get("capabilities")
+    if capabilities is not None:
+        if not isinstance(capabilities, dict):
+            raise ValueError("Plugin capabilities must be a mapping.")
+        capabilities_cfg = cast(dict[str, Any], capabilities)
+        capabilities_map: dict[str, bool] = {}
+        for key, value in capabilities_cfg.items():
+            if not isinstance(value, bool):
+                raise ValueError("Plugin capability values must be booleans.")
+            capabilities_map[str(key)] = value
+        normalized_capabilities = capabilities_map
+    else:
+        normalized_capabilities = None
+
+    default_config = descriptor.get("default_config")
+    if default_config is not None and not isinstance(default_config, dict):
+        raise ValueError("Plugin default_config must be a mapping.")
+
+    return PluginDescriptorCfg(
+        id=str(descriptor["id"]),
+        name=str(descriptor["name"]),
+        version=str(descriptor["version"]),
+        plugin_api_version=int(descriptor["plugin_api_version"]),
+        entrypoint=PluginEntrypointCfg(
+            module=str(entrypoint_cfg["module"]),
+            class_name=str(entrypoint_cfg["class"]),
+        ),
+        description=(
+            str(description)
+            if (description := descriptor.get("description")) is not None
+            else None
+        ),
+        capabilities=normalized_capabilities,
+        default_config=cast(Optional[dict[str, Any]], default_config),
+    )
 
 
 def parse_config(yaml_str: str) -> Config:
@@ -984,6 +1073,18 @@ def parse_config(yaml_str: str) -> Config:
             images_path=item["images_path"],
         )
 
+    def parse_plugin(item: Any) -> PluginCfg:
+        return PluginCfg(
+            id=item["id"],
+            enabled=(
+                bool_to_str(val)
+                if isinstance(val := item.get("enabled", True), bool)
+                else val
+            ),
+            version=item.get("version"),
+            config=item.get("config"),
+        )
+
     def parse_environment(item: Any) -> EnvironmentCfg:
         return EnvironmentCfg(
             template=item["template"],
@@ -1016,6 +1117,11 @@ def parse_config(yaml_str: str) -> Config:
         envs_path=data["envs_path"],
         volumes_path=data["volumes_path"],
         staging_area=parse_staging_area(data["staging_area"]),
+        plugins=(
+            [parse_plugin(plugin) for plugin in data.get("plugins", [])]
+            if data.get("plugins") is not None
+            else None
+        ),
         envs=[parse_environment(env) for env in data["envs"]],
     )
 
@@ -1295,6 +1401,21 @@ class ConfigMng:
             if env.tag == envTag:
                 return env
         return None
+
+    def get_plugins(self) -> list[PluginCfg]:
+        """Return the configured plugin inventory."""
+        return list(self.config.plugins or [])
+
+    def get_plugin(self, plugin_id: str) -> Optional[PluginCfg]:
+        """Return one configured plugin by id."""
+        for plugin in self.get_plugins():
+            if plugin.id == plugin_id:
+                return plugin
+        return None
+
+    def get_plugin_dir(self, plugin_id: str) -> str:
+        """Return the managed install directory for one plugin id."""
+        return os.path.join(self.constants.SHPD_PLUGINS_DIR, plugin_id)
 
     def get_environments(self) -> list[EnvironmentCfg]:
         """

--- a/src/tests/fixtures/cfg/shpd.yaml
+++ b/src/tests/fixtures/cfg/shpd.yaml
@@ -4,6 +4,13 @@ volumes_path: ${volumes_path}
 staging_area:
   volumes_path: ${staging_area_volumes_path}
   images_path: ${staging_area_images_path}
+plugins:
+  - id: acme
+    enabled: true
+    version: 1.2.3
+    config:
+      region: eu-west-1
+      enabled_feature: true
 env_templates:
   - tag: default
     factory: docker-compose

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -24,7 +24,7 @@ import yaml
 from pytest_mock import MockerFixture
 from test_util import read_fixture
 
-from config import Config, ConfigMng
+from config import Config, ConfigMng, parse_config, parse_plugin_descriptor
 from util import Constants
 
 
@@ -195,6 +195,15 @@ def test_load_config(mocker: MockerFixture):
     assert config.volumes_path == "${test_path}/volumes"
     assert config.staging_area.volumes_path == "${test_path}/sa_volumes"
     assert config.staging_area.images_path == "${test_path}/sa_images"
+    assert config.plugins is not None
+    assert config.plugins[0].id == "acme"
+    assert config.plugins[0].enabled == "true"
+    assert config.plugins[0].is_enabled() is True
+    assert config.plugins[0].version == "1.2.3"
+    assert config.plugins[0].config == {
+        "region": "eu-west-1",
+        "enabled_feature": True,
+    }
     assert config.envs[0].status.active is True
     assert config.envs[0].status.rendered_config is None
 
@@ -300,6 +309,99 @@ def test_load_config_change_resolve_status(mocker: MockerFixture):
     config.set_resolved()
     config.envs[0].get_yaml(False)
     config.envs[0].services[0].get_yaml(False)
+
+
+@pytest.mark.cfg
+def test_parse_plugin_descriptor():
+    descriptor_yaml = """
+id: acme
+name: Acme Plugin
+version: 1.2.3
+plugin_api_version: 1
+entrypoint:
+  module: plugin.main
+  class: AcmePlugin
+description: Example plugin
+capabilities:
+  templates: true
+  commands: false
+default_config:
+  region: eu-west-1
+"""
+
+    descriptor = parse_plugin_descriptor(descriptor_yaml)
+
+    assert descriptor.id == "acme"
+    assert descriptor.name == "Acme Plugin"
+    assert descriptor.version == "1.2.3"
+    assert descriptor.plugin_api_version == 1
+    assert descriptor.entrypoint.module == "plugin.main"
+    assert descriptor.entrypoint.class_name == "AcmePlugin"
+    assert descriptor.description == "Example plugin"
+    assert descriptor.capabilities == {
+        "templates": True,
+        "commands": False,
+    }
+    assert descriptor.default_config == {"region": "eu-west-1"}
+
+
+@pytest.mark.cfg
+def test_parse_plugin_descriptor_requires_entrypoint():
+    descriptor_yaml = """
+id: acme
+name: Acme Plugin
+version: 1.2.3
+plugin_api_version: 1
+"""
+
+    with pytest.raises(ValueError):
+        parse_plugin_descriptor(descriptor_yaml)
+
+
+@pytest.mark.cfg
+def test_parse_plugin_descriptor_rejects_non_boolean_capabilities():
+    descriptor_yaml = """
+id: acme
+name: Acme Plugin
+version: 1.2.3
+plugin_api_version: 1
+entrypoint:
+  module: plugin.main
+  class: AcmePlugin
+capabilities:
+  commands: "false"
+  completion: "0"
+"""
+
+    with pytest.raises(ValueError):
+        parse_plugin_descriptor(descriptor_yaml)
+
+
+@pytest.mark.cfg
+def test_parse_plugin_enabled_supports_bool_and_placeholder():
+    config_yaml = """
+templates_path: ${templates_path}
+envs_path: ${envs_path}
+volumes_path: ${volumes_path}
+staging_area:
+  volumes_path: ${staging_area_volumes_path}
+  images_path: ${staging_area_images_path}
+plugins:
+  - id: acme
+    enabled: false
+    version: 1.2.3
+  - id: beta
+    enabled: ${plugin_enabled}
+    version: 2.0.0
+envs: []
+"""
+
+    config = parse_config(config_yaml)
+
+    assert config.plugins is not None
+    assert config.plugins[0].enabled == "false"
+    assert config.plugins[0].is_enabled() is False
+    assert config.plugins[1].enabled == "${plugin_enabled}"
 
 
 @pytest.mark.cfg
@@ -422,6 +524,7 @@ def test_store_config_with_refs_with_real_files():
                 item.setdefault("ready", None)
             for item in expected.get("envs", []):
                 item.setdefault("ready", None)
+            expected.setdefault("plugins", None)
             y2: str = yaml.dump(expected, sort_keys=True)
             assert y1 == y2
 

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -60,6 +60,7 @@ def test_shepherdmng_creates_dirs(
         sm.configMng.config.envs_path,
         sm.configMng.config.volumes_path,
         sm.configMng.constants.SHPD_CERTS_DIR,
+        sm.configMng.constants.SHPD_PLUGINS_DIR,
         sm.configMng.constants.SHPD_SSH_DIR,
         sm.configMng.constants.SHPD_SSHD_DIR,
         sm.configMng.config.staging_area.volumes_path,

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -48,6 +48,10 @@ class Constants:
     def SHPD_SSHD_DIR(self) -> str:
         return os.path.join(self.SHPD_PATH, ".sshd")
 
+    @property
+    def SHPD_PLUGINS_DIR(self) -> str:
+        return os.path.join(self.SHPD_PATH, "plugins")
+
     # Logging configuration
 
     LOG_FILE: str
@@ -165,6 +169,7 @@ class Constants:
                 "volumes_path": "${staging_area_volumes_path}",
                 "images_path": "${staging_area_images_path}",
             },
+            "plugins": [],
             "envs": [],
         }
 

--- a/src/util/util.py
+++ b/src/util/util.py
@@ -358,6 +358,7 @@ class Util:
             "SHPD_CERTS_DIR": constants.SHPD_CERTS_DIR,
             "SHPD_SSH_DIR": constants.SHPD_SSH_DIR,
             "SHPD_SSHD_DIR": constants.SHPD_SSHD_DIR,
+            "SHPD_PLUGINS_DIR": constants.SHPD_PLUGINS_DIR,
         }
 
         for desc, dir_path in dirs.items():


### PR DESCRIPTION
## Summary
- add plugin inventory support to the main config model
- add standalone plugin descriptor parsing and validation
- reserve the managed plugins directory in Shepherd bootstrap paths

## Details
- introduce plugin config dataclasses and config manager accessors
- parse and store plugin entries in the main config while keeping explicit null rendering
- add a typed parser for plugin descriptors without introducing runtime plugin loading yet
- extend fixtures and tests for plugin persistence, descriptor validation, and managed plugin directory creation

## Testing
- python3 -m py_compile src/config/config.py src/config/__init__.py src/util/constants.py src/util/util.py src/tests/test_config.py src/tests/test_shepherd.py
- .venv/bin/pytest src/tests/test_config.py src/tests/test_shepherd.py
- cd src && ../.venv/bin/pytest

Fixes: #171