### PR TITLE
refactor(core): align core registry resolution

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1366,29 +1366,112 @@ class ConfigMng:
         """
         self.store_config(self.config)
 
+    def get_canonical_id(self, identifier: str) -> str:
+        """
+        Return the internal canonical identifier for core or plugin-owned ids.
+
+        Built-in resources keep their short user-facing ids in config and CLI,
+        but internal registry-oriented lookup uses the explicit `core/...`
+        namespace just like plugin-owned resources use `<plugin-id>/...`.
+        """
+        if "/" in identifier:
+            return identifier
+        return f"{self.constants.CORE_PLUGIN_ID}/{identifier}"
+
+    def _is_core_id(self, identifier: str) -> bool:
+        """Return whether the canonical identifier belongs to core."""
+        return identifier.startswith(f"{self.constants.CORE_PLUGIN_ID}/")
+
+    def _local_id(self, identifier: str) -> str:
+        """Return the local identifier portion from a canonical id."""
+        if "/" in identifier:
+            return identifier.split("/", 1)[1]
+        return identifier
+
+    def _core_environment_template_registry(
+        self,
+    ) -> dict[str, EnvironmentTemplateCfg]:
+        """Build the canonical lookup registry for built-in env templates."""
+        return {
+            self.get_canonical_id(env_template.tag): env_template
+            for env_template in self.config.env_templates or []
+        }
+
+    def _core_service_template_registry(
+        self,
+    ) -> dict[str, ServiceTemplateCfg]:
+        """
+        Build the canonical lookup registry for built-in service templates.
+        """
+        return {
+            self.get_canonical_id(service_template.tag): service_template
+            for service_template in self.config.service_templates or []
+        }
+
+    def get_environment_template_registry(
+        self,
+    ) -> dict[str, EnvironmentTemplateCfg]:
+        """Return the merged canonical registry of env templates."""
+        registry = self._core_environment_template_registry()
+        if self.pluginRuntimeMng is not None:
+            registry.update(self.pluginRuntimeMng.registry.env_templates)
+        return registry
+
+    def get_service_template_registry(
+        self,
+    ) -> dict[str, ServiceTemplateCfg]:
+        """Return the merged canonical registry of service templates."""
+        registry = self._core_service_template_registry()
+        if self.pluginRuntimeMng is not None:
+            registry.update(self.pluginRuntimeMng.registry.service_templates)
+        return registry
+
+    def get_canonical_env_factory_id(self, factory_id: str) -> str:
+        """Return the canonical environment factory id."""
+        return self.get_canonical_id(factory_id)
+
+    def get_canonical_svc_factory_id(self, factory_id: str) -> str:
+        """Return the canonical service factory id."""
+        return self.get_canonical_id(factory_id)
+
+    def is_core_env_factory_id(self, factory_id: str) -> bool:
+        """Return whether the environment factory id resolves to core."""
+        return self.get_canonical_env_factory_id(
+            factory_id
+        ) == self.get_canonical_env_factory_id(
+            self.constants.ENV_FACTORY_DEFAULT
+        )
+
+    def is_core_svc_factory_id(self, factory_id: str) -> bool:
+        """Return whether the service factory id resolves to core."""
+        return self.get_canonical_svc_factory_id(
+            factory_id
+        ) == self.get_canonical_svc_factory_id(
+            self.constants.SVC_FACTORY_DEFAULT
+        )
+
     def get_service_template_path(self, serviceTemplate: str) -> Optional[str]:
         """
-        Retrieves the service template path by its tag.
+        Retrieves the service template path by id.
 
-        :param serviceTemplate: The tag of the service template.
+        :param serviceTemplate: The service template id.
         :return: The service template path.
         """
-        if self.config.service_templates and any(
-            svc_template.tag == serviceTemplate
-            for svc_template in self.config.service_templates
-        ):
-            return os.path.join(
-                self.config.templates_path,
-                Constants.SVC_TEMPLATES_DIR,
-                serviceTemplate,
-            )
-        if (
+        canonical_id = self.get_canonical_id(serviceTemplate)
+        if self._is_core_id(canonical_id):
+            local_template_id = self._local_id(canonical_id)
+            if self._core_service_template_registry().get(canonical_id):
+                return os.path.join(
+                    self.config.templates_path,
+                    Constants.SVC_TEMPLATES_DIR,
+                    local_template_id,
+                )
+        elif (
             self.pluginRuntimeMng is not None
-            and "/" in serviceTemplate
             and (
                 plugin_template_path := (
                     self.pluginRuntimeMng.get_service_template_path(
-                        serviceTemplate
+                        canonical_id
                     )
                 )
             )
@@ -1401,18 +1484,14 @@ class ConfigMng:
         self, envTemplate: str
     ) -> Optional[EnvironmentTemplateCfg]:
         """
-        Retrieves an environment template configuration by its tag.
+        Retrieves an environment template configuration by id.
 
-        :param envTemplate: The template of the environment to retrieve.
-        :return: The environment template configuration if found, else None.
+        Accepts both short core ids like `default` and canonical ids like
+        `core/default` or `plugin-id/template`.
         """
-        if self.config.env_templates:
-            for env_template in self.config.env_templates:
-                if env_template.tag == envTemplate:
-                    return env_template
-        if self.pluginRuntimeMng is not None and "/" in envTemplate:
-            return self.pluginRuntimeMng.get_environment_template(envTemplate)
-        return None
+        return self.get_environment_template_registry().get(
+            self.get_canonical_id(envTemplate)
+        )
 
     def get_environment_templates(
         self,
@@ -1422,11 +1501,7 @@ class ConfigMng:
 
         :return: A list of all environment templates.
         """
-        templates = list(self.config.env_templates or [])
-        if self.pluginRuntimeMng is not None:
-            templates.extend(
-                self.pluginRuntimeMng.registry.env_templates.values()
-            )
+        templates = list(self.get_environment_template_registry().values())
         return templates or None
 
     def get_environment_template_tags(self) -> list[str]:
@@ -1438,18 +1513,14 @@ class ConfigMng:
         self, serviceTemplate: str
     ) -> Optional[ServiceTemplateCfg]:
         """
-        Retrieves a service template configuration by its tag.
+        Retrieves a service template configuration by id.
 
-        :param serviceTemplate: The template of the service to retrieve.
-        :return: The service template configuration if found, else None.
+        Accepts both short core ids like `default` and canonical ids like
+        `core/default` or `plugin-id/template`.
         """
-        if self.config.service_templates:
-            for svc_template in self.config.service_templates:
-                if svc_template.tag == serviceTemplate:
-                    return svc_template
-        if self.pluginRuntimeMng is not None and "/" in serviceTemplate:
-            return self.pluginRuntimeMng.get_service_template(serviceTemplate)
-        return None
+        return self.get_service_template_registry().get(
+            self.get_canonical_id(serviceTemplate)
+        )
 
     def get_service_templates(self) -> Optional[list[ServiceTemplateCfg]]:
         """
@@ -1457,11 +1528,7 @@ class ConfigMng:
 
         :return: A list of all service templates.
         """
-        templates = list(self.config.service_templates or [])
-        if self.pluginRuntimeMng is not None:
-            templates.extend(
-                self.pluginRuntimeMng.registry.service_templates.values()
-            )
+        templates = list(self.get_service_template_registry().values())
         return templates or None
 
     def get_resource_templates(self, resource_type: str) -> list[str]:

--- a/src/factory/shpd_env_factory.py
+++ b/src/factory/shpd_env_factory.py
@@ -22,7 +22,6 @@ from config import ConfigMng, EnvironmentCfg, EnvironmentTemplateCfg
 from docker import DockerComposeEnv
 from environment import Environment, EnvironmentFactory
 from service import ServiceFactory
-from util import Constants
 
 
 class ShpdEnvironmentFactory(EnvironmentFactory):
@@ -51,31 +50,30 @@ class ShpdEnvironmentFactory(EnvironmentFactory):
         The template is first converted to an `EnvironmentCfg` snapshot for
         `env_tag`, then routed to the backend-specific environment class.
         """
-        match env_tmpl_cfg.factory:
-            case Constants.ENV_FACTORY_DEFAULT:
-                return DockerComposeEnv(
-                    self.configMng,
-                    self.svcFactory,
-                    self.configMng.env_cfg_from_tag(env_tmpl_cfg, env_tag),
-                    cli_flags=self.cli_flags,
-                )
-            case _:
-                plugin_runtime_mng = self.configMng.pluginRuntimeMng
-                if plugin_runtime_mng is None:
-                    raise ValueError(
-                        f"Unknown environment factory: {env_tmpl_cfg.factory}"
-                    )
-                plugin_factory = plugin_runtime_mng.build_environment_factory(
-                    env_tmpl_cfg.factory,
-                    self.configMng,
-                    self.svcFactory,
-                    self.cli_flags,
-                )
-                if plugin_factory is None:
-                    raise ValueError(
-                        f"Unknown environment factory: {env_tmpl_cfg.factory}"
-                    )
-                return plugin_factory.new_environment(env_tmpl_cfg, env_tag)
+        if self.configMng.is_core_env_factory_id(env_tmpl_cfg.factory):
+            return DockerComposeEnv(
+                self.configMng,
+                self.svcFactory,
+                self.configMng.env_cfg_from_tag(env_tmpl_cfg, env_tag),
+                cli_flags=self.cli_flags,
+            )
+
+        plugin_runtime_mng = self.configMng.pluginRuntimeMng
+        if plugin_runtime_mng is None:
+            raise ValueError(
+                f"Unknown environment factory: {env_tmpl_cfg.factory}"
+            )
+        plugin_factory = plugin_runtime_mng.build_environment_factory(
+            self.configMng.get_canonical_env_factory_id(env_tmpl_cfg.factory),
+            self.configMng,
+            self.svcFactory,
+            self.cli_flags,
+        )
+        if plugin_factory is None:
+            raise ValueError(
+                f"Unknown environment factory: {env_tmpl_cfg.factory}"
+            )
+        return plugin_factory.new_environment(env_tmpl_cfg, env_tag)
 
     @override
     def new_environment_cfg_impl(self, envCfg: EnvironmentCfg) -> Environment:
@@ -84,28 +82,23 @@ class ShpdEnvironmentFactory(EnvironmentFactory):
 
         Used for operations on already persisted environments.
         """
-        match envCfg.factory:
-            case Constants.ENV_FACTORY_DEFAULT:
-                return DockerComposeEnv(
-                    self.configMng,
-                    self.svcFactory,
-                    envCfg,
-                    cli_flags=self.cli_flags,
-                )
-            case _:
-                plugin_runtime_mng = self.configMng.pluginRuntimeMng
-                if plugin_runtime_mng is None:
-                    raise ValueError(
-                        f"Unknown environment factory: {envCfg.factory}"
-                    )
-                plugin_factory = plugin_runtime_mng.build_environment_factory(
-                    envCfg.factory,
-                    self.configMng,
-                    self.svcFactory,
-                    self.cli_flags,
-                )
-                if plugin_factory is None:
-                    raise ValueError(
-                        f"Unknown environment factory: {envCfg.factory}"
-                    )
-                return plugin_factory.new_environment_cfg(envCfg)
+        if self.configMng.is_core_env_factory_id(envCfg.factory):
+            return DockerComposeEnv(
+                self.configMng,
+                self.svcFactory,
+                envCfg,
+                cli_flags=self.cli_flags,
+            )
+
+        plugin_runtime_mng = self.configMng.pluginRuntimeMng
+        if plugin_runtime_mng is None:
+            raise ValueError(f"Unknown environment factory: {envCfg.factory}")
+        plugin_factory = plugin_runtime_mng.build_environment_factory(
+            self.configMng.get_canonical_env_factory_id(envCfg.factory),
+            self.configMng,
+            self.svcFactory,
+            self.cli_flags,
+        )
+        if plugin_factory is None:
+            raise ValueError(f"Unknown environment factory: {envCfg.factory}")
+        return plugin_factory.new_environment_cfg(envCfg)

--- a/src/factory/shpd_svc_factory.py
+++ b/src/factory/shpd_svc_factory.py
@@ -21,7 +21,6 @@ from typing import Any, override
 from config import ConfigMng, EnvironmentCfg, ServiceCfg
 from docker import DockerComposeSvc
 from service import Service, ServiceFactory
-from util import Constants
 
 
 class ShpdServiceFactory(ServiceFactory):
@@ -46,24 +45,20 @@ class ShpdServiceFactory(ServiceFactory):
         Instantiate a concrete service implementation for the configured
         backend.
         """
-        match svcCfg.factory:
-            case Constants.SVC_FACTORY_DEFAULT:
-                return DockerComposeSvc(
-                    self.configMng, envCfg, svcCfg, cli_flags=cli_flags
-                )
-            case _:
-                plugin_runtime_mng = self.configMng.pluginRuntimeMng
-                if plugin_runtime_mng is None:
-                    raise ValueError(
-                        f"Unknown service factory: {svcCfg.factory}"
-                    )
-                plugin_factory = plugin_runtime_mng.build_service_factory(
-                    svcCfg.factory, self.configMng
-                )
-                if plugin_factory is None:
-                    raise ValueError(
-                        f"Unknown service factory: {svcCfg.factory}"
-                    )
-                return plugin_factory.new_service_from_cfg(
-                    envCfg, svcCfg, cli_flags=cli_flags
-                )
+        if self.configMng.is_core_svc_factory_id(svcCfg.factory):
+            return DockerComposeSvc(
+                self.configMng, envCfg, svcCfg, cli_flags=cli_flags
+            )
+
+        plugin_runtime_mng = self.configMng.pluginRuntimeMng
+        if plugin_runtime_mng is None:
+            raise ValueError(f"Unknown service factory: {svcCfg.factory}")
+        plugin_factory = plugin_runtime_mng.build_service_factory(
+            self.configMng.get_canonical_svc_factory_id(svcCfg.factory),
+            self.configMng,
+        )
+        if plugin_factory is None:
+            raise ValueError(f"Unknown service factory: {svcCfg.factory}")
+        return plugin_factory.new_service_from_cfg(
+            envCfg, svcCfg, cli_flags=cli_flags
+        )

--- a/src/plugin/plugin.py
+++ b/src/plugin/plugin.py
@@ -98,6 +98,7 @@ class PluginMng:
             self._extract_plugin_archive(archive_path, extracted_dir)
             descriptor_path = self._find_descriptor_path(extracted_dir)
             descriptor = self._load_descriptor(descriptor_path)
+            self._validate_reserved_plugin_id(descriptor.id)
 
             if self.configMng.get_plugin(descriptor.id) is not None:
                 Util.print_error_and_die(
@@ -146,6 +147,13 @@ class PluginMng:
                 f"Invalid plugin descriptor '{descriptor_path}': {exc}"
             )
             raise AssertionError("unreachable")
+
+    def _validate_reserved_plugin_id(self, plugin_id: str) -> None:
+        """Reject plugin ids reserved for internal canonical namespaces."""
+        if plugin_id == self.configMng.constants.CORE_PLUGIN_ID:
+            Util.print_error_and_die(
+                f"Plugin id '{plugin_id}' is reserved for core resources."
+            )
 
     def _find_descriptor_path(self, extracted_dir: str) -> str:
         descriptor_name = self.configMng.constants.PLUGIN_DESCRIPTOR_FILE

--- a/src/plugin/runtime.py
+++ b/src/plugin/runtime.py
@@ -211,6 +211,11 @@ class PluginRuntimeMng:
         self, plugin_cfg: PluginCfg, descriptor: PluginDescriptorCfg
     ) -> None:
         """Reject stale or incompatible installed plugin metadata."""
+        if descriptor.id == self.configMng.constants.CORE_PLUGIN_ID:
+            Util.print_error_and_die(
+                f"Plugin id '{descriptor.id}' is reserved for core "
+                "resources."
+            )
         if descriptor.id != plugin_cfg.id:
             Util.print_error_and_die(
                 f"Installed plugin '{plugin_cfg.id}' has descriptor id "

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -17,6 +17,7 @@
 
 
 import os
+from copy import deepcopy
 from unittest.mock import mock_open
 
 import pytest
@@ -25,7 +26,27 @@ from pytest_mock import MockerFixture
 from test_util import read_fixture
 
 from config import Config, ConfigMng, parse_config, parse_plugin_descriptor
+from docker import DockerComposeEnv, DockerComposeSvc
+from factory import ShpdEnvironmentFactory, ShpdServiceFactory
 from util import Constants
+
+
+def _load_config_manager(mocker: MockerFixture) -> ConfigMng:
+    values = read_fixture("cfg", "values.conf")
+    config_yaml = read_fixture("cfg", "shpd.yaml")
+
+    mock_open1 = mock_open(read_data=values)
+    mock_open2 = mock_open(read_data=config_yaml)
+
+    mocker.patch("os.path.exists", return_value=True)
+    mocker.patch(
+        "builtins.open",
+        side_effect=[mock_open1.return_value, mock_open2.return_value],
+    )
+
+    cMng = ConfigMng(".shpd.conf")
+    cMng.load()
+    return cMng
 
 
 @pytest.mark.cfg
@@ -206,6 +227,63 @@ def test_load_config(mocker: MockerFixture):
     }
     assert config.envs[0].status.active is True
     assert config.envs[0].status.rendered_config is None
+
+
+@pytest.mark.cfg
+def test_core_canonical_template_lookup(mocker: MockerFixture):
+    cMng = _load_config_manager(mocker)
+
+    env_template = cMng.get_environment_template("default")
+    assert env_template is not None
+    assert cMng.get_environment_template("core/default") == env_template
+
+    svc_template = cMng.get_service_template("oracle")
+    assert svc_template is not None
+    assert cMng.get_service_template("core/oracle") == svc_template
+
+    assert cMng.get_service_template_path("oracle") == os.path.join(
+        cMng.config.templates_path,
+        Constants.SVC_TEMPLATES_DIR,
+        "oracle",
+    )
+    assert cMng.get_service_template_path("core/oracle") == os.path.join(
+        cMng.config.templates_path,
+        Constants.SVC_TEMPLATES_DIR,
+        "oracle",
+    )
+
+
+@pytest.mark.cfg
+def test_core_canonical_factory_dispatch(mocker: MockerFixture):
+    cMng = _load_config_manager(mocker)
+    svc_factory = ShpdServiceFactory(cMng)
+    env_factory = ShpdEnvironmentFactory(cMng, svc_factory)
+
+    env_template = deepcopy(cMng.get_environment_template("default"))
+    assert env_template is not None
+    env_template.factory = cMng.get_canonical_env_factory_id(
+        Constants.ENV_FACTORY_DEFAULT
+    )
+
+    service_template = cMng.get_service_template("oracle")
+    assert service_template is not None
+    service_cfg = cMng.svc_cfg_from_service_template(
+        service_template, "svc-core", None
+    )
+    service_cfg.factory = cMng.get_canonical_svc_factory_id(
+        Constants.SVC_FACTORY_DEFAULT
+    )
+
+    env_cfg = deepcopy(cMng.config.envs[0])
+
+    assert isinstance(
+        env_factory.new_environment(env_template, "sample-core"),
+        DockerComposeEnv,
+    )
+    assert isinstance(
+        svc_factory.new_service_from_cfg(env_cfg, service_cfg),
+        DockerComposeSvc,
+    )
 
 
 @pytest.mark.cfg

--- a/src/tests/test_plugin_runtime.py
+++ b/src/tests/test_plugin_runtime.py
@@ -423,6 +423,31 @@ def test_normal_startup_fails_for_missing_enabled_plugin(
 
 
 @pytest.mark.shpd
+def test_normal_startup_rejects_reserved_core_plugin_id(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _install_fixture_plugin(shpd_path, plugin_id="core")
+    _write_plugin_inventory(
+        shpd_yaml,
+        [
+            {
+                "id": "core",
+                "enabled": True,
+                "version": "1.0.0",
+                "config": None,
+            }
+        ],
+    )
+
+    result = runner.invoke(cli, ["test"])
+
+    assert result.exit_code == 1
+    assert "Plugin id 'core' is reserved" in result.output
+
+
+@pytest.mark.shpd
 def test_startup_fails_for_plugin_command_collision(
     shpd_conf: tuple[Path, Path], mocker: MockerFixture
 ):

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -701,6 +701,25 @@ capabilities:
 
 
 @pytest.mark.shpd
+def test_cli_plugin_install_rejects_reserved_core_plugin_id(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _write_cli_config_with_plugins(shpd_yaml)
+
+    archive_path = shpd_path / "core-plugin.tar.gz"
+    _write_plugin_archive(archive_path, plugin_id="core")
+
+    result = runner.invoke(cli, ["plugin", "install", str(archive_path)])
+
+    assert result.exit_code == 1
+    assert "Plugin id 'core' is reserved" in result.output
+    assert not (shpd_path / "plugins" / "core").exists()
+
+
+@pytest.mark.shpd
 def test_cli_get_svc_without_output_describes_svc(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -73,6 +73,7 @@ class Constants:
     APP_LICENSE: str = "AGPL-3.0"
     APP_URL: str = "https://github.com/MoonyFringers/shepherd"
     PLUGIN_DESCRIPTOR_FILE: str = "plugin.yaml"
+    CORE_PLUGIN_ID: str = "core"
 
     # Environment templates:
 


### PR DESCRIPTION
## Summary
- normalize built-in template and factory ids under an internal core namespace
- route ConfigMng template lookup through canonical registry-style helpers
- align the core env and service dispatchers with the plugin-oriented factory resolution path
- add coverage for core canonical lookups and canonical core factory dispatch

## Testing
- cd src && ../.venv/bin/pyright config/config.py factory/shpd_env_factory.py factory/shpd_svc_factory.py tests/test_config.py util/constants.py
- cd src && ../.venv/bin/pytest tests/test_config.py tests/test_plugin_runtime.py
- cd src && ../.venv/bin/pytest

Fixes: #181