### PR TITLE
feat(plugin): add runtime loader and registries

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -8,9 +8,12 @@ The current implementation scope is limited to:
 - plugin inventory persisted in the main Shepherd config
 - managed plugin installation directory layout
 - plugin lifecycle commands for install, inspect, enable, disable, and remove
+- runtime loading of enabled plugins via `importlib`
+- in-memory registries for plugin commands, completion providers, templates,
+  and factories
 
-Runtime loading, command extension, completion extension, and factory/template
-registration are introduced in later steps of the plugin rollout.
+CLI command injection, completion consumption, and template or factory
+execution still land in later steps of the plugin rollout.
 
 For the architectural rationale and staged implementation plan, see
 [ADR 0004](decisions/0004-plugin-architecture-and-rollout-plan.md).
@@ -126,18 +129,64 @@ The descriptor parser validates:
 - capability values as actual booleans
 
 Invalid descriptors fail validation early, before runtime plugin loading is
-introduced.
+attempted.
+
+## Runtime Loading
+
+Enabled plugins are now loaded eagerly during normal startup:
+
+1. Shepherd reads enabled plugin entries from the main config.
+2. It derives each managed install directory from `~/.shpd/plugins/<plugin-id>/`.
+3. It validates the installed `plugin.yaml`.
+4. It imports the declared entrypoint with `importlib`.
+5. It instantiates the root plugin object and registers the contributed
+   runtime metadata.
+
+Normal commands fail fast if an enabled plugin is missing, invalid, or cannot
+be imported.
+
+The `plugin` management scope keeps a safe bootstrap path and does not import
+enabled external plugins before running:
+
+- `shepctl plugin list`
+- `shepctl plugin get <plugin-id>`
+- `shepctl plugin install <archive>`
+- `shepctl plugin enable <plugin-id>`
+- `shepctl plugin disable <plugin-id>`
+- `shepctl plugin remove <plugin-id>`
+
+This keeps recovery commands available even if one enabled plugin is broken.
+
+## Runtime Registries
+
+The loader now builds in-memory registries for:
+
+- loaded plugin metadata
+- scope and verb contributions
+- completion providers
+- environment templates
+- service templates
+- environment factories
+- service factories
+
+Template and factory ids are canonicalized under the plugin namespace:
+
+- templates: `plugin-id/template-id`
+- factories: `plugin-id/factory-id`
+
+These registries are currently validated and populated at startup. They are not
+yet consumed by the CLI, completion engine, or env and service factory flows.
 
 ## Scope Of This Step
 
 This documentation matches the current implementation step. At this stage,
 Shepherd does not yet:
 
-- import plugin Python entrypoints with `importlib`
 - load plugin commands into the CLI
 - load plugin completion providers
-- register plugin factories or templates at runtime
+- execute plugin factories or plugin-owned templates through env and svc flows
 
-Plugin archive installation and persisted inventory management are available
-now. Runtime loading and extension points are added in follow-up PRs from the
-plugin rollout plan.
+Plugin archive installation, persisted inventory management, and runtime loader
+bootstrap are available now. Command wiring, completion execution, and factory
+or template consumption are added in follow-up PRs from the plugin rollout
+plan.

--- a/src/plugin/__init__.py
+++ b/src/plugin/__init__.py
@@ -17,16 +17,18 @@
 
 """Public plugin APIs shared by the CLI bootstrap and external plugins."""
 
-from .plugin import PluginMng
-from .runtime import (
-    LoadedPlugin,
+from .api import (
     PluginCommandSpec,
     PluginCompletionSpec,
     PluginFactorySpec,
-    PluginRegistry,
-    PluginRuntimeMng,
     PluginTemplateSpec,
     ShepherdPlugin,
+)
+from .plugin import PluginMng
+from .runtime import (
+    LoadedPlugin,
+    PluginRegistry,
+    PluginRuntimeMng,
 )
 
 __all__ = [

--- a/src/plugin/__init__.py
+++ b/src/plugin/__init__.py
@@ -15,6 +15,28 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .plugin import PluginMng
+"""Public plugin APIs shared by the CLI bootstrap and external plugins."""
 
-__all__ = ["PluginMng"]
+from .plugin import PluginMng
+from .runtime import (
+    LoadedPlugin,
+    PluginCommandSpec,
+    PluginCompletionSpec,
+    PluginFactorySpec,
+    PluginRegistry,
+    PluginRuntimeMng,
+    PluginTemplateSpec,
+    ShepherdPlugin,
+)
+
+__all__ = [
+    "LoadedPlugin",
+    "PluginCommandSpec",
+    "PluginCompletionSpec",
+    "PluginFactorySpec",
+    "PluginMng",
+    "PluginRegistry",
+    "PluginRuntimeMng",
+    "PluginTemplateSpec",
+    "ShepherdPlugin",
+]

--- a/src/plugin/api.py
+++ b/src/plugin/api.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2025 Moony Fringers
+#
+# This file is part of Shepherd Core Stack
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from abc import ABC
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+
+@dataclass(frozen=True)
+class PluginCommandSpec:
+    """One scope/verb pair contributed by a plugin."""
+
+    scope: str
+    verb: str
+
+
+@dataclass(frozen=True)
+class PluginCompletionSpec:
+    """
+    One completion provider contribution keyed by scope.
+
+    `provider` is intentionally untyped in this step because the runtime
+    loader only stores provider objects in the registry; it does not invoke
+    them yet. A later completion-integration step will narrow this to the
+    concrete callable or provider protocol the completion engine expects.
+    """
+
+    scope: str
+    provider: Any
+
+
+@dataclass(frozen=True)
+class PluginTemplateSpec:
+    """
+    One template contribution declared by a plugin.
+
+    `provider` carries the plugin-owned object or data structure that
+    describes the template payload. The loader treats it as opaque for now and
+    only registers it under the canonical `plugin-id/template-id` name.
+    """
+
+    id: str
+    provider: Any
+
+
+@dataclass(frozen=True)
+class PluginFactorySpec:
+    """
+    One factory contribution declared by a plugin.
+
+    `provider` carries the concrete factory object published by the plugin.
+    The runtime layer currently validates and stores it only; env and service
+    flows will start consuming these provider objects in a later rollout step.
+    """
+
+    id: str
+    provider: Any
+
+
+class ShepherdPlugin(ABC):
+    """
+    Root runtime interface implemented by external plugins.
+
+    A concrete plugin exposes its capabilities by overriding the contribution
+    getters below. Returning an empty sequence means that the plugin does not
+    participate in that extension area.
+    """
+
+    def get_commands(self) -> Sequence[PluginCommandSpec]:
+        """Return scope and verb contributions declared by the plugin."""
+        return ()
+
+    def get_completion_providers(self) -> Sequence[PluginCompletionSpec]:
+        """Return completion providers grouped by the scopes they serve."""
+        return ()
+
+    def get_env_templates(self) -> Sequence[PluginTemplateSpec]:
+        """Return environment templates owned by the plugin."""
+        return ()
+
+    def get_service_templates(self) -> Sequence[PluginTemplateSpec]:
+        """Return service templates owned by the plugin."""
+        return ()
+
+    def get_env_factories(self) -> Sequence[PluginFactorySpec]:
+        """Return environment factories owned by the plugin."""
+        return ()
+
+    def get_service_factories(self) -> Sequence[PluginFactorySpec]:
+        """Return service factories owned by the plugin."""
+        return ()

--- a/src/plugin/runtime.py
+++ b/src/plugin/runtime.py
@@ -1,0 +1,536 @@
+# Copyright (c) 2025 Moony Fringers
+#
+# This file is part of Shepherd Core Stack
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from abc import ABC
+from dataclasses import dataclass, field
+from typing import Any, Sequence
+from types import ModuleType
+
+import yaml
+
+from completion import CompletionMng
+from config import (
+    ConfigMng,
+    PluginCfg,
+    PluginDescriptorCfg,
+    parse_plugin_descriptor,
+)
+from util import Util
+
+SUPPORTED_PLUGIN_API_VERSION = 1
+
+
+def _loaded_plugin_registry() -> dict[str, "LoadedPlugin"]:
+    """Create a typed default for the loaded-plugin registry."""
+    return {}
+
+
+def _command_registry() -> dict[str, dict[str, str]]:
+    """Create a typed default for contributed scope and verb ownership."""
+    return {}
+
+
+def _completion_registry() -> dict[str, list["PluginCompletionSpec"]]:
+    """Create a typed default for completion providers grouped by scope."""
+    return {}
+
+
+def _template_registry() -> dict[str, "PluginTemplateSpec"]:
+    """Create a typed default for canonical template registrations."""
+    return {}
+
+
+def _factory_registry() -> dict[str, "PluginFactorySpec"]:
+    """Create a typed default for canonical factory registrations."""
+    return {}
+
+
+@dataclass(frozen=True)
+class PluginCommandSpec:
+    """One scope/verb pair contributed by a plugin."""
+
+    scope: str
+    verb: str
+
+
+@dataclass(frozen=True)
+class PluginCompletionSpec:
+    """
+    One completion provider contribution keyed by scope.
+
+    `provider` is intentionally untyped in this step because the runtime
+    loader only stores provider objects in the registry; it does not invoke
+    them yet. A later completion-integration step will narrow this to the
+    concrete callable or provider protocol the completion engine expects.
+    """
+
+    scope: str
+    provider: Any
+
+
+@dataclass(frozen=True)
+class PluginTemplateSpec:
+    """
+    One template contribution declared by a plugin.
+
+    `provider` carries the plugin-owned object or data structure that
+    describes the template payload. The loader treats it as opaque for now and
+    only registers it under the canonical `plugin-id/template-id` name.
+    """
+
+    id: str
+    provider: Any
+
+
+@dataclass(frozen=True)
+class PluginFactorySpec:
+    """
+    One factory contribution declared by a plugin.
+
+    `provider` carries the concrete factory object published by the plugin.
+    The runtime layer currently validates and stores it only; env and service
+    flows will start consuming these provider objects in a later rollout step.
+    """
+
+    id: str
+    provider: Any
+
+
+class ShepherdPlugin(ABC):
+    """
+    Root runtime interface implemented by external plugins.
+
+    A concrete plugin exposes its capabilities by overriding the contribution
+    getters below. Returning an empty sequence means that the plugin does not
+    participate in that extension area.
+    """
+
+    def get_commands(self) -> Sequence[PluginCommandSpec]:
+        """Return scope and verb contributions declared by the plugin."""
+        return ()
+
+    def get_completion_providers(self) -> Sequence[PluginCompletionSpec]:
+        """Return completion providers grouped by the scopes they serve."""
+        return ()
+
+    def get_env_templates(self) -> Sequence[PluginTemplateSpec]:
+        """Return environment templates owned by the plugin."""
+        return ()
+
+    def get_service_templates(self) -> Sequence[PluginTemplateSpec]:
+        """Return service templates owned by the plugin."""
+        return ()
+
+    def get_env_factories(self) -> Sequence[PluginFactorySpec]:
+        """Return environment factories owned by the plugin."""
+        return ()
+
+    def get_service_factories(self) -> Sequence[PluginFactorySpec]:
+        """Return service factories owned by the plugin."""
+        return ()
+
+
+@dataclass(frozen=True)
+class LoadedPlugin:
+    """Runtime record for one loaded plugin."""
+
+    config: PluginCfg
+    descriptor: PluginDescriptorCfg
+    plugin_dir: str
+    instance: ShepherdPlugin
+
+
+@dataclass
+class PluginRegistry:
+    """
+    In-memory registry of loaded plugin contributions.
+
+    The runtime loader populates this once during CLI startup. Later rollout
+    steps will consume these registries to inject commands, delegate
+    completion, and resolve plugin-owned templates and factories.
+    """
+
+    plugins: dict[str, LoadedPlugin] = field(
+        default_factory=_loaded_plugin_registry
+    )
+    commands: dict[str, dict[str, str]] = field(
+        default_factory=_command_registry
+    )
+    completion_providers: dict[str, list[PluginCompletionSpec]] = field(
+        default_factory=_completion_registry
+    )
+    env_templates: dict[str, PluginTemplateSpec] = field(
+        default_factory=_template_registry
+    )
+    service_templates: dict[str, PluginTemplateSpec] = field(
+        default_factory=_template_registry
+    )
+    env_factories: dict[str, PluginFactorySpec] = field(
+        default_factory=_factory_registry
+    )
+    service_factories: dict[str, PluginFactorySpec] = field(
+        default_factory=_factory_registry
+    )
+
+
+class PluginRuntimeMng:
+    """
+    Load enabled plugins and register their declared runtime contributions.
+
+    This manager is used only on the normal fail-fast startup path. The
+    administrative `plugin` scope keeps using the safe bootstrap path exposed
+    by `PluginMng`, so operators can still disable or remove a broken plugin.
+    """
+
+    CORE_SCOPE_VERBS = {
+        scope: set(verbs) for scope, verbs in CompletionMng.SCOPE_VERBS.items()
+    }
+
+    def __init__(self, configMng: ConfigMng):
+        self.configMng = configMng
+        self.registry = PluginRegistry()
+        self.load_enabled_plugins()
+
+    def load_enabled_plugins(self) -> PluginRegistry:
+        """
+        Load all enabled plugins from config into the runtime registry.
+
+        Plugins are loaded eagerly so command registration, collision checks,
+        and later extension hooks see the complete active plugin set.
+        """
+        for plugin_cfg in self.configMng.get_plugins():
+            if not plugin_cfg.is_enabled():
+                continue
+            loaded = self._load_plugin(plugin_cfg)
+            self._register_plugin(loaded)
+        return self.registry
+
+    def _load_plugin(self, plugin_cfg: PluginCfg) -> LoadedPlugin:
+        """Load one enabled plugin from its managed install directory."""
+        plugin_dir = self.configMng.get_plugin_dir(plugin_cfg.id)
+        if not os.path.isdir(plugin_dir):
+            Util.print_error_and_die(
+                f"Enabled plugin '{plugin_cfg.id}' is missing from the "
+                f"managed plugin root: {plugin_dir}"
+            )
+
+        descriptor_path = os.path.join(
+            plugin_dir, self.configMng.constants.PLUGIN_DESCRIPTOR_FILE
+        )
+        descriptor = self._load_descriptor(plugin_cfg.id, descriptor_path)
+        self._validate_descriptor(plugin_cfg, descriptor)
+        plugin = self._import_plugin(plugin_cfg.id, plugin_dir, descriptor)
+        return LoadedPlugin(
+            config=plugin_cfg,
+            descriptor=descriptor,
+            plugin_dir=plugin_dir,
+            instance=plugin,
+        )
+
+    def _load_descriptor(
+        self, plugin_id: str, descriptor_path: str
+    ) -> PluginDescriptorCfg:
+        """Parse and validate the installed descriptor for one plugin."""
+        try:
+            with open(
+                descriptor_path, "r", encoding="utf-8"
+            ) as descriptor_file:
+                return parse_plugin_descriptor(descriptor_file.read())
+        except (
+            OSError,
+            KeyError,
+            TypeError,
+            ValueError,
+            yaml.YAMLError,
+        ) as exc:
+            Util.print_error_and_die(
+                f"Invalid plugin descriptor for '{plugin_id}': {exc}"
+            )
+            raise AssertionError("unreachable")
+
+    def _validate_descriptor(
+        self, plugin_cfg: PluginCfg, descriptor: PluginDescriptorCfg
+    ) -> None:
+        """Reject stale or incompatible installed plugin metadata."""
+        if descriptor.id != plugin_cfg.id:
+            Util.print_error_and_die(
+                f"Installed plugin '{plugin_cfg.id}' has descriptor id "
+                f"'{descriptor.id}'."
+            )
+        if (
+            plugin_cfg.version is not None
+            and descriptor.version != plugin_cfg.version
+        ):
+            Util.print_error_and_die(
+                f"Installed plugin '{plugin_cfg.id}' version "
+                f"'{descriptor.version}' does not match configured version "
+                f"'{plugin_cfg.version}'."
+            )
+        if descriptor.plugin_api_version != SUPPORTED_PLUGIN_API_VERSION:
+            Util.print_error_and_die(
+                f"Plugin '{plugin_cfg.id}' declares unsupported "
+                f"plugin_api_version={descriptor.plugin_api_version}. "
+                f"Supported version: {SUPPORTED_PLUGIN_API_VERSION}."
+            )
+
+    def _import_plugin(
+        self,
+        plugin_id: str,
+        plugin_dir: str,
+        descriptor: PluginDescriptorCfg,
+    ) -> ShepherdPlugin:
+        """
+        Import and instantiate the plugin entrypoint declared in the descriptor.
+
+        The declared module name is imported as-is so plugin-internal absolute
+        imports keep working. We still guard against module-root collisions by
+        tracking which plugin owns each imported top-level package name.
+        """
+        module_name = descriptor.entrypoint.module
+        class_name = descriptor.entrypoint.class_name
+        module_root = module_name.split(".", 1)[0]
+        self._prepare_module_root(plugin_id, plugin_dir, module_root)
+
+        try:
+            sys.path.insert(0, plugin_dir)
+            module = importlib.import_module(module_name)
+        except Exception as exc:
+            Util.print_error_and_die(
+                f"Failed to import plugin '{plugin_id}' entrypoint "
+                f"'{module_name}.{class_name}': {exc}"
+            )
+            raise AssertionError("unreachable")
+        finally:
+            if sys.path and sys.path[0] == plugin_dir:
+                sys.path.pop(0)
+
+        self._tag_plugin_modules(plugin_id, plugin_dir, module_root)
+
+        try:
+            plugin_class = getattr(module, class_name)
+        except AttributeError:
+            Util.print_error_and_die(
+                f"Plugin '{plugin_id}' entrypoint class '{class_name}' was "
+                f"not found in module '{module_name}'."
+            )
+            raise AssertionError("unreachable")
+
+        try:
+            plugin = plugin_class()
+        except Exception as exc:
+            Util.print_error_and_die(
+                f"Failed to instantiate plugin '{plugin_id}' entrypoint "
+                f"'{module_name}.{class_name}': {exc}"
+            )
+            raise AssertionError("unreachable")
+
+        if not isinstance(plugin, ShepherdPlugin):
+            Util.print_error_and_die(
+                f"Plugin '{plugin_id}' entrypoint '{module_name}.{class_name}' "
+                "must implement ShepherdPlugin."
+            )
+        return plugin
+
+    def _prepare_module_root(
+        self, plugin_id: str, plugin_dir: str, module_root: str
+    ) -> None:
+        """
+        Validate or reset the declared top-level module root before import.
+
+        Repeated loads of the same plugin id in one Python process are allowed
+        and force a fresh import from the current managed directory. A
+        different plugin claiming the same module root is rejected.
+        """
+        root_module = sys.modules.get(module_root)
+        if root_module is None:
+            return
+
+        owner_id = getattr(root_module, "__shepherd_plugin_id__", None)
+        owner_dir = getattr(root_module, "__shepherd_plugin_dir__", None)
+        if owner_id == plugin_id:
+            self._purge_module_root(module_root)
+            return
+
+        if owner_id is not None and owner_dir is not None:
+            Util.print_error_and_die(
+                f"Plugin '{plugin_id}' module root '{module_root}' collides "
+                f"with plugin '{owner_id}'."
+            )
+
+        Util.print_error_and_die(
+            f"Plugin '{plugin_id}' module root '{module_root}' collides with "
+            "an existing Python module."
+        )
+
+    def _purge_module_root(self, module_root: str) -> None:
+        """Remove a previously loaded plugin module root and its submodules."""
+        for module_name in list(sys.modules):
+            if module_name == module_root or module_name.startswith(
+                f"{module_root}."
+            ):
+                del sys.modules[module_name]
+
+    def _tag_plugin_modules(
+        self, plugin_id: str, plugin_dir: str, module_root: str
+    ) -> None:
+        """Tag loaded plugin modules so future loads can detect ownership."""
+        for module_name, module in sys.modules.items():
+            if module_name == module_root or module_name.startswith(
+                f"{module_root}."
+            ):
+                self._tag_plugin_module(module, plugin_id, plugin_dir)
+
+    def _tag_plugin_module(
+        self, module: ModuleType, plugin_id: str, plugin_dir: str
+    ) -> None:
+        """Attach plugin ownership metadata to one loaded module."""
+        setattr(module, "__shepherd_plugin_id__", plugin_id)
+        setattr(module, "__shepherd_plugin_dir__", plugin_dir)
+
+    def _register_plugin(self, loaded: LoadedPlugin) -> None:
+        """Register every contribution published by one loaded plugin."""
+        plugin_id = loaded.descriptor.id
+        if plugin_id in self.registry.plugins:
+            Util.print_error_and_die(f"Plugin '{plugin_id}' is already loaded.")
+        self.registry.plugins[plugin_id] = loaded
+        self._register_commands(plugin_id, loaded.instance.get_commands())
+        self._register_completion_providers(
+            plugin_id, loaded.instance.get_completion_providers()
+        )
+        self._register_templates(
+            plugin_id,
+            loaded.instance.get_env_templates(),
+            self.registry.env_templates,
+            "environment template",
+        )
+        self._register_templates(
+            plugin_id,
+            loaded.instance.get_service_templates(),
+            self.registry.service_templates,
+            "service template",
+        )
+        self._register_factories(
+            plugin_id,
+            loaded.instance.get_env_factories(),
+            self.registry.env_factories,
+            "environment factory",
+        )
+        self._register_factories(
+            plugin_id,
+            loaded.instance.get_service_factories(),
+            self.registry.service_factories,
+            "service factory",
+        )
+
+    def _register_commands(
+        self,
+        plugin_id: str,
+        commands: Sequence[PluginCommandSpec],
+    ) -> None:
+        """Register scope and verb contributions with collision checks."""
+        seen: set[tuple[str, str]] = set()
+        for command in commands:
+            scope = command.scope
+            verb = command.verb
+            if (scope, verb) in seen:
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' declares duplicate command "
+                    f"'{scope} {verb}'."
+                )
+            seen.add((scope, verb))
+
+            if verb in self.CORE_SCOPE_VERBS.get(scope, set()):
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' command '{scope} {verb}' "
+                    "collides with a core command."
+                )
+
+            scope_commands = self.registry.commands.setdefault(scope, {})
+            owner = scope_commands.get(verb)
+            if owner is not None:
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' command '{scope} {verb}' "
+                    f"collides with plugin '{owner}'."
+                )
+            scope_commands[verb] = plugin_id
+
+    def _register_completion_providers(
+        self,
+        plugin_id: str,
+        providers: Sequence[PluginCompletionSpec],
+    ) -> None:
+        """Register completion providers, grouped by the scope they serve."""
+        seen_scopes: set[str] = set()
+        for provider in providers:
+            if provider.scope in seen_scopes:
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' declares multiple completion "
+                    f"providers for scope '{provider.scope}'."
+                )
+            seen_scopes.add(provider.scope)
+            self.registry.completion_providers.setdefault(
+                provider.scope, []
+            ).append(provider)
+
+    def _register_templates(
+        self,
+        plugin_id: str,
+        templates: Sequence[PluginTemplateSpec],
+        registry: dict[str, PluginTemplateSpec],
+        kind: str,
+    ) -> None:
+        """Register namespaced templates in the selected runtime registry."""
+        for template in templates:
+            if "/" in template.id:
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' {kind} id '{template.id}' must "
+                    "not contain '/'."
+                )
+            canonical_id = f"{plugin_id}/{template.id}"
+            if canonical_id in registry:
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' declares duplicate {kind} "
+                    f"'{canonical_id}'."
+                )
+            registry[canonical_id] = template
+
+    def _register_factories(
+        self,
+        plugin_id: str,
+        factories: Sequence[PluginFactorySpec],
+        registry: dict[str, PluginFactorySpec],
+        kind: str,
+    ) -> None:
+        """Register namespaced factories in the selected runtime registry."""
+        for factory in factories:
+            if "/" in factory.id:
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' {kind} id '{factory.id}' must "
+                    "not contain '/'."
+                )
+            canonical_id = f"{plugin_id}/{factory.id}"
+            if canonical_id in registry:
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' declares duplicate {kind} "
+                    f"'{canonical_id}'."
+                )
+            registry[canonical_id] = factory

--- a/src/plugin/runtime.py
+++ b/src/plugin/runtime.py
@@ -20,10 +20,9 @@ from __future__ import annotations
 import importlib
 import os
 import sys
-from abc import ABC
 from dataclasses import dataclass, field
-from typing import Any, Sequence
 from types import ModuleType
+from typing import Sequence
 
 import yaml
 
@@ -33,6 +32,13 @@ from config import (
     PluginCfg,
     PluginDescriptorCfg,
     parse_plugin_descriptor,
+)
+from plugin.api import (
+    PluginCommandSpec,
+    PluginCompletionSpec,
+    PluginFactorySpec,
+    PluginTemplateSpec,
+    ShepherdPlugin,
 )
 from util import Util
 
@@ -62,91 +68,6 @@ def _template_registry() -> dict[str, "PluginTemplateSpec"]:
 def _factory_registry() -> dict[str, "PluginFactorySpec"]:
     """Create a typed default for canonical factory registrations."""
     return {}
-
-
-@dataclass(frozen=True)
-class PluginCommandSpec:
-    """One scope/verb pair contributed by a plugin."""
-
-    scope: str
-    verb: str
-
-
-@dataclass(frozen=True)
-class PluginCompletionSpec:
-    """
-    One completion provider contribution keyed by scope.
-
-    `provider` is intentionally untyped in this step because the runtime
-    loader only stores provider objects in the registry; it does not invoke
-    them yet. A later completion-integration step will narrow this to the
-    concrete callable or provider protocol the completion engine expects.
-    """
-
-    scope: str
-    provider: Any
-
-
-@dataclass(frozen=True)
-class PluginTemplateSpec:
-    """
-    One template contribution declared by a plugin.
-
-    `provider` carries the plugin-owned object or data structure that
-    describes the template payload. The loader treats it as opaque for now and
-    only registers it under the canonical `plugin-id/template-id` name.
-    """
-
-    id: str
-    provider: Any
-
-
-@dataclass(frozen=True)
-class PluginFactorySpec:
-    """
-    One factory contribution declared by a plugin.
-
-    `provider` carries the concrete factory object published by the plugin.
-    The runtime layer currently validates and stores it only; env and service
-    flows will start consuming these provider objects in a later rollout step.
-    """
-
-    id: str
-    provider: Any
-
-
-class ShepherdPlugin(ABC):
-    """
-    Root runtime interface implemented by external plugins.
-
-    A concrete plugin exposes its capabilities by overriding the contribution
-    getters below. Returning an empty sequence means that the plugin does not
-    participate in that extension area.
-    """
-
-    def get_commands(self) -> Sequence[PluginCommandSpec]:
-        """Return scope and verb contributions declared by the plugin."""
-        return ()
-
-    def get_completion_providers(self) -> Sequence[PluginCompletionSpec]:
-        """Return completion providers grouped by the scopes they serve."""
-        return ()
-
-    def get_env_templates(self) -> Sequence[PluginTemplateSpec]:
-        """Return environment templates owned by the plugin."""
-        return ()
-
-    def get_service_templates(self) -> Sequence[PluginTemplateSpec]:
-        """Return service templates owned by the plugin."""
-        return ()
-
-    def get_env_factories(self) -> Sequence[PluginFactorySpec]:
-        """Return environment factories owned by the plugin."""
-        return ()
-
-    def get_service_factories(self) -> Sequence[PluginFactorySpec]:
-        """Return service factories owned by the plugin."""
-        return ()
 
 
 @dataclass(frozen=True)

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -28,7 +28,7 @@ from completion import CompletionMng
 from config import ConfigMng, EnvironmentCfg
 from environment import EnvironmentMng
 from factory import ShpdEnvironmentFactory, ShpdServiceFactory
-from plugin import PluginMng
+from plugin import PluginMng, PluginRuntimeMng
 from service import ServiceMng
 from util import Util, setup_logging
 from util.constants import DEFAULT_COMPOSE_COMMAND_LOG_LIMIT
@@ -40,9 +40,19 @@ class ShepherdMng:
 
     The click context stores one instance per invocation so command handlers
     share the same loaded config and CLI flags.
+
+    `load_runtime_plugins` keeps the bootstrap split explicit:
+    normal commands eagerly load enabled plugins and fail fast on runtime
+    errors, while the administrative `plugin` scope and raw completion entry
+    point can opt into the safe path that skips external plugin imports.
     """
 
-    def __init__(self, cli_flags: dict[str, Any] = {}):
+    def __init__(
+        self,
+        cli_flags: dict[str, Any] = {},
+        *,
+        load_runtime_plugins: bool = True,
+    ):
         shpd_conf = os.environ.get("SHPD_CONF", "~/.shpd.conf")
         self.configMng = ConfigMng(shpd_conf)
         setup_logging(
@@ -72,6 +82,9 @@ class ShepherdMng:
             self.cli_flags, self.configMng, self.svcFactory
         )
         self.pluginMng = PluginMng(self.cli_flags, self.configMng)
+        self.pluginRuntimeMng: Optional[PluginRuntimeMng] = None
+        if load_runtime_plugins:
+            self.pluginRuntimeMng = PluginRuntimeMng(self.configMng)
 
 
 def require_active_env(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -123,7 +136,11 @@ def cli(
     }
 
     if ctx.obj is None:
-        ctx.obj = ShepherdMng(cli_flags)
+        ctx.obj = ShepherdMng(
+            cli_flags,
+            load_runtime_plugins=ctx.invoked_subcommand
+            not in {"plugin", "__complete"},
+        )
 
 
 @cli.command(name="test", hidden=True)

--- a/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/__init__.py
+++ b/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/__init__.py
@@ -1,0 +1,1 @@
+# Fixture package for plugin runtime loader tests.

--- a/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/helpers.py
+++ b/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/helpers.py
@@ -1,0 +1,9 @@
+"""
+Fixture helper module imported through a package-absolute path.
+
+The runtime loader tests keep this in a separate module to prove that plugin
+packages can import their own siblings with statements like
+`from fixture_plugin.helpers import ...`.
+"""
+
+COMPLETION_PROVIDER = "observability-completion"

--- a/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py
+++ b/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py
@@ -1,0 +1,39 @@
+from fixture_plugin.helpers import COMPLETION_PROVIDER
+
+from plugin import (
+    PluginCommandSpec,
+    PluginCompletionSpec,
+    PluginFactorySpec,
+    PluginTemplateSpec,
+    ShepherdPlugin,
+)
+
+
+class RuntimeFixturePlugin(ShepherdPlugin):
+    def get_commands(self):
+        return [
+            PluginCommandSpec(scope="observability", verb="tail"),
+            PluginCommandSpec(scope="env", verb="doctor"),
+        ]
+
+    def get_completion_providers(self):
+        return [
+            PluginCompletionSpec(
+                scope="observability",
+                provider=COMPLETION_PROVIDER,
+            )
+        ]
+
+    def get_env_templates(self):
+        return [PluginTemplateSpec(id="baseline", provider={"kind": "env"})]
+
+    def get_service_templates(self):
+        return [PluginTemplateSpec(id="api", provider={"kind": "svc"})]
+
+    def get_env_factories(self):
+        return [
+            PluginFactorySpec(id="baseline-factory", provider="env-factory")
+        ]
+
+    def get_service_factories(self):
+        return [PluginFactorySpec(id="api-factory", provider="svc-factory")]

--- a/src/tests/fixtures/plugins/runtime_plugin/plugin.yaml
+++ b/src/tests/fixtures/plugins/runtime_plugin/plugin.yaml
@@ -1,0 +1,16 @@
+id: runtime-plugin
+name: Runtime Plugin
+version: 1.0.0
+plugin_api_version: 1
+description: Fixture plugin for runtime loader tests
+entrypoint:
+  module: fixture_plugin.main
+  class: RuntimeFixturePlugin
+capabilities:
+  commands: true
+  completion: true
+  templates: true
+  env_factories: true
+  svc_factories: true
+default_config:
+  region: eu-west-1

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -73,7 +73,7 @@ def test_completion_no_args(
     runner: CliRunner,
     mocker: MockerFixture,
 ):
-    sm = ShepherdMng()
+    sm = ShepherdMng(load_runtime_plugins=False)
     completions = sm.completionMng.get_completions([])
     assert completions == sm.completionMng.SCOPES, "Expected scopes only"
 
@@ -84,7 +84,7 @@ def test_completion_global_flags_prefix(
     runner: CliRunner,
     mocker: MockerFixture,
 ):
-    sm = ShepherdMng()
+    sm = ShepherdMng(load_runtime_plugins=False)
     completions = sm.completionMng.get_completions(["--q"])
     assert completions == ["--quiet"], "Expected filtered global flag"
 
@@ -97,7 +97,7 @@ def test_completion_scope_prefix_does_not_suggest_root_flags(
     mocker: MockerFixture,
     args: list[str],
 ):
-    sm = ShepherdMng()
+    sm = ShepherdMng(load_runtime_plugins=False)
     completions = sm.completionMng.get_completions(args)
     assert completions == [], "Expected no root flags after choosing a scope"
 
@@ -115,7 +115,7 @@ def test_completion_add(
     shpd_config = read_fixture("completion", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    sm = ShepherdMng()
+    sm = ShepherdMng(load_runtime_plugins=False)
     completions = sm.completionMng.get_completions(["env"])
     assert (
         completions == sm.completionMng.SCOPE_VERBS["env"]
@@ -128,7 +128,7 @@ def test_completion_plugin_scope(
     runner: CliRunner,
     mocker: MockerFixture,
 ):
-    sm = ShepherdMng()
+    sm = ShepherdMng(load_runtime_plugins=False)
     completions = sm.completionMng.get_completions(["plugin"])
     assert (
         completions == sm.completionMng.SCOPE_VERBS["plugin"]
@@ -156,7 +156,7 @@ def test_completion_plugin_id_verbs(
     shpd_yaml = shpd_path / ".shpd.yaml"
     _write_completion_config_with_plugins(shpd_yaml)
 
-    sm = ShepherdMng()
+    sm = ShepherdMng(load_runtime_plugins=False)
     completions = sm.completionMng.get_completions(args)
     assert completions == [
         "acme",
@@ -175,7 +175,7 @@ def test_completion_plugin_id_prefix(
     shpd_yaml = shpd_path / ".shpd.yaml"
     _write_completion_config_with_plugins(shpd_yaml)
 
-    sm = ShepherdMng()
+    sm = ShepherdMng(load_runtime_plugins=False)
     completions = sm.completionMng.get_completions(["plugin", "get", "ac"])
     assert completions == [
         "acme",

--- a/src/tests/test_plugin_runtime.py
+++ b/src/tests/test_plugin_runtime.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2025 Moony Fringers
+#
+# This file is part of Shepherd Core Stack
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+from pytest_mock import MockerFixture
+from test_util import read_fixture
+
+from shepctl import ShepherdMng, cli
+
+
+@pytest.fixture
+def shpd_conf(tmp_path: Path, mocker: MockerFixture) -> tuple[Path, Path]:
+    temp_home = tmp_path / "home"
+    temp_home.mkdir()
+
+    config_file = temp_home / ".shpd.conf"
+    values = read_fixture("shpd", "values.conf")
+    config_file.write_text(values.replace("${test_path}", str(temp_home)))
+
+    os.environ["SHPD_CONF"] = str(config_file)
+    return temp_home, config_file
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _write_plugin_inventory(
+    config_path: Path, plugins: list[dict[str, object]]
+) -> None:
+    shpd_config = yaml.safe_load(read_fixture("shpd", "shpd.yaml"))
+    shpd_config["plugins"] = plugins
+    config_path.write_text(yaml.dump(shpd_config, sort_keys=False))
+
+
+def _install_fixture_plugin(
+    shpd_path: Path,
+    plugin_id: str = "runtime-plugin",
+    *,
+    version: str = "1.0.0",
+    main_content: str | None = None,
+) -> Path:
+    fixture_root = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "plugins"
+        / "runtime_plugin"
+    )
+    plugin_dir = shpd_path / "plugins" / plugin_id
+    shutil.copytree(fixture_root, plugin_dir)
+
+    descriptor_path = plugin_dir / "plugin.yaml"
+    descriptor = yaml.safe_load(descriptor_path.read_text())
+    descriptor["id"] = plugin_id
+    descriptor["version"] = version
+    descriptor_path.write_text(yaml.dump(descriptor, sort_keys=False))
+
+    if main_content is not None:
+        (plugin_dir / "fixture_plugin" / "main.py").write_text(main_content)
+
+    return plugin_dir
+
+
+@pytest.mark.shpd
+def test_shepherd_loads_enabled_plugin_runtime_registry(
+    shpd_conf: tuple[Path, Path], mocker: MockerFixture
+):
+    """
+    Load the fixture plugin through a real package-absolute import.
+
+    The fixture plugin imports `fixture_plugin.helpers` from its `main.py`.
+    Without the real-module import strategy in the loader, that sibling import
+    would fail during startup because only a synthetic module name would exist.
+    """
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _install_fixture_plugin(shpd_path)
+    _write_plugin_inventory(
+        shpd_yaml,
+        [
+            {
+                "id": "runtime-plugin",
+                "enabled": True,
+                "version": "1.0.0",
+                "config": {"region": "eu-west-1"},
+            }
+        ],
+    )
+
+    shepherd = ShepherdMng()
+
+    assert shepherd.pluginRuntimeMng is not None
+    registry = shepherd.pluginRuntimeMng.registry
+    assert "runtime-plugin" in registry.plugins
+    assert registry.commands["observability"]["tail"] == "runtime-plugin"
+    assert registry.commands["env"]["doctor"] == "runtime-plugin"
+    assert "runtime-plugin/baseline" in registry.env_templates
+    assert "runtime-plugin/api" in registry.service_templates
+    assert "runtime-plugin/baseline-factory" in registry.env_factories
+    assert "runtime-plugin/api-factory" in registry.service_factories
+    assert (
+        registry.completion_providers["observability"][0].provider
+        == "observability-completion"
+    )
+
+
+@pytest.mark.shpd
+def test_shepherd_reloads_same_plugin_root_in_same_process(
+    shpd_conf: tuple[Path, Path], mocker: MockerFixture
+):
+    """
+    Reload the same plugin root cleanly in one Python process.
+
+    Without purging the owned module root before reload, Python would keep the
+    first import cached in `sys.modules` and the second Shepherd bootstrap
+    would see stale plugin code.
+    """
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    plugin_dir = _install_fixture_plugin(shpd_path)
+    _write_plugin_inventory(
+        shpd_yaml,
+        [
+            {
+                "id": "runtime-plugin",
+                "enabled": True,
+                "version": "1.0.0",
+                "config": {"region": "eu-west-1"},
+            }
+        ],
+    )
+
+    shepherd = ShepherdMng()
+    assert shepherd.pluginRuntimeMng is not None
+
+    updated_main = plugin_dir / "fixture_plugin" / "main.py"
+    updated_main.write_text(
+        (
+            "from fixture_plugin.helpers import COMPLETION_PROVIDER\n"
+            "from plugin import ShepherdPlugin\n\n"
+            "class RuntimeFixturePlugin(ShepherdPlugin):\n"
+            "    def get_completion_providers(self):\n"
+            "        return [\n"
+            "            type(\n"
+            "                'CompletionSpec',\n"
+            "                (),\n"
+            "                {\n"
+            "                    'scope': 'observability',\n"
+            "                    'provider': (\n"
+            "                        COMPLETION_PROVIDER + '-reloaded'\n"
+            "                    ),\n"
+            "                },\n"
+            "            )(),\n"
+            "        ]\n"
+        )
+    )
+
+    reloaded = ShepherdMng()
+    assert reloaded.pluginRuntimeMng is not None
+    providers = reloaded.pluginRuntimeMng.registry.completion_providers
+    assert providers["observability"][0].provider == (
+        "observability-completion-reloaded"
+    )
+
+
+@pytest.mark.shpd
+def test_plugin_scope_skips_runtime_loading_for_broken_plugin(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _write_plugin_inventory(
+        shpd_yaml,
+        [
+            {
+                "id": "broken-plugin",
+                "enabled": True,
+                "version": "1.0.0",
+                "config": None,
+            }
+        ],
+    )
+
+    result = runner.invoke(cli, ["plugin", "disable", "broken-plugin"])
+
+    assert result.exit_code == 0
+    assert "Plugin 'broken-plugin' disabled." in result.output
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    assert stored["plugins"][0]["enabled"] is False
+
+
+@pytest.mark.shpd
+def test_normal_startup_fails_for_missing_enabled_plugin(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _write_plugin_inventory(
+        shpd_yaml,
+        [
+            {
+                "id": "broken-plugin",
+                "enabled": True,
+                "version": "1.0.0",
+                "config": None,
+            }
+        ],
+    )
+
+    result = runner.invoke(cli, ["test"])
+
+    assert result.exit_code == 1
+    assert "Enabled plugin 'broken-plugin' is missing" in result.output
+
+
+@pytest.mark.shpd
+def test_startup_fails_for_plugin_command_collision(
+    shpd_conf: tuple[Path, Path], mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _install_fixture_plugin(shpd_path, plugin_id="runtime-plugin")
+    _install_fixture_plugin(shpd_path, plugin_id="collision-plugin")
+    _write_plugin_inventory(
+        shpd_yaml,
+        [
+            {
+                "id": "runtime-plugin",
+                "enabled": True,
+                "version": "1.0.0",
+                "config": None,
+            },
+            {
+                "id": "collision-plugin",
+                "enabled": True,
+                "version": "1.0.0",
+                "config": None,
+            },
+        ],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        ShepherdMng()
+
+    assert excinfo.value.code == 1
+
+
+@pytest.mark.shpd
+def test_startup_fails_for_invalid_plugin_entrypoint(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _install_fixture_plugin(
+        shpd_path,
+        main_content="class RuntimeFixturePlugin:\n    pass\n",
+    )
+    _write_plugin_inventory(
+        shpd_yaml,
+        [
+            {
+                "id": "runtime-plugin",
+                "enabled": True,
+                "version": "1.0.0",
+                "config": None,
+            }
+        ],
+    )
+
+    result = runner.invoke(cli, ["test"])
+
+    assert result.exit_code == 1
+    assert "must implement ShepherdPlugin" in result.output

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -121,7 +121,8 @@ def test_cli_flags_no_flags(
             "show_commands": False,
             "show_commands_limit": 5,
             "yes": False,
-        }
+        },
+        load_runtime_plugins=True,
     )
 
 
@@ -143,12 +144,12 @@ def test_cli_flags_verbose(
     }
 
     assert result.exit_code == 0
-    mock_init.assert_called_once_with(flags)
+    mock_init.assert_called_once_with(flags, load_runtime_plugins=True)
 
     result = runner.invoke(cli, ["-v", "test"])
 
     assert result.exit_code == 0
-    mock_init.assert_called_with(flags)
+    mock_init.assert_called_with(flags, load_runtime_plugins=True)
 
 
 @pytest.mark.shpd
@@ -169,12 +170,48 @@ def test_cli_flags_yes(
     }
 
     assert result.exit_code == 0
-    mock_init.assert_called_once_with(flags)
+    mock_init.assert_called_once_with(flags, load_runtime_plugins=True)
 
     result = runner.invoke(cli, ["-y", "test"])
 
     assert result.exit_code == 0
-    mock_init.assert_called_with(flags)
+    mock_init.assert_called_with(flags, load_runtime_plugins=True)
+
+
+@pytest.mark.shpd
+def test_cli_plugin_scope_uses_safe_bootstrap(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    def fake_init(
+        self: ShepherdMng,
+        cli_flags: dict[str, object],
+        *,
+        load_runtime_plugins: bool,
+    ) -> None:
+        self.pluginMng = mocker.Mock()
+
+    mock_init = mocker.patch.object(
+        ShepherdMng,
+        "__init__",
+        autospec=True,
+        side_effect=fake_init,
+    )
+
+    result = runner.invoke(cli, ["plugin", "list"])
+
+    assert result.exit_code == 0
+    mock_init.assert_called_once_with(
+        mocker.ANY,
+        {
+            "verbose": False,
+            "quiet": False,
+            "details": False,
+            "show_commands": False,
+            "show_commands_limit": 5,
+            "yes": False,
+        },
+        load_runtime_plugins=False,
+    )
 
 
 @pytest.mark.shpd


### PR DESCRIPTION
## Summary
- add the first runtime plugin contract and loader based on installed descriptors and importlib entrypoints
- build in-memory registries for plugin commands, completion providers, templates, and factories with collision checks
- keep the `plugin` management scope on a safe bootstrap path and add fixture coverage for runtime loading and failure cases
- document the new runtime loading behavior in the plugin guide

## Testing
- `python3 -m py_compile src/plugin/runtime.py src/plugin/__init__.py src/shepctl.py src/tests/test_plugin_runtime.py src/tests/test_shepherd.py`
- `cd src && ../.venv/bin/pyright plugin/runtime.py`
- `cd src && ../.venv/bin/pytest`

Fixes: #175
