### PR TITLE
feat: add plugin lifecycle commands

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -7,6 +7,7 @@ The current implementation scope is limited to:
 - plugin descriptor format
 - plugin inventory persisted in the main Shepherd config
 - managed plugin installation directory layout
+- plugin lifecycle commands for install, inspect, enable, disable, and remove
 
 Runtime loading, command extension, completion extension, and factory/template
 registration are introduced in later steps of the plugin rollout.
@@ -29,6 +30,20 @@ not persisted as a free-form path in the main config.
 
 This keeps plugin discovery deterministic and avoids config drift caused by
 external paths moving or disappearing.
+
+## Plugin Lifecycle Commands
+
+The current CLI exposes plugin inventory management under the `plugin` scope:
+
+- `shepctl plugin list`
+- `shepctl plugin get <plugin-id>`
+- `shepctl plugin install <archive>`
+- `shepctl plugin enable <plugin-id>`
+- `shepctl plugin disable <plugin-id>`
+- `shepctl plugin remove <plugin-id>`
+
+These commands operate on the persisted plugin inventory in the main config and
+on the managed plugin root under `~/.shpd/plugins/`.
 
 ## Plugin Inventory In Config
 
@@ -60,7 +75,7 @@ config fields. YAML booleans are normalized, and placeholders such as
 ## Plugin Descriptor
 
 Each installed plugin ships a descriptor that defines its metadata and
-entrypoint.
+entrypoint. The descriptor file name is currently fixed to `plugin.yaml`.
 
 Example:
 
@@ -118,10 +133,11 @@ introduced.
 This documentation matches the current implementation step. At this stage,
 Shepherd does not yet:
 
-- install plugin archives through `shepctl plugin ...`
 - import plugin Python entrypoints with `importlib`
 - load plugin commands into the CLI
 - load plugin completion providers
 - register plugin factories or templates at runtime
 
-Those capabilities are added in follow-up PRs from the plugin rollout plan.
+Plugin archive installation and persisted inventory management are available
+now. Runtime loading and extension points are added in follow-up PRs from the
+plugin rollout plan.

--- a/docs/shepctl.md
+++ b/docs/shepctl.md
@@ -16,6 +16,7 @@ These options apply to every command:
 Top-level scopes currently available:
 
 - `env`
+- `plugin`
 - `probe`
 - `svc`
 
@@ -135,6 +136,42 @@ Options:
 
 Requires an active environment.
 
+### `plugin`
+
+Manage installed plugins.
+
+#### `plugin list`
+
+List the persisted plugin inventory from the main config.
+
+#### `plugin get PLUGIN_ID`
+
+Get one plugin entry from the persisted inventory.
+
+Options:
+
+- `-o`, `--output [yaml|json]`: output format
+
+#### `plugin install ARCHIVE_PATH`
+
+Install a plugin archive into the managed plugin root under
+`~/.shpd/plugins/<plugin-id>/`.
+
+The archive must contain exactly one `plugin.yaml` descriptor.
+
+#### `plugin enable PLUGIN_ID`
+
+Enable one installed plugin in the persisted inventory.
+
+#### `plugin disable PLUGIN_ID`
+
+Disable one installed plugin in the persisted inventory.
+
+#### `plugin remove PLUGIN_ID`
+
+Remove one installed plugin from both the persisted inventory and the managed
+plugin root.
+
 ### `svc`
 
 Manage services.
@@ -196,6 +233,7 @@ Requires an active environment.
 ## Notes
 
 - Many commands operate on the active environment selected with `env checkout`.
+- Plugin lifecycle commands are grouped under `plugin`.
 - Commands that manage environment runtime state are centered around
   `env up`, `env halt`, `env reload`, and `env status`.
 - Service-oriented commands (`svc build`, `svc logs`, `svc shell`,

--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -35,6 +35,14 @@ class CompletionMng(AbstractCompletionMng):
     """
 
     SCOPE_VERBS = {
+        "plugin": [
+            "install",
+            "list",
+            "get",
+            "enable",
+            "disable",
+            "remove",
+        ],
         "env": [
             "get",
             "add",
@@ -244,6 +252,23 @@ class CompletionMng(AbstractCompletionMng):
     def _unique(self, values: list[str]) -> list[str]:
         return list(dict.fromkeys(values))
 
+    def _get_plugin_completions(
+        self, sanitized_args: list[str], verb: str, last_token: str
+    ) -> list[str]:
+        if verb in {"get", "enable", "disable", "remove"}:
+            if len(sanitized_args) <= 3:
+                plugin_ids = sorted(
+                    [plugin.id for plugin in self.configMng.get_plugins()]
+                )
+                if len(sanitized_args) == 3 and last_token:
+                    return [
+                        plugin_id
+                        for plugin_id in plugin_ids
+                        if plugin_id.startswith(last_token)
+                    ]
+                return plugin_ids
+        return []
+
     @override
     def get_completions_impl(self, args: list[str]) -> list[str]:
         sanitized_args, scope, verb, used_options, expect_value_for = (
@@ -296,6 +321,11 @@ class CompletionMng(AbstractCompletionMng):
                     )
                 )
             return self._unique(suggestions)
+
+        if scope == "plugin":
+            return self._get_plugin_completions(
+                sanitized_args, verb, last_token
+            )
 
         completion_manager = self.get_completion_manager(scope)
         if completion_manager:

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1417,6 +1417,39 @@ class ConfigMng:
         """Return the managed install directory for one plugin id."""
         return os.path.join(self.constants.SHPD_PLUGINS_DIR, plugin_id)
 
+    def set_plugin(self, plugin_cfg: PluginCfg) -> None:
+        """Add or replace one plugin entry and persist the config."""
+        plugins = list(self.config.plugins or [])
+        for index, plugin in enumerate(plugins):
+            if plugin.id == plugin_cfg.id:
+                plugins[index] = plugin_cfg
+                self.config.plugins = plugins
+                self.store()
+                return
+        plugins.append(plugin_cfg)
+        self.config.plugins = plugins
+        self.store()
+
+    def set_plugin_enabled(self, plugin_id: str, enabled: bool) -> PluginCfg:
+        """Update one plugin enabled flag and persist the config."""
+        plugin = self.get_plugin(plugin_id)
+        if plugin is None:
+            raise ValueError(f"Plugin '{plugin_id}' not found.")
+        plugin.enabled = bool_to_str(enabled)
+        self.store()
+        return plugin
+
+    def remove_plugin(self, plugin_id: str) -> PluginCfg:
+        """Remove one plugin entry from config and persist the change."""
+        plugins = list(self.config.plugins or [])
+        for index, plugin in enumerate(plugins):
+            if plugin.id == plugin_id:
+                del plugins[index]
+                self.config.plugins = plugins
+                self.store()
+                return plugin
+        raise ValueError(f"Plugin '{plugin_id}' not found.")
+
     def get_environments(self) -> list[EnvironmentCfg]:
         """
         Retrieves all environments.

--- a/src/plugin/__init__.py
+++ b/src/plugin/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 Moony Fringers
+#
+# This file is part of Shepherd Core Stack
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .plugin import PluginMng
+
+__all__ = ["PluginMng"]

--- a/src/plugin/plugin.py
+++ b/src/plugin/plugin.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2025 Moony Fringers
+#
+# This file is part of Shepherd Core Stack
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tarfile
+import tempfile
+from typing import Any
+
+import yaml
+
+from config import ConfigMng, parse_plugin_descriptor
+from config.config import PluginCfg, PluginDescriptorCfg, cfg_asdict
+from util import Util
+
+
+class PluginMng:
+    """Manage the persisted plugin inventory and managed plugin files."""
+
+    def __init__(
+        self,
+        cli_flags: dict[str, Any],
+        configMng: ConfigMng,
+    ):
+        self.cli_flags = cli_flags
+        self.configMng = configMng
+
+    def list_plugins(self) -> None:
+        plugins = self.configMng.get_plugins()
+        if not plugins:
+            Util.print("No plugins installed.")
+            return
+
+        rows = [
+            [
+                plugin.id,
+                "true" if plugin.is_enabled() else "false",
+                plugin.version or "",
+            ]
+            for plugin in plugins
+        ]
+        Util.render_table(
+            "Plugins",
+            [
+                {"header": "Id", "style": "cyan"},
+                {"header": "Enabled"},
+                {"header": "Version"},
+            ],
+            rows,
+        )
+
+    def render_plugin(self, plugin_id: str, output: str = "yaml") -> str:
+        plugin = self._require_plugin(plugin_id)
+        rendered = cfg_asdict(plugin)
+        if output == "json":
+            return json.dumps(rendered, indent=2)
+        return yaml.dump(rendered, sort_keys=False)
+
+    def enable_plugin(self, plugin_id: str) -> None:
+        self._require_plugin(plugin_id)
+        plugin = self.configMng.set_plugin_enabled(plugin_id, True)
+        Util.print(f"Plugin '{plugin.id}' enabled.")
+
+    def disable_plugin(self, plugin_id: str) -> None:
+        self._require_plugin(plugin_id)
+        plugin = self.configMng.set_plugin_enabled(plugin_id, False)
+        Util.print(f"Plugin '{plugin.id}' disabled.")
+
+    def remove_plugin(self, plugin_id: str) -> None:
+        plugin = self._require_plugin(plugin_id)
+        plugin_dir = self.configMng.get_plugin_dir(plugin.id)
+        if os.path.isdir(plugin_dir):
+            shutil.rmtree(plugin_dir)
+        self.configMng.remove_plugin(plugin.id)
+        Util.print(f"Plugin '{plugin.id}' removed.")
+
+    def install_plugin(self, archive_path: str) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            extracted_dir = os.path.join(tmp_dir, "plugin")
+            os.makedirs(extracted_dir, exist_ok=True)
+            self._extract_plugin_archive(archive_path, extracted_dir)
+            descriptor_path = self._find_descriptor_path(extracted_dir)
+            descriptor = self._load_descriptor(descriptor_path)
+
+            if self.configMng.get_plugin(descriptor.id) is not None:
+                Util.print_error_and_die(
+                    f"Plugin '{descriptor.id}' is already installed."
+                )
+
+            descriptor_dir = os.path.dirname(descriptor_path)
+            target_dir = self.configMng.get_plugin_dir(descriptor.id)
+            if os.path.exists(target_dir):
+                Util.print_error_and_die(
+                    f"Managed plugin directory already exists: {target_dir}"
+                )
+
+            shutil.move(descriptor_dir, target_dir)
+            self.configMng.set_plugin(
+                PluginCfg(
+                    id=descriptor.id,
+                    enabled="true",
+                    version=descriptor.version,
+                    config=descriptor.default_config,
+                )
+            )
+        Util.print(f"Plugin '{descriptor.id}' installed.")
+
+    def _require_plugin(self, plugin_id: str) -> PluginCfg:
+        plugin = self.configMng.get_plugin(plugin_id)
+        if plugin is None:
+            Util.print_error_and_die(f"Plugin '{plugin_id}' not found.")
+            raise AssertionError("unreachable")
+        return plugin
+
+    def _load_descriptor(self, descriptor_path: str) -> PluginDescriptorCfg:
+        try:
+            with open(
+                descriptor_path, "r", encoding="utf-8"
+            ) as descriptor_file:
+                return parse_plugin_descriptor(descriptor_file.read())
+        except (
+            OSError,
+            KeyError,
+            TypeError,
+            ValueError,
+            yaml.YAMLError,
+        ) as exc:
+            Util.print_error_and_die(
+                f"Invalid plugin descriptor '{descriptor_path}': {exc}"
+            )
+            raise AssertionError("unreachable")
+
+    def _find_descriptor_path(self, extracted_dir: str) -> str:
+        descriptor_name = self.configMng.constants.PLUGIN_DESCRIPTOR_FILE
+        matches: list[str] = []
+        for root, _, files in os.walk(extracted_dir):
+            if descriptor_name in files:
+                matches.append(os.path.join(root, descriptor_name))
+
+        if not matches:
+            Util.print_error_and_die(
+                f"Plugin archive does not contain '{descriptor_name}'."
+            )
+        if len(matches) > 1:
+            Util.print_error_and_die(
+                f"Plugin archive contains multiple '{descriptor_name}' files."
+            )
+        return matches[0]
+
+    def _extract_plugin_archive(
+        self, archive_path: str, extracted_dir: str
+    ) -> None:
+        try:
+            with tarfile.open(archive_path, "r:*") as archive:
+                self._safe_extract_tar(archive, extracted_dir)
+        except (tarfile.TarError, OSError) as exc:
+            Util.print_error_and_die(
+                f"Failed to extract plugin archive '{archive_path}': {exc}"
+            )
+
+    def _safe_extract_tar(
+        self, archive: tarfile.TarFile, destination: str
+    ) -> None:
+        for member in archive.getmembers():
+            member_path = os.path.join(destination, member.name)
+            resolved_path = os.path.realpath(member_path)
+            resolved_destination = os.path.realpath(destination)
+            if not resolved_path.startswith(resolved_destination + os.sep):
+                Util.print_error_and_die(
+                    "Plugin archive contains an invalid path."
+                )
+        try:
+            archive.extractall(destination, filter="data")
+        except TypeError:
+            archive.extractall(destination)

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -28,6 +28,7 @@ from completion import CompletionMng
 from config import ConfigMng, EnvironmentCfg
 from environment import EnvironmentMng
 from factory import ShpdEnvironmentFactory, ShpdServiceFactory
+from plugin import PluginMng
 from service import ServiceMng
 from util import Util, setup_logging
 from util.constants import DEFAULT_COMPOSE_COMMAND_LOG_LIMIT
@@ -70,6 +71,7 @@ class ShepherdMng:
         self.serviceMng = ServiceMng(
             self.cli_flags, self.configMng, self.svcFactory
         )
+        self.pluginMng = PluginMng(self.cli_flags, self.configMng)
 
 
 def require_active_env(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -620,6 +622,73 @@ def check_probe(
         probe_tag = None
     exit_code = shepherd.environmentMng.check_probes(envCfg, probe_tag)
     exit(exit_code)
+
+
+# =====================================================
+# PLUGIN
+# =====================================================
+@cli.group()
+def plugin():
+    """Manage plugins."""
+    pass
+
+
+@plugin.command(name="list")
+@click.pass_obj
+def list_plugins(shepherd: ShepherdMng):
+    """List installed plugins."""
+    shepherd.pluginMng.list_plugins()
+
+
+@plugin.command(name="get")
+@click.argument("plugin_id", required=True)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Choice(["yaml", "json"]),
+    default="yaml",
+    show_default=True,
+)
+@click.pass_obj
+def get_plugin(shepherd: ShepherdMng, plugin_id: str, output: str):
+    """Get plugin details."""
+    click.echo(shepherd.pluginMng.render_plugin(plugin_id, output))
+
+
+@plugin.command(name="install")
+@click.argument(
+    "archive_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=str),
+)
+@click.pass_obj
+def install_plugin(shepherd: ShepherdMng, archive_path: str):
+    """Install a plugin archive into the managed plugin root."""
+    shepherd.pluginMng.install_plugin(archive_path)
+
+
+@plugin.command(name="enable")
+@click.argument("plugin_id", required=True)
+@click.pass_obj
+def enable_plugin(shepherd: ShepherdMng, plugin_id: str):
+    """Enable one installed plugin."""
+    shepherd.pluginMng.enable_plugin(plugin_id)
+
+
+@plugin.command(name="disable")
+@click.argument("plugin_id", required=True)
+@click.pass_obj
+def disable_plugin(shepherd: ShepherdMng, plugin_id: str):
+    """Disable one installed plugin."""
+    shepherd.pluginMng.disable_plugin(plugin_id)
+
+
+@plugin.command(name="remove")
+@click.argument("plugin_id", required=True)
+@click.pass_obj
+def remove_plugin(shepherd: ShepherdMng, plugin_id: str):
+    """Remove one installed plugin."""
+    shepherd.pluginMng.remove_plugin(plugin_id)
 
 
 if __name__ == "__main__":

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -21,6 +21,7 @@ import os
 from pathlib import Path
 
 import pytest
+import yaml
 from click.testing import CliRunner
 from pytest_mock import MockerFixture
 from test_util import read_fixture
@@ -45,6 +46,25 @@ def shpd_conf(tmp_path: Path, mocker: MockerFixture) -> tuple[Path, Path]:
 @pytest.fixture
 def runner() -> CliRunner:
     return CliRunner()
+
+
+def _write_completion_config_with_plugins(config_path: Path) -> None:
+    shpd_config = yaml.safe_load(read_fixture("completion", "shpd.yaml"))
+    shpd_config["plugins"] = [
+        {
+            "id": "acme",
+            "enabled": True,
+            "version": "1.2.3",
+            "config": {"region": "eu-west-1"},
+        },
+        {
+            "id": "acme-extra",
+            "enabled": False,
+            "version": "1.0.0",
+            "config": None,
+        },
+    ]
+    config_path.write_text(yaml.dump(shpd_config, sort_keys=False))
 
 
 @pytest.mark.compl
@@ -100,6 +120,67 @@ def test_completion_add(
     assert (
         completions == sm.completionMng.SCOPE_VERBS["env"]
     ), "Expected env verbs"
+
+
+@pytest.mark.compl
+def test_completion_plugin_scope(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["plugin"])
+    assert (
+        completions == sm.completionMng.SCOPE_VERBS["plugin"]
+    ), "Expected plugin verbs"
+
+
+@pytest.mark.compl
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["plugin", "get"],
+        ["plugin", "enable"],
+        ["plugin", "disable"],
+        ["plugin", "remove"],
+    ],
+)
+def test_completion_plugin_id_verbs(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+    args: list[str],
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _write_completion_config_with_plugins(shpd_yaml)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(args)
+    assert completions == [
+        "acme",
+        "acme-extra",
+    ], "Expected plugin id completion"
+
+
+@pytest.mark.compl
+def test_completion_plugin_id_prefix(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _write_completion_config_with_plugins(shpd_yaml)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["plugin", "get", "ac"])
+    assert completions == [
+        "acme",
+        "acme-extra",
+    ], "Expected filtered plugin id completion"
 
 
 @pytest.mark.compl

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -17,10 +17,13 @@
 
 from __future__ import annotations
 
+import io
 import os
+import tarfile
 from pathlib import Path
 
 import pytest
+import yaml
 from click.testing import CliRunner
 from pytest_mock import MockerFixture
 from test_util import read_fixture
@@ -404,6 +407,203 @@ def test_cli_build_svc(
     result = runner.invoke(cli, ["svc", "build", "service_tag"])
     assert result.exit_code == 0
     mock_build.assert_called_once()
+
+
+def _write_plugin_archive(
+    archive_path: Path,
+    plugin_id: str = "acme-extra",
+    version: str = "1.0.0",
+    descriptor_content: str | None = None,
+) -> None:
+    with tarfile.open(archive_path, "w:gz") as archive:
+        descriptor = descriptor_content or f"""id: {plugin_id}
+name: Acme Extra
+version: {version}
+plugin_api_version: 1
+entrypoint:
+  module: plugin.main
+  class: AcmePlugin
+capabilities:
+  commands: true
+default_config:
+  region: eu-west-1
+"""
+        descriptor_bytes = descriptor.encode("utf-8")
+        descriptor_info = tarfile.TarInfo("acme-extra/plugin.yaml")
+        descriptor_info.size = len(descriptor_bytes)
+        archive.addfile(descriptor_info, fileobj=io.BytesIO(descriptor_bytes))
+
+        module_bytes = b"class AcmePlugin:\n    pass\n"
+        module_info = tarfile.TarInfo("acme-extra/plugin/main.py")
+        module_info.size = len(module_bytes)
+        archive.addfile(module_info, fileobj=io.BytesIO(module_bytes))
+
+
+def _write_cli_config_with_plugins(config_path: Path) -> None:
+    shpd_config = yaml.safe_load(read_fixture("shpd", "shpd.yaml"))
+    shpd_config["plugins"] = [
+        {
+            "id": "acme",
+            "enabled": True,
+            "version": "1.2.3",
+            "config": {
+                "region": "eu-west-1",
+                "enabled_feature": True,
+            },
+        }
+    ]
+    config_path.write_text(yaml.dump(shpd_config, sort_keys=False))
+
+
+@pytest.mark.shpd
+def test_cli_plugin_list(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _write_cli_config_with_plugins(shpd_yaml)
+
+    result = runner.invoke(cli, ["plugin", "list"])
+
+    assert result.exit_code == 0
+    assert "acme" in result.output
+    assert "1.2.3" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_plugin_get_yaml(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _write_cli_config_with_plugins(shpd_yaml)
+
+    result = runner.invoke(cli, ["plugin", "get", "acme"])
+
+    assert result.exit_code == 0
+    rendered = yaml.safe_load(result.output)
+    assert rendered["id"] == "acme"
+    assert rendered["enabled"] is True
+    assert rendered["version"] == "1.2.3"
+
+
+@pytest.mark.shpd
+def test_cli_plugin_enable_disable(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _write_cli_config_with_plugins(shpd_yaml)
+
+    result = runner.invoke(cli, ["plugin", "disable", "acme"])
+    assert result.exit_code == 0
+    assert "Plugin 'acme' disabled." in result.output
+
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    assert stored["plugins"][0]["enabled"] is False
+
+    result = runner.invoke(cli, ["plugin", "enable", "acme"])
+    assert result.exit_code == 0
+    assert "Plugin 'acme' enabled." in result.output
+
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    assert stored["plugins"][0]["enabled"] is True
+
+
+@pytest.mark.shpd
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["plugin", "enable", "missing"],
+        ["plugin", "disable", "missing"],
+    ],
+)
+def test_cli_plugin_enable_disable_missing_plugin(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+    args: list[str],
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _write_cli_config_with_plugins(shpd_yaml)
+
+    result = runner.invoke(cli, args)
+
+    assert result.exit_code == 1
+    assert "Error: Plugin 'missing' not found." in result.output
+
+
+@pytest.mark.shpd
+def test_cli_plugin_install_and_remove(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _write_cli_config_with_plugins(shpd_yaml)
+
+    archive_path = shpd_path / "acme-extra.tar.gz"
+    _write_plugin_archive(archive_path)
+
+    result = runner.invoke(cli, ["plugin", "install", str(archive_path)])
+    assert result.exit_code == 0
+    assert "Plugin 'acme-extra' installed." in result.output
+
+    plugin_dir = shpd_path / "plugins" / "acme-extra"
+    assert plugin_dir.is_dir()
+    assert (plugin_dir / "plugin.yaml").is_file()
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    plugin_cfg = next(
+        plugin for plugin in stored["plugins"] if plugin["id"] == "acme-extra"
+    )
+    assert plugin_cfg["enabled"] is True
+    assert plugin_cfg["version"] == "1.0.0"
+    assert plugin_cfg["config"] == {"region": "eu-west-1"}
+
+    result = runner.invoke(cli, ["plugin", "remove", "acme-extra"])
+    assert result.exit_code == 0
+    assert "Plugin 'acme-extra' removed." in result.output
+    assert not plugin_dir.exists()
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    assert all(plugin["id"] != "acme-extra" for plugin in stored["plugins"])
+
+
+@pytest.mark.shpd
+def test_cli_plugin_install_invalid_descriptor(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _write_cli_config_with_plugins(shpd_yaml)
+
+    archive_path = shpd_path / "invalid-plugin.tar.gz"
+    _write_plugin_archive(
+        archive_path,
+        descriptor_content="""id: broken
+name: Broken Plugin
+version: 1.0.0
+plugin_api_version: 1
+entrypoint:
+  module: plugin.main
+  class: BrokenPlugin
+capabilities:
+  commands: "false"
+""",
+    )
+
+    result = runner.invoke(cli, ["plugin", "install", str(archive_path)])
+
+    assert result.exit_code == 1
+    assert "Error: Invalid plugin descriptor" in result.output
+    assert "Plugin capability values must" in result.output
+    assert "be booleans." in result.output
+    assert not (shpd_path / "plugins" / "broken").exists()
 
 
 @pytest.mark.shpd

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -72,6 +72,7 @@ class Constants:
     APP_AUTHOR: str = "Moony Fringers"
     APP_LICENSE: str = "AGPL-3.0"
     APP_URL: str = "https://github.com/MoonyFringers/shepherd"
+    PLUGIN_DESCRIPTOR_FILE: str = "plugin.yaml"
 
     # Environment templates:
 


### PR DESCRIPTION
## Summary
- add the plugin CLI scope with install, list, get, enable, disable, and remove
- add a dedicated plugin manager for archive validation, managed installation, inventory updates, and removal
- document the new plugin lifecycle commands and current plugin descriptor expectations

## Testing
- python3 -m py_compile src/shepctl.py src/plugin/plugin.py src/plugin/__init__.py src/config/config.py src/util/constants.py src/tests/test_shepherd.py
- .venv/bin/black src/config/config.py src/shepctl.py src/tests/test_shepherd.py src/util/constants.py src/plugin/plugin.py src/plugin/__init__.py
- .venv/bin/isort src/config/config.py src/shepctl.py src/tests/test_shepherd.py src/util/constants.py src/plugin/plugin.py src/plugin/__init__.py
- cd src && ../.venv/bin/pytest

Fixes: #173