### PR TITLE
Wire plugin runtime into command tree and completion

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -9,11 +9,13 @@ The current implementation scope is limited to:
 - managed plugin installation directory layout
 - plugin lifecycle commands for install, inspect, enable, disable, and remove
 - runtime loading of enabled plugins via `importlib`
+- executable plugin commands injected into the CLI tree
+- live plugin completion providers executed by the completion engine
 - in-memory registries for plugin commands, completion providers, templates,
   and factories
 
-CLI command injection, completion consumption, and template or factory
-execution still land in later steps of the plugin rollout.
+Template and factory execution still land in later steps of the plugin
+rollout.
 
 For the architectural rationale and staged implementation plan, see
 [ADR 0004](decisions/0004-plugin-architecture-and-rollout-plan.md).
@@ -175,18 +177,58 @@ Template and factory ids are canonicalized under the plugin namespace:
 - factories: `plugin-id/factory-id`
 
 These registries are currently validated and populated at startup. They are not
-yet consumed by the CLI, completion engine, or env and service factory flows.
+yet consumed by env and service factory flows.
+
+## Runtime Command Wiring
+
+Plugin command contributions are now executable.
+
+Each `PluginCommandSpec` declares:
+
+- the target `scope`
+- the target `verb`
+- a ready-to-register Click command object
+
+At startup Shepherd validates that:
+
+- the Click command exists
+- the Click command name matches the declared `verb`
+- the command does not collide with a core command
+- the command does not collide with another plugin command
+
+If a plugin contributes a new top-level scope, Shepherd exposes it as a normal
+CLI scope. If a plugin contributes a verb under an existing scope, Shepherd
+extends that scope in place.
+
+Examples:
+
+- `shepctl observability tail`
+- `shepctl env doctor`
+
+## Runtime Completion Wiring
+
+Plugin completion providers are now executed by the shared completion engine.
+
+Each `PluginCompletionSpec` targets one scope and provides either:
+
+- a callable that accepts the raw completion args and returns suggestions
+- an object exposing `get_completions(args)`
+
+Completion results are merged with the built-in completion managers for the
+same scope. This allows plugins to:
+
+- complete verbs under plugin-owned scopes
+- complete values for plugin-added verbs under existing scopes
+- return dynamic values computed in Python at completion time
 
 ## Scope Of This Step
 
 This documentation matches the current implementation step. At this stage,
 Shepherd does not yet:
 
-- load plugin commands into the CLI
-- load plugin completion providers
 - execute plugin factories or plugin-owned templates through env and svc flows
 
-Plugin archive installation, persisted inventory management, and runtime loader
-bootstrap are available now. Command wiring, completion execution, and factory
-or template consumption are added in follow-up PRs from the plugin rollout
+Plugin archive installation, persisted inventory management, runtime loader
+bootstrap, command wiring, and completion execution are available now. Factory
+and template consumption are added in follow-up PRs from the plugin rollout
 plan.

--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Optional, override
 
 from completion.completion_env import CompletionEnvMng
 from completion.completion_mng import AbstractCompletionMng
+from completion.completion_plugin import CompletionPluginMng
 from completion.completion_probe import CompletionProbeMng
 from completion.completion_svc import CompletionSvcMng
 from config import ConfigMng
@@ -137,6 +138,7 @@ class CompletionMng(AbstractCompletionMng):
         self.configMng = configMng
         self.plugin_registry = plugin_registry
         self.completionEnvMng = CompletionEnvMng(cli_flags, configMng)
+        self.completionPluginMng = CompletionPluginMng(cli_flags, configMng)
         self.completionSvcMng = CompletionSvcMng(cli_flags, configMng)
         self.completionProbeMng = CompletionProbeMng(cli_flags, configMng)
         self._option_by_token: dict[str, CompletionMng.OptionSpec] = {}
@@ -181,6 +183,8 @@ class CompletionMng(AbstractCompletionMng):
     ) -> Optional[AbstractCompletionMng]:
         if scope == "env":
             return self.completionEnvMng
+        if scope == "plugin":
+            return self.completionPluginMng
         if scope == "svc":
             return self.completionSvcMng
         if scope == "probe":
@@ -278,23 +282,6 @@ class CompletionMng(AbstractCompletionMng):
     def _unique(self, values: list[str]) -> list[str]:
         return list(dict.fromkeys(values))
 
-    def _get_plugin_scope_completions(
-        self, sanitized_args: list[str], verb: str, last_token: str
-    ) -> list[str]:
-        if verb in {"get", "enable", "disable", "remove"}:
-            if len(sanitized_args) <= 3:
-                plugin_ids = sorted(
-                    [plugin.id for plugin in self.configMng.get_plugins()]
-                )
-                if len(sanitized_args) == 3 and last_token:
-                    return [
-                        plugin_id
-                        for plugin_id in plugin_ids
-                        if plugin_id.startswith(last_token)
-                    ]
-                return plugin_ids
-        return []
-
     def _get_runtime_provider_completions(
         self, scope: str, sanitized_args: list[str]
     ) -> list[str]:
@@ -381,11 +368,6 @@ class CompletionMng(AbstractCompletionMng):
                     )
                 )
             return self._unique(suggestions)
-
-        if scope == "plugin":
-            return self._get_plugin_scope_completions(
-                sanitized_args, verb, last_token
-            )
 
         provider_suggestions = self._get_runtime_provider_completions(
             scope, sanitized_args

--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -17,13 +17,16 @@
 
 
 from dataclasses import dataclass
-from typing import Any, Optional, override
+from typing import TYPE_CHECKING, Any, Optional, override
 
 from completion.completion_env import CompletionEnvMng
 from completion.completion_mng import AbstractCompletionMng
 from completion.completion_probe import CompletionProbeMng
 from completion.completion_svc import CompletionSvcMng
 from config import ConfigMng
+
+if TYPE_CHECKING:
+    from plugin import PluginRegistry
 
 
 class CompletionMng(AbstractCompletionMng):
@@ -34,7 +37,7 @@ class CompletionMng(AbstractCompletionMng):
     scope, mirroring the Click command tree.
     """
 
-    SCOPE_VERBS = {
+    CORE_SCOPE_VERBS = {
         "plugin": [
             "install",
             "list",
@@ -59,6 +62,7 @@ class CompletionMng(AbstractCompletionMng):
         "svc": ["get", "add", "up", "halt", "reload", "build", "logs", "shell"],
         "probe": ["get", "check"],
     }
+    SCOPE_VERBS = CORE_SCOPE_VERBS
 
     @dataclass(frozen=True)
     class OptionSpec:
@@ -123,9 +127,15 @@ class CompletionMng(AbstractCompletionMng):
         ("probe", "check"): (OptionSpec(tokens=("-a", "--all")),),
     }
 
-    def __init__(self, cli_flags: dict[str, Any], configMng: ConfigMng):
+    def __init__(
+        self,
+        cli_flags: dict[str, Any],
+        configMng: ConfigMng,
+        plugin_registry: "PluginRegistry | None" = None,
+    ):
         self.cli_flags = cli_flags
         self.configMng = configMng
+        self.plugin_registry = plugin_registry
         self.completionEnvMng = CompletionEnvMng(cli_flags, configMng)
         self.completionSvcMng = CompletionSvcMng(cli_flags, configMng)
         self.completionProbeMng = CompletionProbeMng(cli_flags, configMng)
@@ -140,7 +150,23 @@ class CompletionMng(AbstractCompletionMng):
 
     @property
     def SCOPES(self) -> list[str]:
-        return list(self.SCOPE_VERBS.keys())
+        return list(self.scope_verbs.keys())
+
+    @property
+    def scope_verbs(self) -> dict[str, list[str]]:
+        """Return core verbs merged with plugin-contributed scope verbs."""
+        merged = {
+            scope: list(verbs) for scope, verbs in self.CORE_SCOPE_VERBS.items()
+        }
+        if self.plugin_registry is None:
+            return merged
+
+        for scope, commands in self.plugin_registry.commands.items():
+            verbs = merged.setdefault(scope, [])
+            for verb in commands:
+                if verb not in verbs:
+                    verbs.append(verb)
+        return merged
 
     def is_scope_chosen(self, args: list[str]) -> bool:
         return bool(args) and args[0] in self.SCOPES
@@ -148,7 +174,7 @@ class CompletionMng(AbstractCompletionMng):
     def is_verb_chosen(self, args: list[str]) -> bool:
         if len(args) < 2:
             return False
-        return args[1] in self.SCOPE_VERBS.get(args[0], [])
+        return args[1] in self.scope_verbs.get(args[0], [])
 
     def get_completion_manager(
         self, scope: Optional[str]
@@ -218,7 +244,7 @@ class CompletionMng(AbstractCompletionMng):
                 scope = token
                 continue
             if verb is None and scope is not None:
-                if token in self.SCOPE_VERBS.get(scope, []):
+                if token in self.scope_verbs.get(scope, []):
                     verb = token
 
         return sanitized, scope, verb, used_options, expect_value_for
@@ -252,7 +278,7 @@ class CompletionMng(AbstractCompletionMng):
     def _unique(self, values: list[str]) -> list[str]:
         return list(dict.fromkeys(values))
 
-    def _get_plugin_completions(
+    def _get_plugin_scope_completions(
         self, sanitized_args: list[str], verb: str, last_token: str
     ) -> list[str]:
         if verb in {"get", "enable", "disable", "remove"}:
@@ -268,6 +294,40 @@ class CompletionMng(AbstractCompletionMng):
                     ]
                 return plugin_ids
         return []
+
+    def _get_runtime_provider_completions(
+        self, scope: str, sanitized_args: list[str]
+    ) -> list[str]:
+        """Execute plugin completion providers registered for one scope."""
+        if self.plugin_registry is None:
+            return []
+
+        suggestions: list[str] = []
+        for provider_spec in self.plugin_registry.completion_providers.get(
+            scope, []
+        ):
+            provider = provider_spec.provider
+            if callable(provider):
+                suggestions.extend(
+                    self._normalize_provider_suggestions(
+                        provider(sanitized_args)
+                    )
+                )
+                continue
+            get_completions = getattr(provider, "get_completions", None)
+            if callable(get_completions):
+                suggestions.extend(
+                    self._normalize_provider_suggestions(
+                        get_completions(sanitized_args)
+                    )
+                )
+        return suggestions
+
+    def _normalize_provider_suggestions(self, values: Any) -> list[str]:
+        """Normalize plugin completion provider output to string suggestions."""
+        if isinstance(values, str):
+            return [values]
+        return [value for value in values if isinstance(value, str)]
 
     @override
     def get_completions_impl(self, args: list[str]) -> list[str]:
@@ -313,7 +373,7 @@ class CompletionMng(AbstractCompletionMng):
             )
 
         if not verb:
-            suggestions = list(self.SCOPE_VERBS.get(scope, []))
+            suggestions = list(self.scope_verbs.get(scope, []))
             if not suggestions:
                 suggestions.extend(
                     self._get_option_suggestions(
@@ -323,13 +383,17 @@ class CompletionMng(AbstractCompletionMng):
             return self._unique(suggestions)
 
         if scope == "plugin":
-            return self._get_plugin_completions(
+            return self._get_plugin_scope_completions(
                 sanitized_args, verb, last_token
             )
 
+        provider_suggestions = self._get_runtime_provider_completions(
+            scope, sanitized_args
+        )
         completion_manager = self.get_completion_manager(scope)
         if completion_manager:
             suggestions = completion_manager.get_completions(sanitized_args)
+            suggestions.extend(provider_suggestions)
             if option_prefix is not None:
                 suggestions.extend(
                     self._get_option_suggestions(
@@ -345,5 +409,8 @@ class CompletionMng(AbstractCompletionMng):
                     )
                 )
             return self._unique(suggestions)
+
+        if provider_suggestions:
+            return self._unique(provider_suggestions)
 
         return []

--- a/src/completion/completion_mng.py
+++ b/src/completion/completion_mng.py
@@ -24,8 +24,16 @@ from config import ConfigMng
 
 class AbstractCompletionMng(ABC):
     """
-    Abstract base class for completion managers.
-    This class defines the interface for completion managers.
+    Internal base class for built-in scope completion managers.
+
+    Concrete managers implement completion for one CLI scope, such as `env`,
+    `svc`, `probe`, or the built-in administrative `plugin` scope. The
+    top-level `CompletionMng` routes the raw argv to one of these managers once
+    it has identified the active scope and verb.
+
+    This abstraction is intentionally internal to Shepherd's built-in
+    completion package. External plugins use the public plugin API from
+    `plugin.api` instead of subclassing this base directly.
     """
 
     def __init__(self, cli_flags: dict[str, Any], configMng: ConfigMng):
@@ -34,10 +42,15 @@ class AbstractCompletionMng(ABC):
 
     def get_completions(self, args: list[str]) -> list[str]:
         """
-        Public completion entrypoint used by the CLI completion command.
+        Return scope-local completion suggestions for raw CLI argv.
+
+        `args` still contains the scope and verb tokens. Individual managers
+        are free to dispatch directly on that raw argv or slice it further for
+        command-local helper methods.
         """
         return self.get_completions_impl(args)
 
     @abstractmethod
     def get_completions_impl(self, args: list[str]) -> list[str]:
+        """Implement scope-specific completion logic."""
         pass

--- a/src/completion/completion_plugin.py
+++ b/src/completion/completion_plugin.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2025 Moony Fringers
+#
+# This file is part of Shepherd Core Stack
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Any, override
+
+from completion.completion_mng import AbstractCompletionMng
+from config import ConfigMng
+
+
+class CompletionPluginMng(AbstractCompletionMng):
+    """Administrative plugin scope completer."""
+
+    def __init__(self, cli_flags: dict[str, Any], configMng: ConfigMng):
+        self.cli_flags = cli_flags
+        self.configMng = configMng
+
+    @override
+    def get_completions_impl(self, args: list[str]) -> list[str]:
+        """Complete plugin inventory verbs that take a plugin id argument."""
+        if len(args) < 2:
+            return []
+
+        verb = args[1]
+        if verb not in {"get", "enable", "disable", "remove"}:
+            return []
+
+        plugin_ids = sorted(
+            [plugin.id for plugin in self.configMng.get_plugins()]
+        )
+        local_args = args[2:]
+        if len(local_args) > 1:
+            return []
+        if len(local_args) == 1:
+            prefix = local_args[0]
+            return [
+                plugin_id
+                for plugin_id in plugin_ids
+                if plugin_id.startswith(prefix)
+            ]
+        return plugin_ids

--- a/src/plugin/api.py
+++ b/src/plugin/api.py
@@ -21,13 +21,22 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import Any, Sequence
 
+import click
+
 
 @dataclass(frozen=True)
 class PluginCommandSpec:
-    """One scope/verb pair contributed by a plugin."""
+    """
+    One executable scope and verb contribution declared by a plugin.
+
+    `command` must be a ready-to-register Click command for the declared verb.
+    Shepherd validates that the Click command name matches `verb` before
+    exposing it through the runtime registry.
+    """
 
     scope: str
     verb: str
+    command: click.Command
 
 
 @dataclass(frozen=True)
@@ -35,10 +44,13 @@ class PluginCompletionSpec:
     """
     One completion provider contribution keyed by scope.
 
-    `provider` is intentionally untyped in this step because the runtime
-    loader only stores provider objects in the registry; it does not invoke
-    them yet. A later completion-integration step will narrow this to the
-    concrete callable or provider protocol the completion engine expects.
+    `provider` may be either:
+
+    * a callable accepting the raw completion args and returning suggestions
+    * an object exposing `get_completions(args)`
+
+    The runtime validates that one of those two execution shapes is present
+    before adding the provider to the registry.
     """
 
     scope: str

--- a/src/plugin/runtime.py
+++ b/src/plugin/runtime.py
@@ -22,8 +22,9 @@ import os
 import sys
 from dataclasses import dataclass, field
 from types import ModuleType
-from typing import Sequence
+from typing import Any, Sequence
 
+import click
 import yaml
 
 from completion import CompletionMng
@@ -50,8 +51,8 @@ def _loaded_plugin_registry() -> dict[str, "LoadedPlugin"]:
     return {}
 
 
-def _command_registry() -> dict[str, dict[str, str]]:
-    """Create a typed default for contributed scope and verb ownership."""
+def _command_registry() -> dict[str, dict[str, "RegisteredPluginCommand"]]:
+    """Create a typed default for contributed executable commands."""
     return {}
 
 
@@ -93,7 +94,7 @@ class PluginRegistry:
     plugins: dict[str, LoadedPlugin] = field(
         default_factory=_loaded_plugin_registry
     )
-    commands: dict[str, dict[str, str]] = field(
+    commands: dict[str, dict[str, "RegisteredPluginCommand"]] = field(
         default_factory=_command_registry
     )
     completion_providers: dict[str, list[PluginCompletionSpec]] = field(
@@ -113,6 +114,14 @@ class PluginRegistry:
     )
 
 
+@dataclass(frozen=True)
+class RegisteredPluginCommand:
+    """One validated command contribution stored in the runtime registry."""
+
+    plugin_id: str
+    spec: PluginCommandSpec
+
+
 class PluginRuntimeMng:
     """
     Load enabled plugins and register their declared runtime contributions.
@@ -123,7 +132,8 @@ class PluginRuntimeMng:
     """
 
     CORE_SCOPE_VERBS = {
-        scope: set(verbs) for scope, verbs in CompletionMng.SCOPE_VERBS.items()
+        scope: set(verbs)
+        for scope, verbs in CompletionMng.CORE_SCOPE_VERBS.items()
     }
 
     def __init__(self, configMng: ConfigMng):
@@ -372,6 +382,7 @@ class PluginRuntimeMng:
         for command in commands:
             scope = command.scope
             verb = command.verb
+            command_obj: Any = command.command
             if (scope, verb) in seen:
                 Util.print_error_and_die(
                     f"Plugin '{plugin_id}' declares duplicate command "
@@ -379,10 +390,25 @@ class PluginRuntimeMng:
                 )
             seen.add((scope, verb))
 
+            if scope == "plugin":
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' command '{scope} {verb}' "
+                    "uses reserved administrative scope 'plugin'."
+                )
             if verb in self.CORE_SCOPE_VERBS.get(scope, set()):
                 Util.print_error_and_die(
                     f"Plugin '{plugin_id}' command '{scope} {verb}' "
                     "collides with a core command."
+                )
+            if not isinstance(command_obj, click.Command):
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' command '{scope} {verb}' must "
+                    "provide a Click command."
+                )
+            if command_obj.name != verb:
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' command '{scope} {verb}' must "
+                    "use a Click command with the same verb name."
                 )
 
             scope_commands = self.registry.commands.setdefault(scope, {})
@@ -390,9 +416,11 @@ class PluginRuntimeMng:
             if owner is not None:
                 Util.print_error_and_die(
                     f"Plugin '{plugin_id}' command '{scope} {verb}' "
-                    f"collides with plugin '{owner}'."
+                    f"collides with plugin '{owner.plugin_id}'."
                 )
-            scope_commands[verb] = plugin_id
+            scope_commands[verb] = RegisteredPluginCommand(
+                plugin_id=plugin_id, spec=command
+            )
 
     def _register_completion_providers(
         self,
@@ -407,10 +435,24 @@ class PluginRuntimeMng:
                     f"Plugin '{plugin_id}' declares multiple completion "
                     f"providers for scope '{provider.scope}'."
                 )
+            if not self._is_completion_provider(provider.provider):
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' completion provider for scope "
+                    f"'{provider.scope}' must be callable or expose "
+                    "'get_completions(args)'."
+                )
             seen_scopes.add(provider.scope)
             self.registry.completion_providers.setdefault(
                 provider.scope, []
             ).append(provider)
+
+    def _is_completion_provider(self, provider: Any) -> bool:
+        """
+        Return whether the completion provider exposes an executable shape.
+        """
+        if callable(provider):
+            return True
+        return callable(getattr(provider, "get_completions", None))
 
     def _register_templates(
         self,

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -52,6 +52,7 @@ class ShepherdMng:
         cli_flags: dict[str, Any] = {},
         *,
         load_runtime_plugins: bool = True,
+        plugin_runtime_mng: Optional[PluginRuntimeMng] = None,
     ):
         shpd_conf = os.environ.get("SHPD_CONF", "~/.shpd.conf")
         self.configMng = ConfigMng(shpd_conf)
@@ -70,7 +71,6 @@ class ShepherdMng:
         Util.ensure_config_file(self.configMng.constants)
         self.configMng.load()
         self.configMng.ensure_dirs()
-        self.completionMng = CompletionMng(self.cli_flags, self.configMng)
         self.svcFactory = ShpdServiceFactory(self.configMng)
         self.envFactory = ShpdEnvironmentFactory(
             self.configMng, self.svcFactory, cli_flags=self.cli_flags
@@ -82,9 +82,98 @@ class ShepherdMng:
             self.cli_flags, self.configMng, self.svcFactory
         )
         self.pluginMng = PluginMng(self.cli_flags, self.configMng)
-        self.pluginRuntimeMng: Optional[PluginRuntimeMng] = None
-        if load_runtime_plugins:
+        self.pluginRuntimeMng = plugin_runtime_mng
+        if self.pluginRuntimeMng is None and load_runtime_plugins:
             self.pluginRuntimeMng = PluginRuntimeMng(self.configMng)
+        self.completionMng = CompletionMng(
+            self.cli_flags,
+            self.configMng,
+            (
+                None
+                if self.pluginRuntimeMng is None
+                else self.pluginRuntimeMng.registry
+            ),
+        )
+
+
+def _load_plugin_runtime_for_click(ctx: click.Context) -> PluginRuntimeMng:
+    """
+    Load and cache the runtime plugin manager for Click command resolution.
+
+    Click resolves commands before the root callback creates `ShepherdMng`, so
+    plugin-provided scopes and verbs need a small pre-bootstrap path. The
+    cached runtime manager lives on the root Click context to avoid repeated
+    loads during one invocation.
+    """
+    root_ctx = ctx.find_root()
+    runtime_mng = root_ctx.meta.get("plugin_runtime_mng")
+    if runtime_mng is not None:
+        return runtime_mng
+
+    shpd_conf = os.environ.get("SHPD_CONF", "~/.shpd.conf")
+    configMng = ConfigMng(shpd_conf)
+    Util.ensure_shpd_dirs(configMng.constants)
+    Util.ensure_config_file(configMng.constants)
+    configMng.load()
+    configMng.ensure_dirs()
+    runtime_mng = PluginRuntimeMng(configMng)
+    root_ctx.meta["plugin_runtime_mng"] = runtime_mng
+    return runtime_mng
+
+
+class PluginRootGroup(click.Group):
+    """Root Click group extended with runtime plugin scopes."""
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        commands = list(super().list_commands(ctx))
+        registry = _load_plugin_runtime_for_click(ctx).registry
+        for scope in sorted(registry.commands):
+            if scope not in commands:
+                commands.append(scope)
+        return commands
+
+    def get_command(
+        self, ctx: click.Context, cmd_name: str
+    ) -> Optional[click.Command]:
+        command = super().get_command(ctx, cmd_name)
+        if command is not None:
+            return command
+
+        registry = _load_plugin_runtime_for_click(ctx).registry
+        if cmd_name in registry.commands:
+            return PluginScopeGroup(
+                name=cmd_name,
+                help=f"Manage plugin scope '{cmd_name}'.",
+            )
+        return None
+
+
+class PluginScopeGroup(click.Group):
+    """Click scope group extended with runtime plugin verbs."""
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        commands = list(super().list_commands(ctx))
+        if self.name == "plugin":
+            return commands
+
+        registry = _load_plugin_runtime_for_click(ctx).registry
+        for verb in sorted(registry.commands.get(self.name or "", {})):
+            if verb not in commands:
+                commands.append(verb)
+        return commands
+
+    def get_command(
+        self, ctx: click.Context, cmd_name: str
+    ) -> Optional[click.Command]:
+        command = super().get_command(ctx, cmd_name)
+        if command is not None or self.name == "plugin":
+            return command
+
+        registry = _load_plugin_runtime_for_click(ctx).registry
+        registered = registry.commands.get(self.name or "", {}).get(cmd_name)
+        if registered is None:
+            return None
+        return registered.spec.command
 
 
 def require_active_env(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -107,7 +196,7 @@ def require_active_env(func: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
-@click.group()
+@click.group(cls=PluginRootGroup)
 @click.option("-v", "--verbose", is_flag=True, help="Enable verbose mode.")
 @click.option("--quiet", is_flag=True, help="Suppress command output.")
 @click.option(
@@ -136,11 +225,19 @@ def cli(
     }
 
     if ctx.obj is None:
-        ctx.obj = ShepherdMng(
-            cli_flags,
-            load_runtime_plugins=ctx.invoked_subcommand
-            not in {"plugin", "__complete"},
-        )
+        load_runtime_plugins = ctx.invoked_subcommand != "plugin"
+        preloaded_runtime = ctx.meta.get("plugin_runtime_mng")
+        if preloaded_runtime is None:
+            ctx.obj = ShepherdMng(
+                cli_flags,
+                load_runtime_plugins=load_runtime_plugins,
+            )
+        else:
+            ctx.obj = ShepherdMng(
+                cli_flags,
+                load_runtime_plugins=load_runtime_plugins,
+                plugin_runtime_mng=preloaded_runtime,
+            )
 
 
 @cli.command(name="test", hidden=True)
@@ -185,7 +282,7 @@ def complete(shepherd: ShepherdMng, args: Any):
 # =====================================================
 # ENV
 # =====================================================
-@cli.group()
+@cli.group(cls=PluginScopeGroup)
 def env():
     """Manage environments."""
     pass
@@ -430,7 +527,7 @@ def status_env(
 # =====================================================
 # SVC
 # =====================================================
-@cli.group()
+@cli.group(cls=PluginScopeGroup)
 def svc():
     """Manage services."""
     pass
@@ -583,7 +680,7 @@ def shell(
 # =====================================================
 # PROBE
 # =====================================================
-@cli.group()
+@cli.group(cls=PluginScopeGroup)
 def probe():
     """Manage probes."""
     pass
@@ -644,7 +741,7 @@ def check_probe(
 # =====================================================
 # PLUGIN
 # =====================================================
-@cli.group()
+@cli.group(cls=PluginScopeGroup)
 def plugin():
     """Manage plugins."""
     pass

--- a/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/helpers.py
+++ b/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/helpers.py
@@ -4,6 +4,17 @@ Fixture helper module imported through a package-absolute path.
 The runtime loader tests keep this in a separate module to prove that plugin
 packages can import their own siblings with statements like
 `from fixture_plugin.helpers import ...`.
+
+The helper also exposes the dynamic completion callable used by the plugin
+fixture. That lets the tests cover both the import fix and the later runtime
+execution path for plugin-provided completion values.
 """
 
-COMPLETION_PROVIDER = "observability-completion"
+
+def complete_observability(args: list[str]) -> list[str]:
+    """Return dynamic completion values for the fixture plugin scopes."""
+    if args[:2] == ["observability", "tail"]:
+        return ["logs", "metrics", "traces"]
+    if args[:2] == ["env", "doctor"]:
+        return ["containers", "network", "volumes"]
+    return []

--- a/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py
+++ b/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py
@@ -1,4 +1,5 @@
-from fixture_plugin.helpers import COMPLETION_PROVIDER
+import click
+from fixture_plugin.helpers import complete_observability
 
 from plugin import (
     PluginCommandSpec,
@@ -11,17 +12,32 @@ from plugin import (
 
 class RuntimeFixturePlugin(ShepherdPlugin):
     def get_commands(self):
+        @click.command(name="tail")
+        @click.argument("target", required=False)
+        def tail(target: str | None):
+            click.echo(f"plugin-tail:{target or 'default'}")
+
+        @click.command(name="doctor")
+        @click.argument("subject", required=False)
+        def doctor(subject: str | None):
+            click.echo(f"plugin-doctor:{subject or 'default'}")
+
         return [
-            PluginCommandSpec(scope="observability", verb="tail"),
-            PluginCommandSpec(scope="env", verb="doctor"),
+            PluginCommandSpec(
+                scope="observability",
+                verb="tail",
+                command=tail,
+            ),
+            PluginCommandSpec(scope="env", verb="doctor", command=doctor),
         ]
 
     def get_completion_providers(self):
         return [
             PluginCompletionSpec(
                 scope="observability",
-                provider=COMPLETION_PROVIDER,
-            )
+                provider=complete_observability,
+            ),
+            PluginCompletionSpec(scope="env", provider=complete_observability),
         ]
 
     def get_env_templates(self):

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 from pathlib import Path
 
 import pytest
@@ -65,6 +66,17 @@ def _write_completion_config_with_plugins(config_path: Path) -> None:
         },
     ]
     config_path.write_text(yaml.dump(shpd_config, sort_keys=False))
+
+
+def _install_runtime_fixture_plugin(shpd_path: Path) -> None:
+    fixture_root = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "plugins"
+        / "runtime_plugin"
+    )
+    plugin_dir = shpd_path / "plugins" / "runtime-plugin"
+    shutil.copytree(fixture_root, plugin_dir)
 
 
 @pytest.mark.compl
@@ -118,7 +130,7 @@ def test_completion_add(
     sm = ShepherdMng(load_runtime_plugins=False)
     completions = sm.completionMng.get_completions(["env"])
     assert (
-        completions == sm.completionMng.SCOPE_VERBS["env"]
+        completions == sm.completionMng.scope_verbs["env"]
     ), "Expected env verbs"
 
 
@@ -131,8 +143,69 @@ def test_completion_plugin_scope(
     sm = ShepherdMng(load_runtime_plugins=False)
     completions = sm.completionMng.get_completions(["plugin"])
     assert (
-        completions == sm.completionMng.SCOPE_VERBS["plugin"]
+        completions == sm.completionMng.scope_verbs["plugin"]
     ), "Expected plugin verbs"
+
+
+@pytest.mark.compl
+def test_completion_includes_plugin_scope_and_scope_extension(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _write_completion_config_with_plugins(shpd_yaml)
+    _install_runtime_fixture_plugin(shpd_path)
+    shpd_config = yaml.safe_load(shpd_yaml.read_text())
+    shpd_config["plugins"] = [
+        {
+            "id": "runtime-plugin",
+            "enabled": True,
+            "version": "1.0.0",
+            "config": None,
+        }
+    ]
+    shpd_yaml.write_text(yaml.dump(shpd_config, sort_keys=False))
+
+    sm = ShepherdMng()
+
+    assert "observability" in sm.completionMng.get_completions([])
+    assert "doctor" in sm.completionMng.get_completions(["env"])
+
+
+@pytest.mark.compl
+def test_completion_executes_runtime_plugin_provider(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = yaml.safe_load(read_fixture("completion", "shpd.yaml"))
+    shpd_config["plugins"] = [
+        {
+            "id": "runtime-plugin",
+            "enabled": True,
+            "version": "1.0.0",
+            "config": None,
+        }
+    ]
+    shpd_yaml.write_text(yaml.dump(shpd_config, sort_keys=False))
+    _install_runtime_fixture_plugin(shpd_path)
+
+    sm = ShepherdMng()
+
+    assert sm.completionMng.get_completions(["observability", "tail"]) == [
+        "logs",
+        "metrics",
+        "traces",
+    ]
+    assert sm.completionMng.get_completions(["env", "doctor"]) == [
+        "containers",
+        "network",
+        "volumes",
+    ]
 
 
 @pytest.mark.compl

--- a/src/tests/test_plugin_runtime.py
+++ b/src/tests/test_plugin_runtime.py
@@ -115,16 +115,15 @@ def test_shepherd_loads_enabled_plugin_runtime_registry(
     assert shepherd.pluginRuntimeMng is not None
     registry = shepherd.pluginRuntimeMng.registry
     assert "runtime-plugin" in registry.plugins
-    assert registry.commands["observability"]["tail"] == "runtime-plugin"
-    assert registry.commands["env"]["doctor"] == "runtime-plugin"
+    assert registry.commands["observability"]["tail"].plugin_id == (
+        "runtime-plugin"
+    )
+    assert registry.commands["env"]["doctor"].plugin_id == "runtime-plugin"
     assert "runtime-plugin/baseline" in registry.env_templates
     assert "runtime-plugin/api" in registry.service_templates
     assert "runtime-plugin/baseline-factory" in registry.env_factories
     assert "runtime-plugin/api-factory" in registry.service_factories
-    assert (
-        registry.completion_providers["observability"][0].provider
-        == "observability-completion"
-    )
+    assert callable(registry.completion_providers["observability"][0].provider)
 
 
 @pytest.mark.shpd
@@ -159,7 +158,7 @@ def test_shepherd_reloads_same_plugin_root_in_same_process(
     updated_main = plugin_dir / "fixture_plugin" / "main.py"
     updated_main.write_text(
         (
-            "from fixture_plugin.helpers import COMPLETION_PROVIDER\n"
+            "from fixture_plugin.helpers import complete_observability\n"
             "from plugin import ShepherdPlugin\n\n"
             "class RuntimeFixturePlugin(ShepherdPlugin):\n"
             "    def get_completion_providers(self):\n"
@@ -169,8 +168,11 @@ def test_shepherd_reloads_same_plugin_root_in_same_process(
             "                (),\n"
             "                {\n"
             "                    'scope': 'observability',\n"
-            "                    'provider': (\n"
-            "                        COMPLETION_PROVIDER + '-reloaded'\n"
+            "                    'provider': staticmethod(\n"
+            "                        lambda args: [\n"
+            "                            complete_observability(args)[0]\n"
+            "                            + '-reloaded'\n"
+            "                        ]\n"
             "                    ),\n"
             "                },\n"
             "            )(),\n"
@@ -181,9 +183,103 @@ def test_shepherd_reloads_same_plugin_root_in_same_process(
     reloaded = ShepherdMng()
     assert reloaded.pluginRuntimeMng is not None
     providers = reloaded.pluginRuntimeMng.registry.completion_providers
-    assert providers["observability"][0].provider == (
-        "observability-completion-reloaded"
+    assert providers["observability"][0].provider(
+        ["observability", "tail"]
+    ) == ["logs-reloaded"]
+
+
+@pytest.mark.shpd
+def test_cli_executes_plugin_scope_and_verb(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _install_fixture_plugin(shpd_path)
+    _write_plugin_inventory(
+        shpd_yaml,
+        [
+            {
+                "id": "runtime-plugin",
+                "enabled": True,
+                "version": "1.0.0",
+                "config": None,
+            }
+        ],
     )
+
+    result = runner.invoke(cli, ["observability", "tail", "logs"])
+
+    assert result.exit_code == 0
+    assert "plugin-tail:logs" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_executes_plugin_verb_under_core_scope(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _install_fixture_plugin(shpd_path)
+    _write_plugin_inventory(
+        shpd_yaml,
+        [
+            {
+                "id": "runtime-plugin",
+                "enabled": True,
+                "version": "1.0.0",
+                "config": None,
+            }
+        ],
+    )
+
+    result = runner.invoke(cli, ["env", "doctor", "network"])
+
+    assert result.exit_code == 0
+    assert "plugin-doctor:network" in result.output
+
+
+@pytest.mark.shpd
+def test_startup_rejects_plugin_commands_under_reserved_plugin_scope(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _install_fixture_plugin(
+        shpd_path,
+        main_content=(
+            "import click\n"
+            "from plugin import PluginCommandSpec, ShepherdPlugin\n\n"
+            "class RuntimeFixturePlugin(ShepherdPlugin):\n"
+            "    def get_commands(self):\n"
+            "        @click.command(name='doctor')\n"
+            "        def doctor():\n"
+            "            click.echo('reserved')\n"
+            "        return [\n"
+            "            PluginCommandSpec(\n"
+            "                scope='plugin',\n"
+            "                verb='doctor',\n"
+            "                command=doctor,\n"
+            "            )\n"
+            "        ]\n"
+        ),
+    )
+    _write_plugin_inventory(
+        shpd_yaml,
+        [
+            {
+                "id": "runtime-plugin",
+                "enabled": True,
+                "version": "1.0.0",
+                "config": None,
+            }
+        ],
+    )
+
+    result = runner.invoke(cli, ["test"])
+
+    assert result.exit_code == 1
+    assert "uses reserved" in result.output
+    assert "administrative scope 'plugin'" in result.output
 
 
 @pytest.mark.shpd

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -21,7 +21,9 @@ import io
 import os
 import tarfile
 from pathlib import Path
+from types import SimpleNamespace
 
+import click
 import pytest
 import yaml
 from click.testing import CliRunner
@@ -30,6 +32,8 @@ from test_util import read_fixture
 
 from config import EnvironmentCfg
 from environment import EnvironmentMng
+from plugin import PluginCommandSpec
+from plugin.runtime import RegisteredPluginCommand
 from service import ServiceMng
 from shepctl import ShepherdMng, cli
 from util.constants import Constants
@@ -211,6 +215,59 @@ def test_cli_plugin_scope_uses_safe_bootstrap(
             "yes": False,
         },
         load_runtime_plugins=False,
+    )
+
+
+@pytest.mark.shpd
+def test_cli_reuses_preloaded_runtime_for_plugin_commands(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    @click.command(name="tail")
+    def tail() -> None:
+        click.echo("plugin-tail")
+
+    fake_runtime = SimpleNamespace(
+        registry=SimpleNamespace(
+            commands={
+                "observability": {
+                    "tail": RegisteredPluginCommand(
+                        plugin_id="runtime-plugin",
+                        spec=PluginCommandSpec(
+                            scope="observability",
+                            verb="tail",
+                            command=tail,
+                        ),
+                    )
+                }
+            }
+        )
+    )
+
+    def fake_loader(ctx: click.Context) -> SimpleNamespace:
+        ctx.find_root().meta["plugin_runtime_mng"] = fake_runtime
+        return fake_runtime
+
+    mock_loader = mocker.patch(
+        "shepctl._load_plugin_runtime_for_click",
+        side_effect=fake_loader,
+    )
+    mock_init = mocker.patch.object(ShepherdMng, "__init__", return_value=None)
+
+    result = runner.invoke(cli, ["observability", "tail"])
+
+    assert result.exit_code == 0
+    mock_loader.assert_called()
+    mock_init.assert_called_once_with(
+        {
+            "verbose": False,
+            "quiet": False,
+            "details": False,
+            "show_commands": False,
+            "show_commands_limit": 5,
+            "yes": False,
+        },
+        load_runtime_plugins=True,
+        plugin_runtime_mng=fake_runtime,
     )
 
 


### PR DESCRIPTION
## Summary
- wire runtime plugin command specs into the Click command tree
- execute runtime plugin completion providers and merge them with core completion
- document the now-supported command and completion plugin model

## Testing
- `python3 -m py_compile src/plugin/api.py src/plugin/runtime.py src/shepctl.py src/completion/completion.py src/tests/test_plugin_runtime.py src/tests/test_completion.py src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/helpers.py`
- `cd src && ../.venv/bin/pyright plugin/api.py plugin/runtime.py completion/completion.py`
- `cd src && ../.venv/bin/pytest tests/test_plugin_runtime.py tests/test_completion.py`
- `cd src && ../.venv/bin/pytest`

Fixes: #177
