### PR TITLE
feat(plugin): resolve templates and factories at runtime

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -13,9 +13,8 @@ The current implementation scope is limited to:
 - live plugin completion providers executed by the completion engine
 - in-memory registries for plugin commands, completion providers, templates,
   and factories
-
-Template and factory execution still land in later steps of the plugin
-rollout.
+- env and service flows resolving plugin-owned templates and factories at
+  runtime
 
 For the architectural rationale and staged implementation plan, see
 [ADR 0004](decisions/0004-plugin-architecture-and-rollout-plan.md).
@@ -28,6 +27,13 @@ Shepherd reserves a managed plugin root under the local Shepherd home:
 
 ```text
 ~/.shpd/plugins/<plugin-id>/
+```
+
+Plugin-owned service template assets are resolved from the installed plugin
+directory using this convention:
+
+```text
+~/.shpd/plugins/<plugin-id>/templates/svcs/<template-id>/
 ```
 
 The install directory is derived from the managed root and the plugin id. It is
@@ -177,7 +183,8 @@ Template and factory ids are canonicalized under the plugin namespace:
 - factories: `plugin-id/factory-id`
 
 These registries are currently validated and populated at startup. They are not
-yet consumed by env and service factory flows.
+just metadata anymore: env and service commands now resolve namespaced
+template and factory ids through them.
 
 ## Runtime Command Wiring
 
@@ -224,11 +231,20 @@ same scope. This allows plugins to:
 ## Scope Of This Step
 
 This documentation matches the current implementation step. At this stage,
-Shepherd does not yet:
+Shepherd now does:
 
-- execute plugin factories or plugin-owned templates through env and svc flows
+- execute plugin-owned environment factories through `env add` and normal env
+  rehydration
+- execute plugin-owned service factories through `svc add` and normal service
+  rehydration
+- resolve plugin-owned templates from canonical namespaced ids like
+  `runtime-plugin/baseline`
+- surface plugin-owned env and svc templates through the built-in completion
+  managers
+- copy plugin-owned service template assets from the installed plugin tree
+  during environment realization
 
 Plugin archive installation, persisted inventory management, runtime loader
-bootstrap, command wiring, and completion execution are available now. Factory
-and template consumption are added in follow-up PRs from the plugin rollout
-plan.
+bootstrap, command wiring, completion execution, and template/factory
+consumption are available now. A later rollout step can still align more core
+behavior behind the same plugin abstraction.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -107,6 +107,18 @@ capabilities:
   svc_factories: true
 default_config:
   region: eu-west-1
+env_templates:
+  - tag: baseline
+    factory: baseline-factory
+    service_templates:
+      - template: api
+        tag: plugin-api
+service_templates:
+  - tag: api
+    factory: api-factory
+    containers:
+      - image: busybox:stable-glibc
+        tag: app
 ```
 
 Required fields:
@@ -123,9 +135,16 @@ Optional fields:
 - `description`
 - `capabilities`
 - `default_config`
+- `env_templates`
+- `service_templates`
 
 Capability flags must be real YAML booleans. String values such as `"false"` or
 `"0"` are rejected during descriptor validation.
+
+Plugin-owned env and service templates are now declared declaratively in
+`plugin.yaml`, using the same schema shapes as the core Shepherd config. This
+keeps template authoring data-driven. Python plugin code is only needed for
+behavioral extensions like commands, completion, and factories.
 
 ## Current Validation Rules
 
@@ -182,9 +201,14 @@ Template and factory ids are canonicalized under the plugin namespace:
 - templates: `plugin-id/template-id`
 - factories: `plugin-id/factory-id`
 
-These registries are currently validated and populated at startup. They are not
-just metadata anymore: env and service commands now resolve namespaced
-template and factory ids through them.
+Descriptor-declared template tags are loaded as local ids like `baseline` or
+`api`, then canonicalized at runtime to:
+
+- templates: `plugin-id/template-id`
+- factories: `plugin-id/factory-id`
+
+These registries are validated and populated at startup. Env and service
+commands then resolve namespaced template and factory ids through them.
 
 ## Runtime Command Wiring
 

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -19,24 +19,28 @@
 from .config import (
     Config,
     ConfigMng,
+    ContainerCfg,
     EnvironmentCfg,
     EnvironmentTemplateCfg,
     PluginCfg,
     PluginDescriptorCfg,
     ServiceCfg,
     ServiceTemplateCfg,
+    ServiceTemplateRefCfg,
     UpstreamCfg,
     parse_config,
     parse_plugin_descriptor,
 )
 
 __all__ = [
+    "ContainerCfg",
     "Config",
     "EnvironmentTemplateCfg",
     "EnvironmentCfg",
     "PluginCfg",
     "PluginDescriptorCfg",
     "ServiceTemplateCfg",
+    "ServiceTemplateRefCfg",
     "ServiceCfg",
     "UpstreamCfg",
     "ConfigMng",

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1086,21 +1086,19 @@ def parse_config(yaml_str: str) -> Config:
         )
 
     def parse_environment(item: Any) -> EnvironmentCfg:
+        services_data = cast(list[dict[str, Any]], item.get("services") or [])
+        probes_data = cast(list[dict[str, Any]], item.get("probes") or [])
+        networks_data = cast(list[dict[str, Any]], item.get("networks") or [])
+        volumes_data = cast(list[dict[str, Any]], item.get("volumes") or [])
         return EnvironmentCfg(
             template=item["template"],
             factory=item["factory"],
             tag=item["tag"],
-            services=[
-                parse_service(service) for service in item.get("services", [])
-            ],
-            probes=[parse_probe(probe) for probe in item.get("probes", [])],
+            services=[parse_service(service) for service in services_data],
+            probes=[parse_probe(probe) for probe in probes_data],
             ready=parse_ready(item["ready"]) if item.get("ready") else None,
-            networks=[
-                parse_network(network) for network in item.get("networks", [])
-            ],
-            volumes=[
-                parse_volume(volume) for volume in item.get("volumes", [])
-            ],
+            networks=[parse_network(network) for network in networks_data],
+            volumes=[parse_volume(volume) for volume in volumes_data],
             status=parse_status(item["status"]),
         )
 
@@ -1157,6 +1155,11 @@ class ConfigMng:
             RAW_LOG_STDOUT=self.user_values["log_stdout"],
             LOG_FORMAT=self.user_values["log_format"],
         )
+        self.pluginRuntimeMng = None
+
+    def set_plugin_runtime_mng(self, pluginRuntimeMng: Any) -> None:
+        """Attach the optional runtime plugin manager for lookup helpers."""
+        self.pluginRuntimeMng = pluginRuntimeMng
 
     def ensure_dirs(self):
         dirs = {
@@ -1173,14 +1176,14 @@ class ConfigMng:
             "IMAGES_SA": self.config.staging_area.images_path,
         }
 
-        for template in self.get_environment_templates() or []:
+        for template in self.config.env_templates or []:
             dirs[f"TEMPLATE_ENV_{template.tag}"] = os.path.join(
                 self.config.templates_path,
                 Constants.ENV_TEMPLATES_DIR,
                 template.tag,
             )
 
-        for template in self.get_service_templates() or []:
+        for template in self.config.service_templates or []:
             dirs[f"TEMPLATE_SVC_{template.tag}"] = os.path.join(
                 self.config.templates_path,
                 Constants.SVC_TEMPLATES_DIR,
@@ -1311,12 +1314,28 @@ class ConfigMng:
         :param serviceTemplate: The tag of the service template.
         :return: The service template path.
         """
-        if self.get_service_template(serviceTemplate):
+        if self.config.service_templates and any(
+            svc_template.tag == serviceTemplate
+            for svc_template in self.config.service_templates
+        ):
             return os.path.join(
                 self.config.templates_path,
                 Constants.SVC_TEMPLATES_DIR,
                 serviceTemplate,
             )
+        if (
+            self.pluginRuntimeMng is not None
+            and "/" in serviceTemplate
+            and (
+                plugin_template_path := (
+                    self.pluginRuntimeMng.get_service_template_path(
+                        serviceTemplate
+                    )
+                )
+            )
+            is not None
+        ):
+            return plugin_template_path
         return None
 
     def get_environment_template(
@@ -1332,6 +1351,8 @@ class ConfigMng:
             for env_template in self.config.env_templates:
                 if env_template.tag == envTemplate:
                     return env_template
+        if self.pluginRuntimeMng is not None and "/" in envTemplate:
+            return self.pluginRuntimeMng.get_environment_template(envTemplate)
         return None
 
     def get_environment_templates(
@@ -1342,9 +1363,20 @@ class ConfigMng:
 
         :return: A list of all environment templates.
         """
-        if self.config.env_templates:
-            return self.config.env_templates
-        return None
+        templates = list(self.config.env_templates or [])
+        if self.pluginRuntimeMng is not None:
+            templates.extend(
+                [
+                    plugin_template.provider
+                    for plugin_template in (
+                        self.pluginRuntimeMng.registry.env_templates.values()
+                    )
+                    if isinstance(
+                        plugin_template.provider, EnvironmentTemplateCfg
+                    )
+                ]
+            )
+        return templates or None
 
     def get_environment_template_tags(self) -> list[str]:
         if env_templates := self.get_environment_templates():
@@ -1364,6 +1396,8 @@ class ConfigMng:
             for svc_template in self.config.service_templates:
                 if svc_template.tag == serviceTemplate:
                     return svc_template
+        if self.pluginRuntimeMng is not None and "/" in serviceTemplate:
+            return self.pluginRuntimeMng.get_service_template(serviceTemplate)
         return None
 
     def get_service_templates(self) -> Optional[list[ServiceTemplateCfg]]:
@@ -1372,19 +1406,26 @@ class ConfigMng:
 
         :return: A list of all service templates.
         """
-        if self.config.service_templates:
-            return self.config.service_templates
-        return None
+        templates = list(self.config.service_templates or [])
+        if self.pluginRuntimeMng is not None:
+            runtime_templates = (
+                self.pluginRuntimeMng.registry.service_templates.values()
+            )
+            templates.extend(
+                [
+                    plugin_template.provider
+                    for plugin_template in runtime_templates
+                    if isinstance(plugin_template.provider, ServiceTemplateCfg)
+                ]
+            )
+        return templates or None
 
     def get_resource_templates(self, resource_type: str) -> list[str]:
         match resource_type:
             case self.constants.RESOURCE_TYPE_SVC:
-                if self.config.service_templates:
+                if service_templates := self.get_service_templates():
                     return sorted(
-                        [
-                            svc_template.tag
-                            for svc_template in self.config.service_templates
-                        ]
+                        [svc_template.tag for svc_template in service_templates]
                     )
                 return []
             case _:

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -819,6 +819,8 @@ class PluginDescriptorCfg(Resolvable):
     description: Optional[str] = None
     capabilities: Optional[dict[str, bool]] = None
     default_config: Optional[dict[str, Any]] = None
+    env_templates: Optional[list[EnvironmentTemplateCfg]] = None
+    service_templates: Optional[list[ServiceTemplateCfg]] = None
 
 
 @dataclass
@@ -871,6 +873,165 @@ def parse_plugin_descriptor(yaml_str: str) -> PluginDescriptorCfg:
     if default_config is not None and not isinstance(default_config, dict):
         raise ValueError("Plugin default_config must be a mapping.")
 
+    def parse_build(item: Any) -> BuildCfg:
+        return BuildCfg(
+            context_path=item.get("context_path"),
+            dockerfile_path=item.get("dockerfile_path"),
+        )
+
+    def parse_init(item: Any) -> InitCfg:
+        return InitCfg(
+            tag=item["tag"],
+            script=item.get("script"),
+            script_path=item.get("script_path"),
+            when_probes=item.get("when_probes", []),
+        )
+
+    def parse_start(item: Any) -> StartCfg:
+        return StartCfg(
+            when_probes=item.get("when_probes", []),
+        )
+
+    def parse_ready(item: Any) -> ReadyCfg:
+        return ReadyCfg(
+            when_probes=item.get("when_probes", []),
+        )
+
+    def parse_container(item: Any) -> ContainerCfg:
+        inits = (
+            [parse_init(init) for init in item.get("inits", [])]
+            if item.get("inits") is not None
+            else None
+        )
+        return ContainerCfg(
+            tag=item.get("tag"),
+            image=item.get("image"),
+            hostname=item.get("hostname"),
+            container_name=item.get("container_name"),
+            workdir=item.get("workdir"),
+            volumes=item.get("volumes", []),
+            environment=item.get("environment", []),
+            ports=item.get("ports", []),
+            networks=item.get("networks", []),
+            extra_hosts=item.get("extra_hosts", []),
+            build=parse_build(item["build"]) if item.get("build") else None,
+            inits=inits,
+        )
+
+    def parse_probe(item: Any) -> ProbeCfg:
+        return ProbeCfg(
+            tag=item["tag"],
+            container=(
+                parse_container(item["container"])
+                if item.get("container")
+                else None
+            ),
+            script=item.get("script"),
+            script_path=item.get("script_path"),
+        )
+
+    def parse_network(item: Any) -> NetworkCfg:
+        external_value = item.get("external", False)
+        return NetworkCfg(
+            tag=item["tag"],
+            name=item.get("name", None),
+            external=(
+                bool_to_str(external_value)
+                if isinstance(external_value, bool)
+                else external_value
+            ),
+            driver=item.get("driver", None),
+            attachable=item.get("attachable", None),
+            enable_ipv6=item.get("enable_ipv6", None),
+            driver_opts=item.get("driver_opts", None),
+            ipam=item.get("ipam", None),
+        )
+
+    def parse_volume(item: Any) -> VolumeCfg:
+        external_value = item.get("external", False)
+        return VolumeCfg(
+            tag=item["tag"],
+            external=(
+                bool_to_str(external_value)
+                if isinstance(external_value, bool)
+                else external_value
+            ),
+            name=item.get("name", None),
+            driver=item.get("driver", None),
+            driver_opts=item.get("driver_opts", None),
+            labels=item.get("labels", None),
+        )
+
+    def parse_service_template_ref(item: Any) -> ServiceTemplateRefCfg:
+        return ServiceTemplateRefCfg(
+            template=item["template"],
+            tag=item["tag"],
+        )
+
+    def parse_service_template(item: Any) -> ServiceTemplateCfg:
+        containers_data = cast(
+            list[dict[str, Any]], item.get("containers") or []
+        )
+        return ServiceTemplateCfg(
+            tag=item["tag"],
+            factory=item["factory"],
+            labels=item.get("labels", []),
+            properties=item.get("properties", {}),
+            containers=[
+                parse_container(container) for container in containers_data
+            ],
+            start=parse_start(item["start"]) if item.get("start") else None,
+        )
+
+    def parse_environment_template(item: Any) -> EnvironmentTemplateCfg:
+        service_templates_data = cast(
+            list[dict[str, Any]], item.get("service_templates") or []
+        )
+        probes_data = cast(list[dict[str, Any]], item.get("probes") or [])
+        networks_data = cast(list[dict[str, Any]], item.get("networks") or [])
+        volumes_data = cast(list[dict[str, Any]], item.get("volumes") or [])
+        return EnvironmentTemplateCfg(
+            tag=item["tag"],
+            factory=item["factory"],
+            service_templates=[
+                parse_service_template_ref(service_template)
+                for service_template in service_templates_data
+            ],
+            probes=[parse_probe(probe) for probe in probes_data],
+            ready=parse_ready(item["ready"]) if item.get("ready") else None,
+            networks=[parse_network(network) for network in networks_data],
+            volumes=[parse_volume(volume) for volume in volumes_data],
+        )
+
+    env_templates_data = descriptor.get("env_templates")
+    if env_templates_data is not None and not isinstance(
+        env_templates_data, list
+    ):
+        raise ValueError("Plugin env_templates must be a list.")
+
+    service_templates_data = descriptor.get("service_templates")
+    if service_templates_data is not None and not isinstance(
+        service_templates_data, list
+    ):
+        raise ValueError("Plugin service_templates must be a list.")
+
+    env_templates = (
+        [
+            parse_environment_template(template)
+            for template in cast(list[dict[str, Any]], env_templates_data)
+        ]
+        if env_templates_data is not None
+        else None
+    )
+    service_templates = (
+        [
+            parse_service_template(template)
+            for template in cast(list[dict[str, Any]], service_templates_data)
+        ]
+        if service_templates_data is not None
+        else None
+    )
+
     return PluginDescriptorCfg(
         id=str(descriptor["id"]),
         name=str(descriptor["name"]),
@@ -887,6 +1048,8 @@ def parse_plugin_descriptor(yaml_str: str) -> PluginDescriptorCfg:
         ),
         capabilities=normalized_capabilities,
         default_config=cast(Optional[dict[str, Any]], default_config),
+        env_templates=env_templates,
+        service_templates=service_templates,
     )
 
 
@@ -1366,15 +1529,7 @@ class ConfigMng:
         templates = list(self.config.env_templates or [])
         if self.pluginRuntimeMng is not None:
             templates.extend(
-                [
-                    plugin_template.provider
-                    for plugin_template in (
-                        self.pluginRuntimeMng.registry.env_templates.values()
-                    )
-                    if isinstance(
-                        plugin_template.provider, EnvironmentTemplateCfg
-                    )
-                ]
+                self.pluginRuntimeMng.registry.env_templates.values()
             )
         return templates or None
 
@@ -1408,15 +1563,8 @@ class ConfigMng:
         """
         templates = list(self.config.service_templates or [])
         if self.pluginRuntimeMng is not None:
-            runtime_templates = (
-                self.pluginRuntimeMng.registry.service_templates.values()
-            )
             templates.extend(
-                [
-                    plugin_template.provider
-                    for plugin_template in runtime_templates
-                    if isinstance(plugin_template.provider, ServiceTemplateCfg)
-                ]
+                self.pluginRuntimeMng.registry.service_templates.values()
             )
         return templates or None
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -839,6 +839,234 @@ class Config(Resolvable):
     envs: list[EnvironmentCfg] = field(default_factory=list[EnvironmentCfg])
 
 
+def _parse_build(item: Any) -> BuildCfg:
+    return BuildCfg(
+        context_path=item.get("context_path"),
+        dockerfile_path=item.get("dockerfile_path"),
+    )
+
+
+def _parse_init(item: Any) -> InitCfg:
+    return InitCfg(
+        tag=item["tag"],
+        script=item.get("script"),
+        script_path=item.get("script_path"),
+        when_probes=item.get("when_probes", []),
+    )
+
+
+def _parse_start(item: Any) -> StartCfg:
+    return StartCfg(
+        when_probes=item.get("when_probes", []),
+    )
+
+
+def _parse_ready(item: Any) -> ReadyCfg:
+    return ReadyCfg(
+        when_probes=item.get("when_probes", []),
+    )
+
+
+def _parse_container(item: Any) -> ContainerCfg:
+    inits = (
+        [_parse_init(init) for init in item.get("inits", [])]
+        if item.get("inits") is not None
+        else None
+    )
+    return ContainerCfg(
+        tag=item.get("tag"),
+        image=item.get("image"),
+        hostname=item.get("hostname"),
+        container_name=item.get("container_name"),
+        workdir=item.get("workdir"),
+        volumes=item.get("volumes", []),
+        environment=item.get("environment", []),
+        ports=item.get("ports", []),
+        networks=item.get("networks", []),
+        extra_hosts=item.get("extra_hosts", []),
+        build=_parse_build(item["build"]) if item.get("build") else None,
+        inits=inits,
+    )
+
+
+def _parse_probe(item: Any) -> ProbeCfg:
+    return ProbeCfg(
+        tag=item["tag"],
+        container=(
+            _parse_container(item["container"])
+            if item.get("container")
+            else None
+        ),
+        script=item.get("script"),
+        script_path=item.get("script_path"),
+    )
+
+
+def _parse_network(item: Any) -> NetworkCfg:
+    external_value = item.get("external", False)
+    attachable_value = item.get("attachable")
+    enable_ipv6_value = item.get("enable_ipv6")
+    return NetworkCfg(
+        tag=item["tag"],
+        name=item.get("name", None),
+        external=(
+            bool_to_str(external_value)
+            if isinstance(external_value, bool)
+            else external_value
+        ),
+        driver=item.get("driver", None),
+        attachable=(
+            bool_to_str(attachable_value)
+            if isinstance(attachable_value, bool)
+            else attachable_value
+        ),
+        enable_ipv6=(
+            bool_to_str(enable_ipv6_value)
+            if isinstance(enable_ipv6_value, bool)
+            else enable_ipv6_value
+        ),
+        driver_opts=item.get("driver_opts"),
+        ipam=item.get("ipam"),
+    )
+
+
+def _parse_volume(item: Any) -> VolumeCfg:
+    external_value = item.get("external", False)
+    return VolumeCfg(
+        tag=item["tag"],
+        external=(
+            bool_to_str(external_value)
+            if isinstance(external_value, bool)
+            else external_value
+        ),
+        name=item.get("name"),
+        driver=item.get("driver"),
+        driver_opts=item.get("driver_opts"),
+        labels=item.get("labels"),
+    )
+
+
+def _parse_service_template_ref(item: Any) -> ServiceTemplateRefCfg:
+    return ServiceTemplateRefCfg(
+        template=item["template"],
+        tag=item["tag"],
+    )
+
+
+def _parse_service_template(item: Any) -> ServiceTemplateCfg:
+    containers_data = cast(list[dict[str, Any]], item.get("containers") or [])
+    return ServiceTemplateCfg(
+        tag=item["tag"],
+        factory=item["factory"],
+        labels=item.get("labels", []),
+        properties=item.get("properties", {}),
+        containers=[
+            _parse_container(container) for container in containers_data
+        ],
+        start=_parse_start(item["start"]) if item.get("start") else None,
+    )
+
+
+def _parse_environment_template(item: Any) -> EnvironmentTemplateCfg:
+    service_templates_data = cast(
+        list[dict[str, Any]], item.get("service_templates") or []
+    )
+    probes_data = cast(list[dict[str, Any]], item.get("probes") or [])
+    networks_data = cast(list[dict[str, Any]], item.get("networks") or [])
+    volumes_data = cast(list[dict[str, Any]], item.get("volumes") or [])
+    return EnvironmentTemplateCfg(
+        tag=item["tag"],
+        factory=item["factory"],
+        service_templates=[
+            _parse_service_template_ref(service_template)
+            for service_template in service_templates_data
+        ],
+        probes=[_parse_probe(probe) for probe in probes_data],
+        ready=_parse_ready(item["ready"]) if item.get("ready") else None,
+        networks=[_parse_network(network) for network in networks_data],
+        volumes=[_parse_volume(volume) for volume in volumes_data],
+    )
+
+
+def _parse_status(item: Any) -> EntityStatus:
+    return EntityStatus(
+        active=item.get("active", False),
+        rendered_config=item.get("rendered_config"),
+    )
+
+
+def _parse_upstream(item: Any) -> UpstreamCfg:
+    enabled_value = item["enabled"]
+    return UpstreamCfg(
+        type=item["type"],
+        tag=item["tag"],
+        properties=item.get("properties", {}),
+        enabled=(
+            bool_to_str(enabled_value)
+            if isinstance(enabled_value, bool)
+            else enabled_value
+        ),
+    )
+
+
+def _parse_service(item: Any) -> ServiceCfg:
+    containers_data = cast(list[dict[str, Any]], item.get("containers") or [])
+    upstreams_data = cast(list[dict[str, Any]], item.get("upstreams") or [])
+    return ServiceCfg(
+        tag=item["tag"],
+        factory=item["factory"],
+        template=item["template"],
+        service_class=item.get("service_class"),
+        labels=item.get("labels", []),
+        properties=item.get("properties", {}),
+        upstreams=[_parse_upstream(upstream) for upstream in upstreams_data],
+        containers=[
+            _parse_container(container) for container in containers_data
+        ],
+        start=_parse_start(item["start"]) if item.get("start") else None,
+        status=_parse_status(item["status"]),
+    )
+
+
+def _parse_staging_area(item: Any) -> StagingAreaCfg:
+    return StagingAreaCfg(
+        volumes_path=item["volumes_path"],
+        images_path=item["images_path"],
+    )
+
+
+def _parse_plugin(item: Any) -> PluginCfg:
+    enabled_value = item.get("enabled", True)
+    return PluginCfg(
+        id=item["id"],
+        enabled=(
+            bool_to_str(enabled_value)
+            if isinstance(enabled_value, bool)
+            else enabled_value
+        ),
+        version=item.get("version"),
+        config=item.get("config"),
+    )
+
+
+def _parse_environment(item: Any) -> EnvironmentCfg:
+    services_data = cast(list[dict[str, Any]], item.get("services") or [])
+    probes_data = cast(list[dict[str, Any]], item.get("probes") or [])
+    networks_data = cast(list[dict[str, Any]], item.get("networks") or [])
+    volumes_data = cast(list[dict[str, Any]], item.get("volumes") or [])
+    return EnvironmentCfg(
+        template=item["template"],
+        factory=item["factory"],
+        tag=item["tag"],
+        services=[_parse_service(service) for service in services_data],
+        probes=[_parse_probe(probe) for probe in probes_data],
+        ready=_parse_ready(item["ready"]) if item.get("ready") else None,
+        networks=[_parse_network(network) for network in networks_data],
+        volumes=[_parse_volume(volume) for volume in volumes_data],
+        status=_parse_status(item["status"]),
+    )
+
+
 def parse_plugin_descriptor(yaml_str: str) -> PluginDescriptorCfg:
     """
     Parse a plugin descriptor YAML into the strongly typed descriptor model.
@@ -873,136 +1101,6 @@ def parse_plugin_descriptor(yaml_str: str) -> PluginDescriptorCfg:
     if default_config is not None and not isinstance(default_config, dict):
         raise ValueError("Plugin default_config must be a mapping.")
 
-    def parse_build(item: Any) -> BuildCfg:
-        return BuildCfg(
-            context_path=item.get("context_path"),
-            dockerfile_path=item.get("dockerfile_path"),
-        )
-
-    def parse_init(item: Any) -> InitCfg:
-        return InitCfg(
-            tag=item["tag"],
-            script=item.get("script"),
-            script_path=item.get("script_path"),
-            when_probes=item.get("when_probes", []),
-        )
-
-    def parse_start(item: Any) -> StartCfg:
-        return StartCfg(
-            when_probes=item.get("when_probes", []),
-        )
-
-    def parse_ready(item: Any) -> ReadyCfg:
-        return ReadyCfg(
-            when_probes=item.get("when_probes", []),
-        )
-
-    def parse_container(item: Any) -> ContainerCfg:
-        inits = (
-            [parse_init(init) for init in item.get("inits", [])]
-            if item.get("inits") is not None
-            else None
-        )
-        return ContainerCfg(
-            tag=item.get("tag"),
-            image=item.get("image"),
-            hostname=item.get("hostname"),
-            container_name=item.get("container_name"),
-            workdir=item.get("workdir"),
-            volumes=item.get("volumes", []),
-            environment=item.get("environment", []),
-            ports=item.get("ports", []),
-            networks=item.get("networks", []),
-            extra_hosts=item.get("extra_hosts", []),
-            build=parse_build(item["build"]) if item.get("build") else None,
-            inits=inits,
-        )
-
-    def parse_probe(item: Any) -> ProbeCfg:
-        return ProbeCfg(
-            tag=item["tag"],
-            container=(
-                parse_container(item["container"])
-                if item.get("container")
-                else None
-            ),
-            script=item.get("script"),
-            script_path=item.get("script_path"),
-        )
-
-    def parse_network(item: Any) -> NetworkCfg:
-        external_value = item.get("external", False)
-        return NetworkCfg(
-            tag=item["tag"],
-            name=item.get("name", None),
-            external=(
-                bool_to_str(external_value)
-                if isinstance(external_value, bool)
-                else external_value
-            ),
-            driver=item.get("driver", None),
-            attachable=item.get("attachable", None),
-            enable_ipv6=item.get("enable_ipv6", None),
-            driver_opts=item.get("driver_opts", None),
-            ipam=item.get("ipam", None),
-        )
-
-    def parse_volume(item: Any) -> VolumeCfg:
-        external_value = item.get("external", False)
-        return VolumeCfg(
-            tag=item["tag"],
-            external=(
-                bool_to_str(external_value)
-                if isinstance(external_value, bool)
-                else external_value
-            ),
-            name=item.get("name", None),
-            driver=item.get("driver", None),
-            driver_opts=item.get("driver_opts", None),
-            labels=item.get("labels", None),
-        )
-
-    def parse_service_template_ref(item: Any) -> ServiceTemplateRefCfg:
-        return ServiceTemplateRefCfg(
-            template=item["template"],
-            tag=item["tag"],
-        )
-
-    def parse_service_template(item: Any) -> ServiceTemplateCfg:
-        containers_data = cast(
-            list[dict[str, Any]], item.get("containers") or []
-        )
-        return ServiceTemplateCfg(
-            tag=item["tag"],
-            factory=item["factory"],
-            labels=item.get("labels", []),
-            properties=item.get("properties", {}),
-            containers=[
-                parse_container(container) for container in containers_data
-            ],
-            start=parse_start(item["start"]) if item.get("start") else None,
-        )
-
-    def parse_environment_template(item: Any) -> EnvironmentTemplateCfg:
-        service_templates_data = cast(
-            list[dict[str, Any]], item.get("service_templates") or []
-        )
-        probes_data = cast(list[dict[str, Any]], item.get("probes") or [])
-        networks_data = cast(list[dict[str, Any]], item.get("networks") or [])
-        volumes_data = cast(list[dict[str, Any]], item.get("volumes") or [])
-        return EnvironmentTemplateCfg(
-            tag=item["tag"],
-            factory=item["factory"],
-            service_templates=[
-                parse_service_template_ref(service_template)
-                for service_template in service_templates_data
-            ],
-            probes=[parse_probe(probe) for probe in probes_data],
-            ready=parse_ready(item["ready"]) if item.get("ready") else None,
-            networks=[parse_network(network) for network in networks_data],
-            volumes=[parse_volume(volume) for volume in volumes_data],
-        )
-
     env_templates_data = descriptor.get("env_templates")
     if env_templates_data is not None and not isinstance(
         env_templates_data, list
@@ -1017,7 +1115,7 @@ def parse_plugin_descriptor(yaml_str: str) -> PluginDescriptorCfg:
 
     env_templates = (
         [
-            parse_environment_template(template)
+            _parse_environment_template(template)
             for template in cast(list[dict[str, Any]], env_templates_data)
         ]
         if env_templates_data is not None
@@ -1025,7 +1123,7 @@ def parse_plugin_descriptor(yaml_str: str) -> PluginDescriptorCfg:
     )
     service_templates = (
         [
-            parse_service_template(template)
+            _parse_service_template(template)
             for template in cast(list[dict[str, Any]], service_templates_data)
         ]
         if service_templates_data is not None
@@ -1063,227 +1161,25 @@ def parse_config(yaml_str: str) -> Config:
 
     data = yaml.safe_load(yaml_str)
 
-    def parse_status(item: Any) -> EntityStatus:
-        return EntityStatus(
-            active=item.get("active", False),
-            rendered_config=item.get("rendered_config"),
-        )
-
-    def parse_upstream(item: Any) -> UpstreamCfg:
-        return UpstreamCfg(
-            type=item["type"],
-            tag=item["tag"],
-            properties=item.get("properties", {}),
-            enabled=(
-                bool_to_str(val)
-                if isinstance(val := item["enabled"], bool)
-                else val
-            ),
-        )
-
-    def parse_build(item: Any) -> BuildCfg:
-        return BuildCfg(
-            context_path=item.get("context_path"),
-            dockerfile_path=item.get("dockerfile_path"),
-        )
-
-    def parse_container(item: Any) -> ContainerCfg:
-        inits = (
-            [parse_init(init) for init in item.get("inits", [])]
-            if item.get("inits") is not None
-            else None
-        )
-        return ContainerCfg(
-            tag=item.get("tag"),
-            image=item.get("image"),
-            hostname=item.get("hostname"),
-            container_name=item.get("container_name"),
-            workdir=item.get("workdir"),
-            volumes=item.get("volumes", []),
-            environment=item.get("environment", []),
-            ports=item.get("ports", []),
-            networks=item.get("networks", []),
-            extra_hosts=item.get("extra_hosts", []),
-            build=parse_build(item["build"]) if item.get("build") else None,
-            inits=inits,
-        )
-
-    def parse_probe(item: Any) -> ProbeCfg:
-        return ProbeCfg(
-            tag=item["tag"],
-            container=(
-                parse_container(item["container"])
-                if item.get("container")
-                else None
-            ),
-            script=item.get("script"),
-            script_path=item.get("script_path"),
-        )
-
-    def parse_init(item: Any) -> InitCfg:
-        return InitCfg(
-            tag=item["tag"],
-            script=item.get("script"),
-            script_path=item.get("script_path"),
-            when_probes=item.get("when_probes", []),
-        )
-
-    def parse_start(item: Any) -> StartCfg:
-        return StartCfg(
-            when_probes=item.get("when_probes", []),
-        )
-
-    def parse_ready(item: Any) -> ReadyCfg:
-        return ReadyCfg(
-            when_probes=item.get("when_probes", []),
-        )
-
-    def parse_service_template(item: Any) -> ServiceTemplateCfg:
-        return ServiceTemplateCfg(
-            tag=item["tag"],
-            factory=item["factory"],
-            labels=item.get("labels", []),
-            properties=item.get("properties", {}),
-            containers=[
-                parse_container(container)
-                for container in item.get("containers", [])
-            ],
-            start=parse_start(item["start"]) if item.get("start") else None,
-        )
-
-    def parse_service(item: Any) -> ServiceCfg:
-        return ServiceCfg(
-            tag=item["tag"],
-            factory=item["factory"],
-            template=item["template"],
-            service_class=item.get("service_class"),
-            labels=item.get("labels", []),
-            properties=item.get("properties", {}),
-            upstreams=[
-                parse_upstream(upstream)
-                for upstream in item.get("upstreams", [])
-            ],
-            containers=[
-                parse_container(container)
-                for container in item.get("containers", [])
-            ],
-            start=parse_start(item["start"]) if item.get("start") else None,
-            status=parse_status(item["status"]),
-        )
-
-    def parse_network(item: Any) -> NetworkCfg:
-        return NetworkCfg(
-            tag=item["tag"],
-            name=item.get("name", None),
-            external=(
-                bool_to_str(val)
-                if isinstance(val := item["external"], bool)
-                else val
-            ),
-            driver=item.get("driver", None),
-            attachable=(
-                bool_to_str(val)
-                if isinstance(val := item.get("attachable"), bool)
-                else val
-            ),
-            enable_ipv6=(
-                bool_to_str(val)
-                if isinstance(val := item.get("enable_ipv6"), bool)
-                else val
-            ),
-            driver_opts=item.get("driver_opts"),
-            ipam=item.get("ipam"),
-        )
-
-    def parse_volume(item: Any) -> VolumeCfg:
-        return VolumeCfg(
-            tag=item["tag"],
-            external=(
-                bool_to_str(val)
-                if isinstance(val := item["external"], bool)
-                else val
-            ),
-            name=item.get("name"),
-            driver=item.get("driver"),
-            driver_opts=item.get("driver_opts"),
-            labels=item.get("labels"),
-        )
-
-    def parse_service_template_refs(item: Any) -> ServiceTemplateRefCfg:
-        return ServiceTemplateRefCfg(template=item["template"], tag=item["tag"])
-
-    def parse_environment_template(item: Any) -> EnvironmentTemplateCfg:
-        return EnvironmentTemplateCfg(
-            tag=item["tag"],
-            factory=item["factory"],
-            service_templates=[
-                parse_service_template_refs(svc_templ_ref)
-                for svc_templ_ref in item.get("service_templates", [])
-            ],
-            probes=[parse_probe(probe) for probe in item.get("probes", [])],
-            ready=parse_ready(item["ready"]) if item.get("ready") else None,
-            networks=[
-                parse_network(network) for network in item.get("networks", [])
-            ],
-            volumes=[
-                parse_volume(volume) for volume in item.get("volumes", [])
-            ],
-        )
-
-    def parse_staging_area(item: Any) -> StagingAreaCfg:
-        return StagingAreaCfg(
-            volumes_path=item["volumes_path"],
-            images_path=item["images_path"],
-        )
-
-    def parse_plugin(item: Any) -> PluginCfg:
-        return PluginCfg(
-            id=item["id"],
-            enabled=(
-                bool_to_str(val)
-                if isinstance(val := item.get("enabled", True), bool)
-                else val
-            ),
-            version=item.get("version"),
-            config=item.get("config"),
-        )
-
-    def parse_environment(item: Any) -> EnvironmentCfg:
-        services_data = cast(list[dict[str, Any]], item.get("services") or [])
-        probes_data = cast(list[dict[str, Any]], item.get("probes") or [])
-        networks_data = cast(list[dict[str, Any]], item.get("networks") or [])
-        volumes_data = cast(list[dict[str, Any]], item.get("volumes") or [])
-        return EnvironmentCfg(
-            template=item["template"],
-            factory=item["factory"],
-            tag=item["tag"],
-            services=[parse_service(service) for service in services_data],
-            probes=[parse_probe(probe) for probe in probes_data],
-            ready=parse_ready(item["ready"]) if item.get("ready") else None,
-            networks=[parse_network(network) for network in networks_data],
-            volumes=[parse_volume(volume) for volume in volumes_data],
-            status=parse_status(item["status"]),
-        )
-
     return Config(
         env_templates=[
-            parse_environment_template(environment_template)
+            _parse_environment_template(environment_template)
             for environment_template in data.get("env_templates", [])
         ],
         service_templates=[
-            parse_service_template(service_template)
+            _parse_service_template(service_template)
             for service_template in data.get("service_templates", [])
         ],
         templates_path=data["templates_path"],
         envs_path=data["envs_path"],
         volumes_path=data["volumes_path"],
-        staging_area=parse_staging_area(data["staging_area"]),
+        staging_area=_parse_staging_area(data["staging_area"]),
         plugins=(
-            [parse_plugin(plugin) for plugin in data.get("plugins", [])]
+            [_parse_plugin(plugin) for plugin in data.get("plugins", [])]
             if data.get("plugins") is not None
             else None
         ),
-        envs=[parse_environment(env) for env in data["envs"]],
+        envs=[_parse_environment(env) for env in data["envs"]],
     )
 
 

--- a/src/factory/shpd_env_factory.py
+++ b/src/factory/shpd_env_factory.py
@@ -60,9 +60,22 @@ class ShpdEnvironmentFactory(EnvironmentFactory):
                     cli_flags=self.cli_flags,
                 )
             case _:
-                raise ValueError(
-                    f"Unknown environment factory: {env_tmpl_cfg.factory}"
+                plugin_runtime_mng = self.configMng.pluginRuntimeMng
+                if plugin_runtime_mng is None:
+                    raise ValueError(
+                        f"Unknown environment factory: {env_tmpl_cfg.factory}"
+                    )
+                plugin_factory = plugin_runtime_mng.build_environment_factory(
+                    env_tmpl_cfg.factory,
+                    self.configMng,
+                    self.svcFactory,
+                    self.cli_flags,
                 )
+                if plugin_factory is None:
+                    raise ValueError(
+                        f"Unknown environment factory: {env_tmpl_cfg.factory}"
+                    )
+                return plugin_factory.new_environment(env_tmpl_cfg, env_tag)
 
     @override
     def new_environment_cfg_impl(self, envCfg: EnvironmentCfg) -> Environment:
@@ -80,6 +93,19 @@ class ShpdEnvironmentFactory(EnvironmentFactory):
                     cli_flags=self.cli_flags,
                 )
             case _:
-                raise ValueError(
-                    f"Unknown environment factory: {envCfg.factory}"
+                plugin_runtime_mng = self.configMng.pluginRuntimeMng
+                if plugin_runtime_mng is None:
+                    raise ValueError(
+                        f"Unknown environment factory: {envCfg.factory}"
+                    )
+                plugin_factory = plugin_runtime_mng.build_environment_factory(
+                    envCfg.factory,
+                    self.configMng,
+                    self.svcFactory,
+                    self.cli_flags,
                 )
+                if plugin_factory is None:
+                    raise ValueError(
+                        f"Unknown environment factory: {envCfg.factory}"
+                    )
+                return plugin_factory.new_environment_cfg(envCfg)

--- a/src/factory/shpd_svc_factory.py
+++ b/src/factory/shpd_svc_factory.py
@@ -52,5 +52,18 @@ class ShpdServiceFactory(ServiceFactory):
                     self.configMng, envCfg, svcCfg, cli_flags=cli_flags
                 )
             case _:
-                raise ValueError(f"""Unknown service type: {svcCfg.template},
-                    plugins not supported yet!""")
+                plugin_runtime_mng = self.configMng.pluginRuntimeMng
+                if plugin_runtime_mng is None:
+                    raise ValueError(
+                        f"Unknown service factory: {svcCfg.factory}"
+                    )
+                plugin_factory = plugin_runtime_mng.build_service_factory(
+                    svcCfg.factory, self.configMng
+                )
+                if plugin_factory is None:
+                    raise ValueError(
+                        f"Unknown service factory: {svcCfg.factory}"
+                    )
+                return plugin_factory.new_service_from_cfg(
+                    envCfg, svcCfg, cli_flags=cli_flags
+                )

--- a/src/plugin/__init__.py
+++ b/src/plugin/__init__.py
@@ -21,7 +21,6 @@ from .api import (
     PluginCommandSpec,
     PluginCompletionSpec,
     PluginFactorySpec,
-    PluginTemplateSpec,
     ShepherdPlugin,
 )
 from .plugin import PluginMng
@@ -39,6 +38,5 @@ __all__ = [
     "PluginMng",
     "PluginRegistry",
     "PluginRuntimeMng",
-    "PluginTemplateSpec",
     "ShepherdPlugin",
 ]

--- a/src/plugin/api.py
+++ b/src/plugin/api.py
@@ -58,20 +58,6 @@ class PluginCompletionSpec:
 
 
 @dataclass(frozen=True)
-class PluginTemplateSpec:
-    """
-    One template contribution declared by a plugin.
-
-    `provider` carries the plugin-owned object or data structure that
-    describes the template payload. The loader treats it as opaque for now and
-    only registers it under the canonical `plugin-id/template-id` name.
-    """
-
-    id: str
-    provider: Any
-
-
-@dataclass(frozen=True)
 class PluginFactorySpec:
     """
     One factory contribution declared by a plugin.
@@ -100,14 +86,6 @@ class ShepherdPlugin(ABC):
 
     def get_completion_providers(self) -> Sequence[PluginCompletionSpec]:
         """Return completion providers grouped by the scopes they serve."""
-        return ()
-
-    def get_env_templates(self) -> Sequence[PluginTemplateSpec]:
-        """Return environment templates owned by the plugin."""
-        return ()
-
-    def get_service_templates(self) -> Sequence[PluginTemplateSpec]:
-        """Return service templates owned by the plugin."""
         return ()
 
     def get_env_factories(self) -> Sequence[PluginFactorySpec]:

--- a/src/plugin/runtime.py
+++ b/src/plugin/runtime.py
@@ -41,7 +41,6 @@ from plugin.api import (
     PluginCommandSpec,
     PluginCompletionSpec,
     PluginFactorySpec,
-    PluginTemplateSpec,
     ShepherdPlugin,
 )
 from service import ServiceFactory
@@ -65,8 +64,13 @@ def _completion_registry() -> dict[str, list["PluginCompletionSpec"]]:
     return {}
 
 
-def _template_registry() -> dict[str, "PluginTemplateSpec"]:
-    """Create a typed default for canonical template registrations."""
+def _env_template_registry() -> dict[str, EnvironmentTemplateCfg]:
+    """Create a typed default for canonical environment templates."""
+    return {}
+
+
+def _service_template_registry() -> dict[str, ServiceTemplateCfg]:
+    """Create a typed default for canonical service templates."""
     return {}
 
 
@@ -104,11 +108,11 @@ class PluginRegistry:
     completion_providers: dict[str, list[PluginCompletionSpec]] = field(
         default_factory=_completion_registry
     )
-    env_templates: dict[str, PluginTemplateSpec] = field(
-        default_factory=_template_registry
+    env_templates: dict[str, EnvironmentTemplateCfg] = field(
+        default_factory=_env_template_registry
     )
-    service_templates: dict[str, PluginTemplateSpec] = field(
-        default_factory=_template_registry
+    service_templates: dict[str, ServiceTemplateCfg] = field(
+        default_factory=_service_template_registry
     )
     env_factories: dict[str, PluginFactorySpec] = field(
         default_factory=_factory_registry
@@ -353,18 +357,7 @@ class PluginRuntimeMng:
         self._register_completion_providers(
             plugin_id, loaded.instance.get_completion_providers()
         )
-        self._register_templates(
-            plugin_id,
-            loaded.instance.get_env_templates(),
-            self.registry.env_templates,
-            "environment template",
-        )
-        self._register_templates(
-            plugin_id,
-            loaded.instance.get_service_templates(),
-            self.registry.service_templates,
-            "service template",
-        )
+        self._register_descriptor_templates(loaded)
         self._register_factories(
             plugin_id,
             loaded.instance.get_env_factories(),
@@ -460,41 +453,145 @@ class PluginRuntimeMng:
             return True
         return callable(getattr(provider, "get_completions", None))
 
-    def _register_templates(
+    def _register_descriptor_templates(self, loaded: LoadedPlugin) -> None:
+        """Register declarative templates loaded from one plugin descriptor."""
+        plugin_id = loaded.descriptor.id
+        service_local_ids = {
+            template.tag
+            for template in (loaded.descriptor.service_templates or [])
+        }
+        self._register_env_templates(
+            plugin_id,
+            loaded.descriptor.env_templates or (),
+            service_local_ids,
+        )
+        self._register_service_templates(
+            plugin_id,
+            loaded.descriptor.service_templates or (),
+        )
+
+    def _register_env_templates(
         self,
         plugin_id: str,
-        templates: Sequence[PluginTemplateSpec],
-        registry: dict[str, PluginTemplateSpec],
-        kind: str,
+        templates: Sequence[EnvironmentTemplateCfg],
+        service_local_ids: set[str],
     ) -> None:
-        """Register namespaced templates in the selected runtime registry."""
+        """Register namespaced environment templates from the descriptor."""
         for template in templates:
-            if "/" in template.id:
+            if "/" in template.tag:
                 Util.print_error_and_die(
-                    f"Plugin '{plugin_id}' {kind} id '{template.id}' must "
+                    f"Plugin '{plugin_id}' environment template id "
+                    f"'{template.tag}' must "
                     "not contain '/'."
                 )
-            canonical_id = f"{plugin_id}/{template.id}"
-            if canonical_id in registry:
+            canonical_id = f"{plugin_id}/{template.tag}"
+            if canonical_id in self.registry.env_templates:
                 Util.print_error_and_die(
-                    f"Plugin '{plugin_id}' declares duplicate {kind} "
-                    f"'{canonical_id}'."
+                    f"Plugin '{plugin_id}' declares duplicate environment "
+                    f"template '{canonical_id}'."
                 )
-            if kind == "environment template" and not isinstance(
-                template.provider, EnvironmentTemplateCfg
-            ):
+            self.registry.env_templates[canonical_id] = (
+                self._namespace_environment_template(
+                    plugin_id, template, service_local_ids
+                )
+            )
+
+    def _register_service_templates(
+        self,
+        plugin_id: str,
+        templates: Sequence[ServiceTemplateCfg],
+    ) -> None:
+        """Register namespaced service templates from the descriptor."""
+        for template in templates:
+            if "/" in template.tag:
                 Util.print_error_and_die(
-                    f"Plugin '{plugin_id}' {kind} '{canonical_id}' must "
-                    "provide an EnvironmentTemplateCfg."
+                    f"Plugin '{plugin_id}' service template id "
+                    f"'{template.tag}' must not contain '/'."
                 )
-            if kind == "service template" and not isinstance(
-                template.provider, ServiceTemplateCfg
-            ):
+            canonical_id = f"{plugin_id}/{template.tag}"
+            if canonical_id in self.registry.service_templates:
                 Util.print_error_and_die(
-                    f"Plugin '{plugin_id}' {kind} '{canonical_id}' must "
-                    "provide a ServiceTemplateCfg."
+                    f"Plugin '{plugin_id}' declares duplicate service "
+                    f"template '{canonical_id}'."
                 )
-            registry[canonical_id] = template
+            self.registry.service_templates[canonical_id] = (
+                self._namespace_service_template(plugin_id, template)
+            )
+
+    def _namespace_environment_template(
+        self,
+        plugin_id: str,
+        template: EnvironmentTemplateCfg,
+        service_local_ids: set[str],
+    ) -> EnvironmentTemplateCfg:
+        """Return one plugin env template with canonicalized ids."""
+        service_templates = template.service_templates
+        if service_templates is not None:
+            service_templates = [
+                self._namespace_service_template_ref(
+                    plugin_id, service_template, service_local_ids
+                )
+                for service_template in service_templates
+            ]
+
+        return EnvironmentTemplateCfg(
+            tag=f"{plugin_id}/{template.tag}",
+            factory=self._namespace_factory_id(
+                plugin_id,
+                template.factory,
+                Constants.ENV_FACTORY_DEFAULT,
+            ),
+            service_templates=service_templates,
+            probes=template.probes,
+            networks=template.networks,
+            volumes=template.volumes,
+            ready=template.ready,
+        )
+
+    def _namespace_service_template(
+        self,
+        plugin_id: str,
+        template: ServiceTemplateCfg,
+    ) -> ServiceTemplateCfg:
+        """Return one plugin service template with canonicalized ids."""
+        return ServiceTemplateCfg(
+            tag=f"{plugin_id}/{template.tag}",
+            factory=self._namespace_factory_id(
+                plugin_id,
+                template.factory,
+                Constants.SVC_FACTORY_DEFAULT,
+            ),
+            labels=template.labels,
+            properties=template.properties,
+            containers=template.containers,
+            start=template.start,
+        )
+
+    def _namespace_service_template_ref(
+        self,
+        plugin_id: str,
+        template_ref: Any,
+        service_local_ids: set[str],
+    ) -> Any:
+        """Return one env->service template reference with canonical ids."""
+        template_name = template_ref.template
+        if "/" not in template_name and template_name in service_local_ids:
+            template_name = f"{plugin_id}/{template_name}"
+        return type(template_ref)(
+            template=template_name,
+            tag=template_ref.tag,
+        )
+
+    def _namespace_factory_id(
+        self,
+        plugin_id: str,
+        factory_id: str,
+        core_factory_id: str,
+    ) -> str:
+        """Namespace plugin-owned factory ids while preserving core ids."""
+        if not factory_id or factory_id == core_factory_id or "/" in factory_id:
+            return factory_id
+        return f"{plugin_id}/{factory_id}"
 
     def _register_factories(
         self,
@@ -534,29 +631,13 @@ class PluginRuntimeMng:
         self, template_id: str
     ) -> EnvironmentTemplateCfg | None:
         """Return one plugin-owned environment template by canonical id."""
-        template = self.registry.env_templates.get(template_id)
-        if template is None:
-            return None
-        provider = template.provider
-        if not isinstance(provider, EnvironmentTemplateCfg):
-            raise ValueError(
-                f"Plugin environment template '{template_id}' is invalid."
-            )
-        return provider
+        return self.registry.env_templates.get(template_id)
 
     def get_service_template(
         self, template_id: str
     ) -> ServiceTemplateCfg | None:
         """Return one plugin-owned service template by canonical id."""
-        template = self.registry.service_templates.get(template_id)
-        if template is None:
-            return None
-        provider = template.provider
-        if not isinstance(provider, ServiceTemplateCfg):
-            raise ValueError(
-                f"Plugin service template '{template_id}' is invalid."
-            )
-        return provider
+        return self.registry.service_templates.get(template_id)
 
     def get_service_template_path(self, template_id: str) -> str | None:
         """

--- a/src/plugin/runtime.py
+++ b/src/plugin/runtime.py
@@ -30,10 +30,13 @@ import yaml
 from completion import CompletionMng
 from config import (
     ConfigMng,
+    EnvironmentTemplateCfg,
     PluginCfg,
     PluginDescriptorCfg,
+    ServiceTemplateCfg,
     parse_plugin_descriptor,
 )
+from environment import EnvironmentFactory
 from plugin.api import (
     PluginCommandSpec,
     PluginCompletionSpec,
@@ -41,7 +44,8 @@ from plugin.api import (
     PluginTemplateSpec,
     ShepherdPlugin,
 )
-from util import Util
+from service import ServiceFactory
+from util import Constants, Util
 
 SUPPORTED_PLUGIN_API_VERSION = 1
 
@@ -135,6 +139,7 @@ class PluginRuntimeMng:
         scope: set(verbs)
         for scope, verbs in CompletionMng.CORE_SCOPE_VERBS.items()
     }
+    PLUGIN_TEMPLATES_DIR = "templates"
 
     def __init__(self, configMng: ConfigMng):
         self.configMng = configMng
@@ -245,6 +250,7 @@ class PluginRuntimeMng:
             sys.path.insert(0, plugin_dir)
             module = importlib.import_module(module_name)
         except Exception as exc:
+            self._purge_module_root(module_root)
             Util.print_error_and_die(
                 f"Failed to import plugin '{plugin_id}' entrypoint "
                 f"'{module_name}.{class_name}': {exc}"
@@ -474,6 +480,20 @@ class PluginRuntimeMng:
                     f"Plugin '{plugin_id}' declares duplicate {kind} "
                     f"'{canonical_id}'."
                 )
+            if kind == "environment template" and not isinstance(
+                template.provider, EnvironmentTemplateCfg
+            ):
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' {kind} '{canonical_id}' must "
+                    "provide an EnvironmentTemplateCfg."
+                )
+            if kind == "service template" and not isinstance(
+                template.provider, ServiceTemplateCfg
+            ):
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' {kind} '{canonical_id}' must "
+                    "provide a ServiceTemplateCfg."
+                )
             registry[canonical_id] = template
 
     def _register_factories(
@@ -496,4 +516,141 @@ class PluginRuntimeMng:
                     f"Plugin '{plugin_id}' declares duplicate {kind} "
                     f"'{canonical_id}'."
                 )
+            if not self._is_factory_provider(factory.provider):
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' {kind} '{canonical_id}' must "
+                    "provide a factory instance, factory class, or "
+                    "factory builder callable."
+                )
             registry[canonical_id] = factory
+
+    def _is_factory_provider(self, provider: Any) -> bool:
+        """Return whether the factory provider can be materialized later."""
+        return isinstance(
+            provider, (EnvironmentFactory, ServiceFactory)
+        ) or callable(provider)
+
+    def get_environment_template(
+        self, template_id: str
+    ) -> EnvironmentTemplateCfg | None:
+        """Return one plugin-owned environment template by canonical id."""
+        template = self.registry.env_templates.get(template_id)
+        if template is None:
+            return None
+        provider = template.provider
+        if not isinstance(provider, EnvironmentTemplateCfg):
+            raise ValueError(
+                f"Plugin environment template '{template_id}' is invalid."
+            )
+        return provider
+
+    def get_service_template(
+        self, template_id: str
+    ) -> ServiceTemplateCfg | None:
+        """Return one plugin-owned service template by canonical id."""
+        template = self.registry.service_templates.get(template_id)
+        if template is None:
+            return None
+        provider = template.provider
+        if not isinstance(provider, ServiceTemplateCfg):
+            raise ValueError(
+                f"Plugin service template '{template_id}' is invalid."
+            )
+        return provider
+
+    def get_service_template_path(self, template_id: str) -> str | None:
+        """
+        Return the installed asset path for a plugin-owned service template.
+        """
+        if template_id not in self.registry.service_templates:
+            return None
+
+        plugin_id, local_template_id = self._split_canonical_id(template_id)
+        plugin = self.registry.plugins.get(plugin_id)
+        if plugin is None:
+            return None
+
+        template_path = os.path.join(
+            plugin.plugin_dir,
+            self.PLUGIN_TEMPLATES_DIR,
+            Constants.SVC_TEMPLATES_DIR,
+            local_template_id,
+        )
+        if os.path.isdir(template_path):
+            return template_path
+        return None
+
+    def build_service_factory(
+        self,
+        factory_id: str,
+        configMng: ConfigMng,
+    ) -> ServiceFactory | None:
+        """Materialize one plugin-owned service factory by canonical id."""
+        spec = self.registry.service_factories.get(factory_id)
+        if spec is None:
+            return None
+        return self._materialize_service_factory(
+            factory_id, spec.provider, configMng
+        )
+
+    def build_environment_factory(
+        self,
+        factory_id: str,
+        configMng: ConfigMng,
+        svc_factory: ServiceFactory,
+        cli_flags: dict[str, Any] | None = None,
+    ) -> EnvironmentFactory | None:
+        """Materialize one plugin-owned environment factory by canonical id."""
+        spec = self.registry.env_factories.get(factory_id)
+        if spec is None:
+            return None
+        return self._materialize_environment_factory(
+            factory_id, spec.provider, configMng, svc_factory, cli_flags
+        )
+
+    def _materialize_service_factory(
+        self,
+        factory_id: str,
+        provider: Any,
+        configMng: ConfigMng,
+    ) -> ServiceFactory:
+        """Build a concrete service factory from the stored provider."""
+        if isinstance(provider, ServiceFactory):
+            return provider
+
+        if callable(provider):
+            instance = provider(configMng)
+            if isinstance(instance, ServiceFactory):
+                return instance
+
+        raise ValueError(f"Plugin service factory '{factory_id}' is invalid.")
+
+    def _materialize_environment_factory(
+        self,
+        factory_id: str,
+        provider: Any,
+        configMng: ConfigMng,
+        svc_factory: ServiceFactory,
+        cli_flags: dict[str, Any] | None = None,
+    ) -> EnvironmentFactory:
+        """Build a concrete environment factory from the stored provider."""
+        if isinstance(provider, EnvironmentFactory):
+            return provider
+
+        if callable(provider):
+            instance = provider(configMng, svc_factory, cli_flags)
+            if isinstance(instance, EnvironmentFactory):
+                return instance
+
+        raise ValueError(
+            f"Plugin environment factory '{factory_id}' is invalid."
+        )
+
+    def _split_canonical_id(self, canonical_id: str) -> tuple[str, str]:
+        """Split one canonical plugin-owned id into plugin and local parts."""
+        if "/" not in canonical_id:
+            raise ValueError(
+                f"Plugin-owned identifier '{canonical_id}' is not namespaced."
+            )
+        plugin_id, local_id = canonical_id.split("/", 1)
+        return plugin_id, local_id

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -71,6 +71,11 @@ class ShepherdMng:
         Util.ensure_config_file(self.configMng.constants)
         self.configMng.load()
         self.configMng.ensure_dirs()
+        self.pluginMng = PluginMng(self.cli_flags, self.configMng)
+        self.pluginRuntimeMng = plugin_runtime_mng
+        if self.pluginRuntimeMng is None and load_runtime_plugins:
+            self.pluginRuntimeMng = PluginRuntimeMng(self.configMng)
+        self.configMng.set_plugin_runtime_mng(self.pluginRuntimeMng)
         self.svcFactory = ShpdServiceFactory(self.configMng)
         self.envFactory = ShpdEnvironmentFactory(
             self.configMng, self.svcFactory, cli_flags=self.cli_flags
@@ -81,10 +86,6 @@ class ShepherdMng:
         self.serviceMng = ServiceMng(
             self.cli_flags, self.configMng, self.svcFactory
         )
-        self.pluginMng = PluginMng(self.cli_flags, self.configMng)
-        self.pluginRuntimeMng = plugin_runtime_mng
-        if self.pluginRuntimeMng is None and load_runtime_plugins:
-            self.pluginRuntimeMng = PluginRuntimeMng(self.configMng)
         self.completionMng = CompletionMng(
             self.cli_flags,
             self.configMng,

--- a/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py
+++ b/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py
@@ -3,12 +3,9 @@ from fixture_plugin.helpers import complete_observability
 
 from config import (
     ConfigMng,
-    ContainerCfg,
     EnvironmentCfg,
     EnvironmentTemplateCfg,
     ServiceCfg,
-    ServiceTemplateCfg,
-    ServiceTemplateRefCfg,
 )
 from docker import DockerComposeEnv, DockerComposeSvc
 from environment import Environment, EnvironmentFactory
@@ -16,7 +13,6 @@ from plugin import (
     PluginCommandSpec,
     PluginCompletionSpec,
     PluginFactorySpec,
-    PluginTemplateSpec,
     ShepherdPlugin,
 )
 from service import Service, ServiceFactory
@@ -96,56 +92,6 @@ class RuntimeFixturePlugin(ShepherdPlugin):
                 provider=complete_observability,
             ),
             PluginCompletionSpec(scope="env", provider=complete_observability),
-        ]
-
-    def get_env_templates(self):
-        return [
-            PluginTemplateSpec(
-                id="baseline",
-                provider=EnvironmentTemplateCfg(
-                    tag="runtime-plugin/baseline",
-                    factory="runtime-plugin/baseline-factory",
-                    service_templates=[
-                        ServiceTemplateRefCfg(
-                            template="runtime-plugin/api",
-                            tag="plugin-api",
-                        )
-                    ],
-                    probes=None,
-                    networks=None,
-                    volumes=None,
-                ),
-            )
-        ]
-
-    def get_service_templates(self):
-        return [
-            PluginTemplateSpec(
-                id="api",
-                provider=ServiceTemplateCfg(
-                    tag="runtime-plugin/api",
-                    factory="runtime-plugin/api-factory",
-                    labels=[],
-                    properties={"source": "plugin"},
-                    containers=[
-                        ContainerCfg(
-                            image="busybox:stable-glibc",
-                            tag="app",
-                            container_name=None,
-                            hostname=None,
-                            workdir=None,
-                            volumes=[],
-                            environment=[],
-                            ports=[],
-                            networks=[],
-                            extra_hosts=[],
-                            inits=None,
-                            build=None,
-                        )
-                    ],
-                    start=None,
-                ),
-            )
         ]
 
     def get_env_factories(self):

--- a/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py
+++ b/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py
@@ -1,6 +1,17 @@
 import click
 from fixture_plugin.helpers import complete_observability
 
+from config import (
+    ConfigMng,
+    ContainerCfg,
+    EnvironmentCfg,
+    EnvironmentTemplateCfg,
+    ServiceCfg,
+    ServiceTemplateCfg,
+    ServiceTemplateRefCfg,
+)
+from docker import DockerComposeEnv, DockerComposeSvc
+from environment import Environment, EnvironmentFactory
 from plugin import (
     PluginCommandSpec,
     PluginCompletionSpec,
@@ -8,6 +19,53 @@ from plugin import (
     PluginTemplateSpec,
     ShepherdPlugin,
 )
+from service import Service, ServiceFactory
+
+
+class FixturePluginServiceFactory(ServiceFactory):
+    def new_service_from_cfg_impl(
+        self,
+        envCfg: EnvironmentCfg,
+        svcCfg: ServiceCfg,
+        cli_flags: dict[str, object] | None = None,
+    ) -> Service:
+        return DockerComposeSvc(
+            self.config, envCfg, svcCfg, cli_flags=cli_flags
+        )
+
+    @classmethod
+    def get_name_impl(cls) -> str:
+        return "fixture-plugin-svc"
+
+
+class FixturePluginEnvironmentFactory(EnvironmentFactory):
+    def __init__(
+        self,
+        configMng: ConfigMng,
+        svcFactory: ServiceFactory,
+        cli_flags: dict[str, object] | None = None,
+    ):
+        self.configMng = configMng
+        self.svcFactory = svcFactory
+        self.cli_flags = cli_flags or {}
+
+    def new_environment_impl(
+        self, env_tmpl_cfg: EnvironmentTemplateCfg, env_tag: str
+    ) -> Environment:
+        return DockerComposeEnv(
+            self.configMng,
+            self.svcFactory,
+            self.configMng.env_cfg_from_tag(env_tmpl_cfg, env_tag),
+            cli_flags=self.cli_flags,
+        )
+
+    def new_environment_cfg_impl(self, envCfg: EnvironmentCfg) -> Environment:
+        return DockerComposeEnv(
+            self.configMng,
+            self.svcFactory,
+            envCfg,
+            cli_flags=self.cli_flags,
+        )
 
 
 class RuntimeFixturePlugin(ShepherdPlugin):
@@ -41,15 +99,67 @@ class RuntimeFixturePlugin(ShepherdPlugin):
         ]
 
     def get_env_templates(self):
-        return [PluginTemplateSpec(id="baseline", provider={"kind": "env"})]
+        return [
+            PluginTemplateSpec(
+                id="baseline",
+                provider=EnvironmentTemplateCfg(
+                    tag="runtime-plugin/baseline",
+                    factory="runtime-plugin/baseline-factory",
+                    service_templates=[
+                        ServiceTemplateRefCfg(
+                            template="runtime-plugin/api",
+                            tag="plugin-api",
+                        )
+                    ],
+                    probes=None,
+                    networks=None,
+                    volumes=None,
+                ),
+            )
+        ]
 
     def get_service_templates(self):
-        return [PluginTemplateSpec(id="api", provider={"kind": "svc"})]
+        return [
+            PluginTemplateSpec(
+                id="api",
+                provider=ServiceTemplateCfg(
+                    tag="runtime-plugin/api",
+                    factory="runtime-plugin/api-factory",
+                    labels=[],
+                    properties={"source": "plugin"},
+                    containers=[
+                        ContainerCfg(
+                            image="busybox:stable-glibc",
+                            tag="app",
+                            container_name=None,
+                            hostname=None,
+                            workdir=None,
+                            volumes=[],
+                            environment=[],
+                            ports=[],
+                            networks=[],
+                            extra_hosts=[],
+                            inits=None,
+                            build=None,
+                        )
+                    ],
+                    start=None,
+                ),
+            )
+        ]
 
     def get_env_factories(self):
         return [
-            PluginFactorySpec(id="baseline-factory", provider="env-factory")
+            PluginFactorySpec(
+                id="baseline-factory",
+                provider=FixturePluginEnvironmentFactory,
+            )
         ]
 
     def get_service_factories(self):
-        return [PluginFactorySpec(id="api-factory", provider="svc-factory")]
+        return [
+            PluginFactorySpec(
+                id="api-factory",
+                provider=FixturePluginServiceFactory,
+            )
+        ]

--- a/src/tests/fixtures/plugins/runtime_plugin/plugin.yaml
+++ b/src/tests/fixtures/plugins/runtime_plugin/plugin.yaml
@@ -14,3 +14,32 @@ capabilities:
   svc_factories: true
 default_config:
   region: eu-west-1
+env_templates:
+  - tag: baseline
+    factory: baseline-factory
+    service_templates:
+      - template: api
+        tag: plugin-api
+    probes: null
+    networks: null
+    volumes: null
+service_templates:
+  - tag: api
+    factory: api-factory
+    labels: []
+    properties:
+      source: plugin
+    containers:
+      - image: busybox:stable-glibc
+        tag: app
+        container_name: null
+        hostname: null
+        workdir: null
+        volumes: []
+        environment: []
+        ports: []
+        networks: []
+        extra_hosts: []
+        inits: null
+        build: null
+    start: null

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -276,6 +276,31 @@ def test_completion_add_env(
 
 
 @pytest.mark.compl
+def test_completion_add_env_includes_plugin_templates(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = yaml.safe_load(read_fixture("completion", "shpd.yaml"))
+    shpd_config["plugins"] = [
+        {
+            "id": "runtime-plugin",
+            "enabled": True,
+            "version": "1.0.0",
+            "config": None,
+        }
+    ]
+    shpd_yaml.write_text(yaml.dump(shpd_config, sort_keys=False))
+    _install_runtime_fixture_plugin(shpd_path)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["env", "add"])
+    assert "runtime-plugin/baseline" in completions
+
+
+@pytest.mark.compl
 def test_completion_add_svc_1(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
@@ -290,6 +315,31 @@ def test_completion_add_svc_1(
     sm = ShepherdMng()
     completions = sm.completionMng.get_completions(["svc", "add"])
     assert completions == ["t1", "t2"], "Expected add svc -1- completion"
+
+
+@pytest.mark.compl
+def test_completion_add_svc_includes_plugin_templates(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = yaml.safe_load(read_fixture("completion", "shpd.yaml"))
+    shpd_config["plugins"] = [
+        {
+            "id": "runtime-plugin",
+            "enabled": True,
+            "version": "1.0.0",
+            "config": None,
+        }
+    ]
+    shpd_yaml.write_text(yaml.dump(shpd_config, sort_keys=False))
+    _install_runtime_fixture_plugin(shpd_path)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["svc", "add"])
+    assert "runtime-plugin/api" in completions
 
 
 @pytest.mark.compl

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -327,6 +327,35 @@ capabilities:
   commands: false
 default_config:
   region: eu-west-1
+env_templates:
+  - tag: baseline
+    factory: baseline-factory
+    service_templates:
+      - template: api
+        tag: plugin-api
+    probes: null
+    networks: null
+    volumes: null
+service_templates:
+  - tag: api
+    factory: api-factory
+    labels: []
+    properties:
+      source: plugin
+    containers:
+      - image: busybox
+        tag: app
+        container_name: null
+        hostname: null
+        workdir: null
+        volumes: []
+        environment: []
+        ports: []
+        networks: []
+        extra_hosts: []
+        inits: null
+        build: null
+    start: null
 """
 
     descriptor = parse_plugin_descriptor(descriptor_yaml)
@@ -343,6 +372,14 @@ default_config:
         "commands": False,
     }
     assert descriptor.default_config == {"region": "eu-west-1"}
+    assert descriptor.env_templates is not None
+    assert descriptor.env_templates[0].tag == "baseline"
+    assert descriptor.env_templates[0].factory == "baseline-factory"
+    assert descriptor.env_templates[0].service_templates is not None
+    assert descriptor.env_templates[0].service_templates[0].template == "api"
+    assert descriptor.service_templates is not None
+    assert descriptor.service_templates[0].tag == "api"
+    assert descriptor.service_templates[0].factory == "api-factory"
 
 
 @pytest.mark.cfg
@@ -375,6 +412,36 @@ capabilities:
 
     with pytest.raises(ValueError):
         parse_plugin_descriptor(descriptor_yaml)
+
+
+@pytest.mark.cfg
+def test_parse_plugin_descriptor_allows_omitted_network_and_volume_external():
+    descriptor_yaml = """
+id: acme
+name: Acme Plugin
+version: 1.2.3
+plugin_api_version: 1
+entrypoint:
+  module: plugin.main
+  class: AcmePlugin
+env_templates:
+  - tag: baseline
+    factory: docker-compose
+    service_templates: []
+    probes: []
+    networks:
+      - tag: default
+    volumes:
+      - tag: data
+"""
+
+    descriptor = parse_plugin_descriptor(descriptor_yaml)
+
+    assert descriptor.env_templates is not None
+    assert descriptor.env_templates[0].networks is not None
+    assert descriptor.env_templates[0].networks[0].external == "false"
+    assert descriptor.env_templates[0].volumes is not None
+    assert descriptor.env_templates[0].volumes[0].external == "false"
 
 
 @pytest.mark.cfg

--- a/src/tests/test_plugin_runtime.py
+++ b/src/tests/test_plugin_runtime.py
@@ -124,6 +124,21 @@ def test_shepherd_loads_enabled_plugin_runtime_registry(
     assert "runtime-plugin/baseline-factory" in registry.env_factories
     assert "runtime-plugin/api-factory" in registry.service_factories
     assert callable(registry.completion_providers["observability"][0].provider)
+    env_template = shepherd.configMng.get_environment_template(
+        "runtime-plugin/baseline"
+    )
+    assert env_template is not None
+    assert env_template.factory == "runtime-plugin/baseline-factory"
+    svc_template = shepherd.configMng.get_service_template("runtime-plugin/api")
+    assert svc_template is not None
+    assert svc_template.factory == "runtime-plugin/api-factory"
+    svc_template_path = shepherd.configMng.get_service_template_path(
+        "runtime-plugin/api"
+    )
+    assert svc_template_path is not None
+    assert svc_template_path.endswith(
+        "/plugins/runtime-plugin/templates/svcs/api"
+    )
 
 
 @pytest.mark.shpd
@@ -236,6 +251,81 @@ def test_cli_executes_plugin_verb_under_core_scope(
 
     assert result.exit_code == 0
     assert "plugin-doctor:network" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_adds_environment_from_plugin_template(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _install_fixture_plugin(shpd_path)
+    _write_plugin_inventory(
+        shpd_yaml,
+        [
+            {
+                "id": "runtime-plugin",
+                "enabled": True,
+                "version": "1.0.0",
+                "config": None,
+            }
+        ],
+    )
+
+    result = runner.invoke(
+        cli, ["env", "add", "runtime-plugin/baseline", "plugin-env"]
+    )
+
+    assert result.exit_code == 0
+
+    shepherd = ShepherdMng()
+    env_cfg = shepherd.configMng.get_environment("plugin-env")
+    assert env_cfg is not None
+    assert env_cfg.template == "runtime-plugin/baseline"
+    assert env_cfg.factory == "runtime-plugin/baseline-factory"
+    assert env_cfg.services is not None
+    assert env_cfg.services[0].template == "runtime-plugin/api"
+    assert env_cfg.services[0].factory == "runtime-plugin/api-factory"
+    assert (shpd_path / "envs" / "plugin-env").is_dir()
+    assert (shpd_path / "envs" / "plugin-env" / "plugin-api").is_dir()
+
+
+@pytest.mark.shpd
+def test_cli_adds_service_from_plugin_template(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _install_fixture_plugin(shpd_path)
+    _write_plugin_inventory(
+        shpd_yaml,
+        [
+            {
+                "id": "runtime-plugin",
+                "enabled": True,
+                "version": "1.0.0",
+                "config": None,
+            }
+        ],
+    )
+
+    result = runner.invoke(cli, ["env", "add", "default", "plugin-svc-env"])
+    assert result.exit_code == 0
+
+    result = runner.invoke(cli, ["env", "checkout", "plugin-svc-env"])
+    assert result.exit_code == 0
+
+    result = runner.invoke(cli, ["svc", "add", "runtime-plugin/api", "api-1"])
+    assert result.exit_code == 0
+
+    shepherd = ShepherdMng()
+    env_cfg = shepherd.configMng.get_active_environment()
+    assert env_cfg is not None
+    svc_cfg = env_cfg.get_service("api-1")
+    assert svc_cfg is not None
+    assert svc_cfg.template == "runtime-plugin/api"
+    assert svc_cfg.factory == "runtime-plugin/api-factory"
+    assert svc_cfg.properties == {"source": "plugin"}
 
 
 @pytest.mark.shpd


### PR DESCRIPTION
## Summary
- resolve env and svc templates through the plugin runtime registries
- materialize plugin-owned factory providers from the core factory dispatch
- add runtime fixture coverage for plugin-backed env add, svc add, and built-in completion

## Testing
- python3 -m py_compile src/plugin/runtime.py src/config/config.py src/factory/shpd_env_factory.py src/factory/shpd_svc_factory.py src/shepctl.py src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py src/tests/test_plugin_runtime.py
- cd src && ../.venv/bin/pyright plugin/runtime.py config/config.py factory/shpd_env_factory.py factory/shpd_svc_factory.py shepctl.py tests/test_plugin_runtime.py tests/test_completion.py
- cd src && ../.venv/bin/pytest tests/test_plugin_runtime.py tests/test_completion.py
- cd src && ../.venv/bin/pytest

Fixes: #179