### PR TITLE
feature(core): add macOS path translation and installer support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 ---
+exclude: ^\.github/cla_signatures\.json$
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/docs/install.md
+++ b/docs/install.md
@@ -33,6 +33,15 @@ sudo apt update
 sudo apt install python3 python3-pip python3-venv -y
 ```
 
+To install them on macOS with Homebrew:
+
+```bash
+brew install python bc jq rsync
+```
+
+For Docker-based workflows on macOS, make sure Docker Desktop is installed
+and running before using `shepctl`.
+
 ### Step 1: Clone the Repository
 
 ```bash
@@ -48,6 +57,9 @@ Use the `source` method to install `shepctl` for development:
 cd scripts
 ./install.sh -m source install
 ```
+
+On Apple Silicon Macs, the installer defaults to the Homebrew prefix under
+`/opt/homebrew`. On Intel Macs, it defaults to `/usr/local`.
 
 This will:
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,8 +16,14 @@ else
   PYTHON="python3"
 fi
 
+OS_NAME="$(uname -s)"
+
 # If no arguments or --help, run without sudo
 if [ $# -eq 0 ] || [[ "$1" == "--help" ]]; then
+  PYTHONPATH=src $PYTHON -m installer.install "$@"
+elif [ "$OS_NAME" = "Darwin" ] && [ "$1" = "uninstall" ]; then
+  sudo PYTHONPATH=src $PYTHON -m installer.install "$@"
+elif [ "$OS_NAME" = "Darwin" ]; then
   PYTHONPATH=src $PYTHON -m installer.install "$@"
 else
   sudo PYTHONPATH=src $PYTHON -m installer.install "$@"

--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -54,7 +54,9 @@ class DockerComposeEnv(Environment):
                 ):
                     device_path = vol.driver_opts.get("device")
                     if device_path:
-                        Util.ensure_dir(device_path, vol.tag)
+                        Util.ensure_dir(
+                            Util.translate_host_path(device_path), vol.tag
+                        )
 
     @override
     def clone_impl(self, dst_env_tag: str) -> DockerComposeEnv:
@@ -345,7 +347,13 @@ class DockerComposeEnv(Environment):
                         if vol.driver:
                             vol_config["driver"] = vol.driver
                         if vol.driver_opts:
-                            vol_config["driver_opts"] = vol.driver_opts
+                            driver_opts = dict(vol.driver_opts)
+                            device_path = driver_opts.get("device")
+                            if device_path:
+                                driver_opts["device"] = (
+                                    Util.translate_host_path(device_path)
+                                )
+                            vol_config["driver_opts"] = driver_opts
                         if vol.labels:
                             vol_config["labels"] = vol.labels
 

--- a/src/docker/docker_compose_util.py
+++ b/src/docker/docker_compose_util.py
@@ -211,7 +211,9 @@ def render_container(
     if cnt.workdir:
         container_def["working_dir"] = cnt.workdir
     if cnt.volumes:
-        container_def["volumes"] = cnt.volumes
+        container_def["volumes"] = [
+            Util.translate_volume_binding(volume) for volume in cnt.volumes
+        ]
     if cnt.environment:
         container_def["environment"] = cnt.environment
     if cnt.ports:

--- a/src/installer/install.py
+++ b/src/installer/install.py
@@ -10,7 +10,7 @@ import pwd
 import shutil
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import click
 
@@ -26,12 +26,17 @@ force_source_download = False
 # Configuration
 exec_dir = Path(__file__).parent.resolve()
 py_src_dir = (exec_dir.parent).resolve()
+default_install_paths = Util.get_default_install_paths()
 
 # Environment variables with defaults
 install_shepctl_dir = Path(
-    os.environ.get("INSTALL_SHEPCTL_DIR", "/opt/shepctl")
+    os.environ.get(
+        "INSTALL_SHEPCTL_DIR", str(default_install_paths.install_dir)
+    )
 ).resolve()
-symlink_dir = Path(os.environ.get("SYMLINK_DIR", "/usr/local/bin")).resolve()
+symlink_dir = Path(
+    os.environ.get("SYMLINK_DIR", str(default_install_paths.symlink_dir))
+).resolve()
 
 
 ####################################################
@@ -80,9 +85,8 @@ def cli(
 @click.pass_context
 def install(ctx: click.Context) -> None:
     """Install shepctl."""
-    # Installer needs to run as root
-    # to install system-wide
-    if not Util.is_root():
+    os_info = Util.get_os_info()
+    if os_info.system != "darwin" and not Util.is_root():
         Util.print_error_and_die("This script must be run as root")
 
     global verbose, skip_ensure_deps, install_method
@@ -97,7 +101,8 @@ def install(ctx: click.Context) -> None:
 @click.pass_context
 def uninstall(ctx: click.Context) -> None:
     """Uninstall shepctl."""
-    if not Util.is_root():
+    os_info = Util.get_os_info()
+    if os_info.system != "darwin" and not Util.is_root():
         Util.print_error_and_die("This script must be run as root")
 
     # Get options from context
@@ -111,8 +116,9 @@ def uninstall(ctx: click.Context) -> None:
 
 def install_binary() -> None:
     """Install shepctl from binary release."""
+    defaults = Util.get_default_install_paths()
     install_shepctl_dir: str = os.environ.get(
-        "INSTALL_SHEPCTL_DIR", "/opt/shepctl"
+        "INSTALL_SHEPCTL_DIR", str(defaults.install_dir)
     )
 
     version = os.environ.get("VER", "latest")
@@ -136,7 +142,7 @@ def install_binary() -> None:
     os.chmod(f"{install_shepctl_dir}/shepctl", 0o755)
 
     symlink_dir = Path(
-        os.environ.get("SYMLINK_DIR", "/usr/local/bin")
+        os.environ.get("SYMLINK_DIR", str(defaults.symlink_dir))
     ).resolve()
     symlink_path = symlink_dir / "shepctl"
     if not symlink_path.exists():
@@ -158,6 +164,7 @@ def manage_dependencies() -> None:
 
     # Manage dependencies based on OS
     RepositoryManager.install_packages(
+        os_info.system,
         os_info.distro,
         os_info.codename,
         install_method == "source",
@@ -193,8 +200,9 @@ def manage_python_dependencies() -> None:
 # (set to /usr/local/bin by default)
 def manage_source_symlinks() -> None:
     bin_path: Path = Path(install_shepctl_dir) / "bin" / "shepctl"
+    defaults = Util.get_default_install_paths()
     symlink_dir: Path = Path(
-        os.environ.get("SYMLINK_DIR", "/usr/local/bin")
+        os.environ.get("SYMLINK_DIR", str(defaults.symlink_dir))
     ).resolve()
     symlink_path = symlink_dir / "shepctl"
 
@@ -262,8 +270,9 @@ def install_source() -> None:
     - create `.venv` and install requirements
     - create a launcher script in `SYMLINK_DIR`
     """
+    defaults = Util.get_default_install_paths()
     install_shepctl_dir: Path = Path(
-        os.environ.get("INSTALL_SHEPCTL_DIR", "/opt/shepctl")
+        os.environ.get("INSTALL_SHEPCTL_DIR", str(defaults.install_dir))
     ).resolve()
 
     # Ensure the installation directory exists
@@ -293,6 +302,20 @@ def set_py_permissions(dest_dir: Path) -> None:
         py_file.chmod(0o664)
 
 
+def handle_permission_denied(action: str, path: Path) -> None:
+    if Util.get_os_info().system == "darwin":
+        Util.print_error_and_die(
+            f"Failed to {action} '{path}' due to insufficient permissions.\n"
+            "This usually means a previous macOS install was created "
+            "with sudo. Re-run `./scripts/install.sh uninstall` to clean "
+            "up the legacy install, then run install again without sudo."
+        )
+    else:
+        Util.print_error_and_die(
+            f"Failed to {action} '{path}' due to insufficient permissions."
+        )
+
+
 def install_shepctl() -> None:
     """
     Entry point for installer execution after CLI/root checks.
@@ -307,7 +330,12 @@ def install_shepctl() -> None:
 
     # Clean existing installation if it exists
     if Path(install_shepctl_dir).exists():
-        shutil.rmtree(Path(install_shepctl_dir))
+        try:
+            shutil.rmtree(Path(install_shepctl_dir))
+        except PermissionError:
+            handle_permission_denied(
+                "remove install directory", install_shepctl_dir
+            )
     os.makedirs(Path(install_shepctl_dir), exist_ok=True)
 
     if install_method == "binary":
@@ -332,13 +360,21 @@ def get_script_completion_src() -> tuple[Path, str]:
     return scripts_dir / script_completion_name, script_completion_name
 
 
+def get_completion_dir(system: Optional[str] = None) -> Path:
+    current_system = system or Util.get_os_info().system
+    if current_system == "darwin":
+        defaults = Util.get_default_install_paths(current_system)
+        return defaults.symlink_dir.parent / "etc" / "bash_completion.d"
+    return Path("/etc/bash_completion.d")
+
+
 def install_completion() -> None:
     """
     Install shell completion if system bash-completion directory is available.
 
     Failure to install completion is non-fatal for core CLI functionality.
     """
-    completion_dir = Path("/etc/bash_completion.d")
+    completion_dir = get_completion_dir()
 
     src, script_completion_filename = get_script_completion_src()
     dest = completion_dir / script_completion_filename
@@ -372,20 +408,33 @@ def uninstall_shepctl() -> None:
 
     # Remove installation directory
     if Path(install_shepctl_dir).exists():
-        shutil.rmtree(install_shepctl_dir)
+        try:
+            shutil.rmtree(install_shepctl_dir)
+        except PermissionError:
+            handle_permission_denied(
+                "remove install directory", install_shepctl_dir
+            )
         Util.print(f"Removed {install_shepctl_dir}")
 
     # Remove symlink
     symlink_path: Path = Path(symlink_dir) / "shepctl"
     if symlink_path.exists():
-        symlink_path.unlink()
+        try:
+            symlink_path.unlink()
+        except PermissionError:
+            handle_permission_denied("remove symlink", symlink_path)
         Util.print(f"Removed symlink {symlink_path}")
 
     # Remove autocompletion script
-    completion_dir = Path("/etc/bash_completion.d")
+    completion_dir = get_completion_dir()
     completion_script = completion_dir / "shepctl_completion.sh"
     if completion_script.exists():
-        completion_script.unlink()
+        try:
+            completion_script.unlink()
+        except PermissionError:
+            handle_permission_denied(
+                "remove completion script", completion_script
+            )
         Util.print(f"Removed completion script {completion_script}")
 
     Util.print("Uninstalled")
@@ -405,7 +454,7 @@ def create_wrapper_script(
     shepctl_py = install_dir / "shepctl.py"
     # Write the wrapper script
     wrapper_content = (
-        "#!/bin/bash\n" f'exec "{venv_python}" "{shepctl_py}" "$@"\n'
+        "#!/bin/sh\n" f'exec "{venv_python}" "{shepctl_py}" "$@"\n'
     )
     with open(wrapper_path, "w") as f:
         f.write(wrapper_content)
@@ -430,16 +479,18 @@ def create_virtualenv(install_dir: Path) -> Path:
             [python_path, "-m", "venv", str(venv_path)],
             check=True,
         )
-    # Change ownership of the .venv directory to the current user
-    user = Util.get_current_user()
-    uid = pwd.getpwnam(user).pw_uid
-    gid = pwd.getpwnam(user).pw_gid
-    for root, dirs, files in os.walk(venv_path):
-        os.chown(root, uid, gid)
-        for d in dirs:
-            os.chown(os.path.join(root, d), uid, gid)
-        for f in files:
-            os.chown(os.path.join(root, f), uid, gid)
+    if hasattr(os, "chown"):
+        # On Unix, hand ownership back to the invoking user so future updates
+        # do not require root.
+        user = Util.get_current_user()
+        uid = pwd.getpwnam(user).pw_uid
+        gid = pwd.getpwnam(user).pw_gid
+        for root, dirs, files in os.walk(venv_path):
+            os.chown(root, uid, gid)
+            for d in dirs:
+                os.chown(os.path.join(root, d), uid, gid)
+            for f in files:
+                os.chown(os.path.join(root, f), uid, gid)
     return venv_path
 
 

--- a/src/installer/repository_manager.py
+++ b/src/installer/repository_manager.py
@@ -13,6 +13,18 @@ from util import Util, constants
 
 class RepositoryManager:
     @staticmethod
+    def install_missing_brew_packages(
+        missing_packages: List[str], check: bool = True
+    ) -> None:
+        """Install missing Homebrew packages one by one."""
+        if not missing_packages:
+            Util.console.print("No packages to install", style="yellow")
+            return
+
+        for pkg in missing_packages:
+            Util.run_command(["brew", "install", pkg], check=check)
+
+    @staticmethod
     def add_docker_repository(distro: str, codename: str) -> None:
         """
         Add Docker apt repository metadata for the detected distro/codename.
@@ -32,18 +44,18 @@ class RepositoryManager:
         if os.path.exists(repo_path):
             return  # Exit early if the repository file already exists
 
-        with open(repo_path, "w") as f:
+        with open(repo_path, "w", encoding="utf-8") as f:
             f.write(repo_string)
 
         update_command = constants.UPDATE_COMMANDS[distro].split()
-        Util.run_command(update_command, check=True)  # Update the package list
+        Util.run_command(update_command, check=True)
         Util.console.print("Repository added successfully.", style="green")
 
     @staticmethod
     def install_missing_packages(
         distro: str, missing_packages: List[str], check: bool = True
     ) -> None:
-        """Install missing packages using the appropriate package manager."""
+        """Install missing Linux packages using the appropriate manager."""
         if not missing_packages:
             Util.console.print("No packages to install", style="yellow")
             return
@@ -65,12 +77,64 @@ class RepositoryManager:
             return False
 
     @staticmethod
-    def install_required_packages(distro: str) -> None:
-        """Install required packages for the detected distribution."""
+    def check_brew_package_installed(pkg: str) -> bool:
+        """Check whether a Homebrew formula or cask is already installed."""
+        for kind in ("formula", "cask"):
+            try:
+                result = Util.run_command(
+                    ["brew", "list", f"--{kind}", pkg],
+                    check=False,
+                    capture_output=True,
+                )
+            except Exception:
+                continue
+            if result.returncode == 0:
+                return True
+        return False
+
+    @staticmethod
+    def install_required_packages(system: str, distro: str | None) -> None:
+        """Install required non-Python system packages for the platform."""
+        if system == "darwin":
+            required_packages = ["bc", "jq", "curl", "rsync"]
+            missing_packages: List[str] = []
+            for pkg in required_packages:
+                if not RepositoryManager.check_brew_package_installed(pkg):
+                    Util.console.print(
+                        f"Package {pkg} is missing.", style="yellow"
+                    )
+                    missing_packages.append(pkg)
+                else:
+                    Util.console.print(
+                        f"Package {pkg} is already installed.",
+                        style="green",
+                    )
+            if missing_packages:
+                missing = ", ".join(missing_packages)
+                Util.console.print(
+                    f"Installing missing packages: {missing}",
+                    style="blue",
+                )
+                RepositoryManager.install_missing_brew_packages(
+                    missing_packages
+                )
+            else:
+                Util.console.print(
+                    "All required packages are already installed.",
+                    style="green",
+                )
+            return
+
+        if distro is None:
+            raise RuntimeError("Linux distribution is required")
+
         missing_packages: List[str] = []
         for pkg in constants.REQUIRED_PKGS:
             if not RepositoryManager.check_package_installed(pkg):
-                Util.console.print(f"Package {pkg} is missing.", style="yellow")
+                Util.console.print(
+                    f"Package {pkg} is missing.",
+                    style="yellow",
+                )
                 missing_packages.append(pkg)
             else:
                 Util.console.print(
@@ -81,7 +145,10 @@ class RepositoryManager:
                 f"Installing missing packages: {', '.join(missing_packages)}",
                 style="blue",
             )
-            RepositoryManager.install_missing_packages(distro, missing_packages)
+            RepositoryManager.install_missing_packages(
+                distro,
+                missing_packages,
+            )
         else:
             Util.console.print(
                 "All required packages are already installed.",
@@ -89,8 +156,8 @@ class RepositoryManager:
             )
 
     @staticmethod
-    def install_python_packages(distro: str) -> None:
-        """Install Python packages using the appropriate package manager."""
+    def install_python_packages(system: str, distro: str | None) -> None:
+        """Install Python prerequisites for source installs."""
         executed_python_version = Util.run_command(
             ["python3", "--version"], check=False, capture_output=True
         )
@@ -101,12 +168,32 @@ class RepositoryManager:
                 "Python version is less than 3.12. Going to update",
                 style="yellow",
             )
-            RepositoryManager.install_missing_packages(distro, ["python3"])
+            if system == "darwin":
+                python_formula = "python@3.12"
+                RepositoryManager.install_missing_brew_packages(
+                    [python_formula]
+                )
+            else:
+                if distro is None:
+                    raise RuntimeError("Linux distribution is required")
+                RepositoryManager.install_missing_packages(distro, ["python3"])
         else:
             Util.console.print(
                 "Python version is 3.12 or greater. No need to update",
                 style="green",
             )
+
+        if system == "darwin":
+            Util.console.print(
+                "macOS source installs rely on Homebrew Python "
+                "and bundled venv support.",
+                style="green",
+            )
+            return
+
+        if distro is None:
+            raise RuntimeError("Linux distribution is required")
+
         missing_python_packages: List[str] = []
         for pkg in constants.REQUIRED_PYTHON_PKGS:
             if not RepositoryManager.check_package_installed(pkg):
@@ -137,13 +224,72 @@ class RepositoryManager:
             )
 
     @staticmethod
-    def install_docker_packages(distro: str, codename: str) -> None:
+    def install_docker_packages(
+        system: str, distro: str | None, codename: str | None
+    ) -> None:
         """
         Ensure Docker engine/compose packages and runtime setup are present.
-
-        This includes repository/keyring bootstrap, package installation, and
-        post-install system setup when Docker is newly installed.
         """
+        if system == "darwin":
+            if RepositoryManager.check_brew_package_installed("docker"):
+                Util.console.print(
+                    "Docker is already installed.", style="green"
+                )
+            else:
+                Util.console.print(
+                    "Docker is not installed. Installing...", style="yellow"
+                )
+                RepositoryManager.install_missing_brew_packages(["docker"])
+
+            docker_version = Util.run_command(
+                ["docker", "--version"], check=False, capture_output=True
+            )
+            Util.console.print(
+                f"Docker version: {docker_version.stdout}", style="green"
+            )
+
+            docker_compose_version = Util.run_command(
+                ["docker", "compose", "version"],
+                check=False,
+                capture_output=True,
+            )
+            if docker_compose_version.returncode == 0:
+                Util.console.print(
+                    "Docker Compose is already installed.", style="green"
+                )
+            else:
+                RepositoryManager.install_missing_brew_packages(
+                    ["docker-compose"]
+                )
+                docker_compose_version = Util.run_command(
+                    ["docker", "compose", "version"],
+                    check=False,
+                    capture_output=True,
+                )
+            Util.console.print(
+                f"Docker Compose version: {docker_compose_version.stdout}",
+                style="green",
+            )
+
+            docker_info = Util.run_command(
+                ["docker", "info"], check=False, capture_output=True
+            )
+            if docker_info.returncode != 0:
+                Util.console.print(
+                    "Docker CLI installed, but no Docker daemon is reachable. "
+                    "Install and start Docker Desktop before using shepctl.",
+                    style="yellow",
+                )
+            else:
+                Util.console.print(
+                    "Docker daemon is reachable.",
+                    style="green",
+                )
+            return
+
+        if distro is None or codename is None:
+            raise RuntimeError("Linux distro and codename are required")
+
         if any(
             RepositoryManager.check_package_installed(pkg)
             for pkg in constants.REQUIRED_DOCKER_PKGS
@@ -165,8 +311,18 @@ class RepositoryManager:
                         "curl",
                         "-fsSL",
                         constants.GPG_KEYS[distro],
-                        "| gpg --dearmor -o ",
+                        "-o",
+                        "/tmp/docker.gpg",
+                    ],
+                    check=True,
+                )
+                Util.run_command(
+                    [
+                        "gpg",
+                        "--dearmor",
+                        "-o",
                         constants.KEYRING_PATH,
+                        "/tmp/docker.gpg",
                     ],
                     check=True,
                 )
@@ -189,7 +345,10 @@ class RepositoryManager:
 
             missing_packages: List[str] = []
             for pkg in constants.REQUIRED_DOCKER_PKGS:
-                Util.console.print(f"Checking for package: {pkg}", style="blue")
+                Util.console.print(
+                    f"Checking for package: {pkg}",
+                    style="blue",
+                )
                 if not RepositoryManager.check_package_installed(pkg):
                     Util.console.print(
                         f"Package {pkg} is missing.", style="yellow"
@@ -225,7 +384,7 @@ class RepositoryManager:
                 f"Docker version: {docker_version.stdout}", style="green"
             )
             docker_compose_version = Util.run_command(
-                ["docker-compose", "--version"],
+                ["docker", "compose", "version"],
                 check=False,
                 capture_output=True,
             )
@@ -256,14 +415,17 @@ class RepositoryManager:
 
     @staticmethod
     def install_packages(
-        distro: str, codename: str, install_source: bool
+        system: str,
+        distro: str | None,
+        codename: str | None,
+        install_source: bool,
     ) -> None:
         """
         Install base dependencies and Docker stack.
 
         Python system packages are installed only for source-based installs.
         """
-        RepositoryManager.install_required_packages(distro)
+        RepositoryManager.install_required_packages(system, distro)
         if install_source:
-            RepositoryManager.install_python_packages(distro)
-        RepositoryManager.install_docker_packages(distro, codename)
+            RepositoryManager.install_python_packages(system, distro)
+        RepositoryManager.install_docker_packages(system, distro, codename)

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -45,7 +45,8 @@ class ShepherdMng:
         load_runtime_plugins: bool = True,
         plugin_runtime_mng: Optional[PluginRuntimeMng] = None,
     ):
-        shpd_conf = os.environ.get("SHPD_CONF", "~/.shpd.conf")
+        shpd_conf = os.environ.get("SHPD_CONF") or "~/.shpd.conf"
+        Util.ensure_config_values_file(shpd_conf)
         self.configMng = ConfigMng(shpd_conf)
         setup_logging(
             self.configMng.constants.LOG_FILE,
@@ -110,7 +111,8 @@ def _load_plugin_runtime_for_click(ctx: click.Context) -> PluginRuntimeMng:
     if runtime_mng is not None:
         return runtime_mng
 
-    shpd_conf = os.environ.get("SHPD_CONF", "~/.shpd.conf")
+    shpd_conf = os.environ.get("SHPD_CONF") or "~/.shpd.conf"
+    Util.ensure_config_values_file(shpd_conf)
     configMng = ConfigMng(shpd_conf)
     Util.ensure_shpd_dirs(configMng.constants)
     Util.ensure_config_file(configMng.constants)
@@ -125,7 +127,7 @@ class PluginRootGroup(click.Group):
     """Root Click group extended with runtime plugin scopes."""
 
     def list_commands(self, ctx: click.Context) -> list[str]:
-        commands = list(super().list_commands(ctx))
+        commands = builtins.list(super().list_commands(ctx))
         registry = _load_plugin_runtime_for_click(ctx).registry
         for scope in sorted(registry.commands):
             if scope not in commands:
@@ -152,7 +154,7 @@ class PluginScopeGroup(click.Group):
     """Click scope group extended with runtime plugin verbs."""
 
     def list_commands(self, ctx: click.Context) -> list[str]:
-        commands = list(super().list_commands(ctx))
+        commands = builtins.list(super().list_commands(ctx))
         if self.name == "plugin":
             return commands
 

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -24,6 +24,7 @@ from test_util import read_fixture
 from docker.docker_compose_env import DockerComposeEnv
 from environment.environment import NonRecoverableStartError, ProbeRunResult
 from shepctl import ShepherdMng, cli
+from util import Util
 
 docker_compose_ps_output = """
 {"Command":"\\\"docker-entrypoint.s…\\\"","CreatedAt":"2025-09-08 12:22:01 +0200 CEST","ExitCode":0,"Health":"","ID":"cc1200024a2a","Image":"postgres:14","Labels":"com.docker.compose.oneoff=False","LocalVolumes":"1","Mounts":"beppe_postgres","Name":"db-instance","Names":"db-instance","Networks":"beppe_beppe","Ports":"0.0.0.0:5432-\u003e5432/tcp, [::]:5432-\u003e5432/tcp","Project":"beppe","Publishers":[{"URL":"0.0.0.0","TargetPort":5432,"PublishedPort":5432,"Protocol":"tcp"},{"URL":"::","TargetPort":5432,"PublishedPort":5432,"Protocol":"tcp"}],"RunningFor":"About a minute ago","Service":"test-1-test-1","Size":"0B","State":"running","Status":"Up About a minute"}
@@ -34,6 +35,13 @@ test_env_running_ps_output = (
     '{"Service":"container-1-test-1-test-1","State":"running"}\n'
     '{"Service":"container-1-test-2-test-1","State":"running"}\n'
 )
+
+
+def normalize_expected_bind_paths(content: str) -> str:
+    return content.replace(
+        "/home/test/.ssh:/home/test/.ssh",
+        Util.translate_volume_binding("/home/test/.ssh:/home/test/.ssh"),
+    )
 
 
 def mock_subprocess_with_running_ps(mocker: MockerFixture):
@@ -446,7 +454,10 @@ def test_env_render_target_compose_env_ext_net(
     )
 
     y1: str = yaml.dump(yaml.safe_load(result.output), sort_keys=True)
-    y2: str = yaml.dump(yaml.safe_load(expected), sort_keys=True)
+    y2: str = yaml.dump(
+        yaml.safe_load(normalize_expected_bind_paths(expected)),
+        sort_keys=True,
+    )
     assert y1 == y2
 
 
@@ -518,7 +529,10 @@ def test_env_render_target_compose_env_resolved(
     )
 
     y1: str = yaml.dump(yaml.safe_load(result.output), sort_keys=True)
-    y2: str = yaml.dump(yaml.safe_load(expected), sort_keys=True)
+    y2: str = yaml.dump(
+        yaml.safe_load(normalize_expected_bind_paths(expected)),
+        sort_keys=True,
+    )
     assert y1 == y2
 
 
@@ -602,7 +616,10 @@ def test_env_render_target_compose_env_int_net(
     )
 
     y1: str = yaml.dump(yaml.safe_load(result.output), sort_keys=True)
-    y2: str = yaml.dump(yaml.safe_load(expected), sort_keys=True)
+    y2: str = yaml.dump(
+        yaml.safe_load(normalize_expected_bind_paths(expected)),
+        sort_keys=True,
+    )
     assert y1 == y2
 
 

--- a/src/tests/test_install_utils.py
+++ b/src/tests/test_install_utils.py
@@ -6,6 +6,7 @@
 # Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 import subprocess
+from pathlib import Path
 from typing import List
 from unittest.mock import MagicMock, patch
 
@@ -251,6 +252,17 @@ class TestInstallUtils:
                 Util.get_os_info()
             assert "Unsupported operating system" in str(exc_info.value)
 
+        with patch("platform.system", return_value="Darwin"):
+            result = Util.get_os_info()
+            assert result.system == "darwin"
+            assert result.distro is None
+            assert result.codename is None
+
+        with patch("platform.system", return_value="FreeBSD"):
+            with pytest.raises(ValueError) as exc_info:
+                Util.get_os_info()
+            assert "Unsupported operating system" in str(exc_info.value)
+
         # Test Linux with distribution info
         with (
             patch("platform.system", return_value="Linux"),
@@ -261,3 +273,75 @@ class TestInstallUtils:
             assert result.system == "linux"
             assert result.distro == "ubuntu"
             assert result.codename == "focal"
+
+    def test_ensure_config_values_file(self, tmp_path: Path):
+        config_values_path = tmp_path / ".shpd.conf"
+
+        Util.ensure_config_values_file(str(config_values_path))
+
+        assert config_values_path.exists()
+        content = config_values_path.read_text()
+        assert "shpd_path=~/shpd" in content
+        assert "default_env_type=docker-compose" in content
+
+    def test_ensure_config_values_file_keeps_existing(self, tmp_path: Path):
+        config_values_path = tmp_path / ".shpd.conf"
+        config_values_path.write_text("shpd_path=/custom/shpd\n")
+
+        Util.ensure_config_values_file(str(config_values_path))
+
+        assert config_values_path.read_text() == "shpd_path=/custom/shpd\n"
+
+    def test_translate_host_path(self):
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("pathlib.Path.home", return_value=Path("/Users/testuser")),
+        ):
+            assert (
+                Util.translate_host_path("/home/test/.ssh")
+                == "/Users/testuser/.ssh"
+            )
+            assert (
+                Util.translate_host_path("~/workspace")
+                == "/Users/testuser/workspace"
+            )
+            assert Util.translate_host_path("/etc/ssh") == "/etc/ssh"
+
+    def test_translate_host_path_linux_noop(self):
+        with patch("platform.system", return_value="Linux"):
+            assert (
+                Util.translate_host_path("/home/test/.ssh") == "/home/test/.ssh"
+            )
+            assert Util.translate_host_path("~/workspace") == "~/workspace"
+
+    def test_translate_volume_binding(self):
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("pathlib.Path.home", return_value=Path("/Users/testuser")),
+        ):
+            assert (
+                Util.translate_volume_binding("/home/test/.ssh:/home/test/.ssh")
+                == "/Users/testuser/.ssh:/home/test/.ssh"
+            )
+            assert (
+                Util.translate_volume_binding(
+                    "/home/test/.ssh:/home/test/.ssh:ro"
+                )
+                == "/Users/testuser/.ssh:/home/test/.ssh:ro"
+            )
+
+    def test_translate_volume_binding_linux_noop(self):
+        with patch("platform.system", return_value="Linux"):
+            assert (
+                Util.translate_volume_binding("/home/test/.ssh:/home/test/.ssh")
+                == "/home/test/.ssh:/home/test/.ssh"
+            )
+
+    def test_get_default_install_paths_macos_arm(self):
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("platform.machine", return_value="arm64"),
+        ):
+            paths = Util.get_default_install_paths()
+            assert paths.install_dir == Path("/opt/homebrew/opt/shepctl")
+            assert paths.symlink_dir == Path("/opt/homebrew/bin")

--- a/src/tests/test_installer.py
+++ b/src/tests/test_installer.py
@@ -43,11 +43,17 @@ class TestInstallScript:
         mock_chmod: MagicMock,
     ) -> None:
         """
-        Test install_completion: should copy and chmod the script if dir exists.
+        Test install_completion when the destination directory exists.
         """
         mock_is_dir.return_value = True
 
-        with patch("installer.install.Util.console.print") as mock_print:
+        with (
+            patch("installer.install.Util.console.print") as mock_print,
+            patch(
+                "installer.install.Util.get_os_info",
+                return_value=Util.OsInfo(system="linux"),
+            ),
+        ):
             install.install_completion()
 
             dest = Path("/etc/bash_completion.d/shepctl_completion.sh")
@@ -70,6 +76,10 @@ class TestInstallScript:
         with (
             patch("pathlib.Path.exists", return_value=True),
             patch("pathlib.Path.unlink") as mock_unlink,
+            patch(
+                "installer.install.Util.get_os_info",
+                return_value=Util.OsInfo(system="linux"),
+            ),
         ):
             install.uninstall_shepctl()
 
@@ -91,13 +101,53 @@ class TestInstallScript:
         # Simulate /etc/bash_completion.d does not exist
         mock_is_dir.return_value = False
 
-        with patch("installer.install.Util.console.print") as mock_print:
+        with (
+            patch("installer.install.Util.console.print") as mock_print,
+            patch(
+                "installer.install.Util.get_os_info",
+                return_value=Util.OsInfo(system="linux"),
+            ),
+        ):
             install.install_completion()
             mock_print.assert_any_call(
                 "Bash completion directory not found. Please install "
                 "manually.",
                 style="yellow",
             )
+
+    @patch("os.chmod")
+    @patch("shutil.copy2")
+    @patch("pathlib.Path.is_dir")
+    def test_install_completion_success_macos(
+        self,
+        mock_is_dir: MagicMock,
+        mock_copy2: MagicMock,
+        mock_chmod: MagicMock,
+    ) -> None:
+        mock_is_dir.return_value = True
+
+        with (
+            patch("installer.install.Util.console.print"),
+            patch(
+                "installer.install.Util.get_os_info",
+                return_value=Util.OsInfo(system="darwin"),
+            ),
+            patch(
+                "installer.install.Util.get_default_install_paths",
+                return_value=Util.InstallPaths(
+                    install_dir=Path("/opt/homebrew/opt/shepctl"),
+                    symlink_dir=Path("/opt/homebrew/bin"),
+                ),
+            ),
+        ):
+            install.install_completion()
+
+            dest = Path(
+                "/opt/homebrew/etc/bash_completion.d/" "shepctl_completion.sh"
+            )
+            src, _ = get_script_completion_src()
+            mock_copy2.assert_called_once_with(src, dest)
+            mock_chmod.assert_called_once_with(dest, 0o755)
 
     """Test suite for the main installation script."""
 
@@ -172,6 +222,26 @@ class TestInstallScript:
         # Should exit with code 1
         assert result.exit_code == 1
 
+    @patch("util.Util.is_root")
+    @patch("util.Util.get_os_info")
+    @patch("installer.install.install_shepctl")
+    def test_cli_install_not_root_macos(
+        self,
+        mock_install_shepctl: MagicMock,
+        mock_get_os_info: MagicMock,
+        mock_is_root: MagicMock,
+    ) -> None:
+        from click.testing import CliRunner
+
+        mock_is_root.return_value = False
+        mock_get_os_info.return_value = Util.OsInfo(system="darwin")
+
+        runner = CliRunner()
+        result = runner.invoke(install.cli, ["install"])
+
+        assert result.exit_code == 0
+        mock_install_shepctl.assert_called_once()
+
     @patch("shutil.rmtree")
     @patch("os.makedirs")
     @patch("util.Util.is_root")
@@ -189,7 +259,8 @@ class TestInstallScript:
 
         runner = CliRunner()
         result = runner.invoke(
-            install.cli, ["-m", "source", "-v", "--skip-deps", "install"]
+            install.cli,
+            ["-m", "source", "-v", "--skip-deps", "install"],
         )
 
         # Should succeed
@@ -228,10 +299,12 @@ class TestInstallScript:
     @patch("os.makedirs")
     @patch("shutil.rmtree")
     @patch("installer.install.install_binary")
+    @patch("installer.install.install_completion")
     @patch("util.Util.run_command")  # Patch the static method directly
     def test_install_with_dependencies(
         self,
         mock_run_command: MagicMock,
+        mock_install_completion: MagicMock,
         mock_install_binary: MagicMock,
         mock_rmtree: MagicMock,
         mock_makedirs: MagicMock,
@@ -258,7 +331,10 @@ class TestInstallScript:
         # Check dependencies were installed
         mock_get_os_info.assert_called_once()
         mock_install_packages.assert_called_once_with(
-            mock_os_info.distro, mock_os_info.codename, False
+            mock_os_info.system,
+            mock_os_info.distro,
+            mock_os_info.codename,
+            False,
         )
 
         # Check directory was recreated
@@ -275,8 +351,10 @@ class TestInstallScript:
     @patch("os.makedirs")
     @patch("shutil.rmtree")
     @patch("installer.install.install_binary")
+    @patch("installer.install.install_completion")
     def test_install_skip_dependencies(
         self,
+        mock_install_completion: MagicMock,
         mock_install_binary: MagicMock,
         mock_rmtree: MagicMock,
         mock_makedirs: MagicMock,
@@ -322,10 +400,55 @@ class TestInstallScript:
             with pytest.raises(SystemExit):
                 install.install_shepctl()
 
+    @patch("installer.install.Util.print_error_and_die")
+    @patch("installer.install.Util.get_os_info")
+    @patch("shutil.rmtree", side_effect=PermissionError)
+    def test_install_permission_error_macos(
+        self,
+        mock_rmtree: MagicMock,
+        mock_get_os_info: MagicMock,
+        mock_print_error_and_die: MagicMock,
+    ) -> None:
+        install.skip_ensure_deps = True
+        install.install_method = "binary"
+        mock_get_os_info.return_value = Util.OsInfo(system="darwin")
+        mock_print_error_and_die.side_effect = SystemExit(1)
+
+        with patch("pathlib.Path.exists", return_value=True):
+            with pytest.raises(SystemExit):
+                install.install_shepctl()
+
+        mock_print_error_and_die.assert_called_once()
+        assert "previous macOS install was created with sudo" in (
+            mock_print_error_and_die.call_args.args[0]
+        )
+
+    @patch("installer.install.Util.print_error_and_die")
+    @patch("installer.install.Util.get_os_info")
+    @patch("shutil.rmtree", side_effect=PermissionError)
+    def test_uninstall_permission_error_macos(
+        self,
+        mock_rmtree: MagicMock,
+        mock_get_os_info: MagicMock,
+        mock_print_error_and_die: MagicMock,
+    ) -> None:
+        mock_get_os_info.return_value = Util.OsInfo(system="darwin")
+        mock_print_error_and_die.side_effect = SystemExit(1)
+
+        with patch("pathlib.Path.exists", return_value=True):
+            with pytest.raises(SystemExit):
+                install.uninstall_shepctl()
+
+        mock_print_error_and_die.assert_called_once()
+        assert "previous macOS install was created with sudo" in (
+            mock_print_error_and_die.call_args.args[0]
+        )
+
     # ...existing code...
 
     @patch("util.Util.check_file_exists", return_value=False)
     @patch("util.Util.run_command")
+    @patch("util.Util.get_current_user", return_value="testuser")
     @patch(
         "installer.repository_manager.RepositoryManager."
         "check_package_installed"
@@ -342,12 +465,11 @@ class TestInstallScript:
         mock_install_missing_packages: MagicMock,
         mock_add_docker_repository: MagicMock,
         mock_check_package_installed: MagicMock,
+        mock_get_current_user: MagicMock,
         mock_run_command: MagicMock,
         mock_check_file_exists: MagicMock,
     ) -> None:
         """Test the installation of Docker packages."""
-        current_user = os.getenv("USER")
-
         # Simulate Docker not being installed
         mock_check_package_installed.return_value = False
 
@@ -357,7 +479,7 @@ class TestInstallScript:
         )
 
         # Call the function under test
-        RepositoryManager.install_docker_packages("debian", "buster")
+        RepositoryManager.install_docker_packages("linux", "debian", "buster")
 
         # Verify that add_docker_repository was called with correct arguments
         mock_add_docker_repository.assert_called_once_with("debian", "buster")
@@ -369,18 +491,128 @@ class TestInstallScript:
         expected_calls = [
             call(["docker", "--version"], check=False, capture_output=True),
             call(
-                ["docker-compose", "--version"],
+                ["docker", "compose", "version"],
                 check=False,
                 capture_output=True,
             ),
             call(["sudo", "systemctl", "enable", "docker"], check=True),
             call(["sudo", "groupadd", "-f", "docker"], check=True),
-            call(["usermod", "-aG", "docker", current_user], check=True),
+            call(["usermod", "-aG", "docker", "testuser"], check=True),
         ]
         mock_run_command.assert_has_calls(expected_calls, any_order=True)
 
         # Verify that the package installation function was called
-        mock_check_package_installed.assert_called_with("docker-compose-plugin")
+        expected_package = "docker-compose-plugin"
+        mock_check_package_installed.assert_called_with(expected_package)
+
+    @patch("installer.repository_manager.Util.console.print")
+    @patch("installer.repository_manager.Util.run_command")
+    @patch(
+        "installer.repository_manager.RepositoryManager."
+        "install_missing_brew_packages"
+    )
+    @patch(
+        "installer.repository_manager.RepositoryManager."
+        "check_brew_package_installed"
+    )
+    def test_install_docker_packages_macos_warns_without_daemon(
+        self,
+        mock_check_brew_package_installed: MagicMock,
+        mock_install_missing_brew_packages: MagicMock,
+        mock_run_command: MagicMock,
+        mock_print: MagicMock,
+    ) -> None:
+        mock_check_brew_package_installed.return_value = False
+        mock_run_command.side_effect = [
+            MagicMock(stdout="Docker version 27.0.0", returncode=0),
+            MagicMock(stderr="compose missing", returncode=1),
+            MagicMock(stdout="Docker Compose version v2.0.0", returncode=0),
+            MagicMock(stderr="daemon unavailable", returncode=1),
+        ]
+
+        RepositoryManager.install_docker_packages("darwin", None, None)
+
+        mock_check_brew_package_installed.assert_called_once_with("docker")
+        mock_install_missing_brew_packages.assert_any_call(["docker"])
+        mock_install_missing_brew_packages.assert_any_call(["docker-compose"])
+        mock_run_command.assert_has_calls(
+            [
+                call(
+                    ["docker", "--version"],
+                    check=False,
+                    capture_output=True,
+                ),
+                call(
+                    ["docker", "compose", "version"],
+                    check=False,
+                    capture_output=True,
+                ),
+                call(
+                    ["docker", "compose", "version"],
+                    check=False,
+                    capture_output=True,
+                ),
+                call(["docker", "info"], check=False, capture_output=True),
+            ]
+        )
+        mock_print.assert_any_call(
+            "Docker CLI installed, but no Docker daemon is reachable. "
+            "Install and start Docker Desktop before using shepctl.",
+            style="yellow",
+        )
+
+    @patch("installer.repository_manager.Util.run_command")
+    @patch(
+        "installer.repository_manager.RepositoryManager."
+        "install_missing_brew_packages"
+    )
+    @patch(
+        "installer.repository_manager.RepositoryManager."
+        "check_brew_package_installed"
+    )
+    def test_install_docker_packages_macos_skips_redundant_compose_install(
+        self,
+        mock_check_brew_package_installed: MagicMock,
+        mock_install_missing_brew_packages: MagicMock,
+        mock_run_command: MagicMock,
+    ) -> None:
+        mock_check_brew_package_installed.return_value = True
+        mock_run_command.side_effect = [
+            MagicMock(stdout="Docker version 27.0.0", returncode=0),
+            MagicMock(stdout="Docker Compose version v2.0.0", returncode=0),
+            MagicMock(stdout="daemon reachable", returncode=0),
+        ]
+
+        RepositoryManager.install_docker_packages("darwin", None, None)
+
+        mock_check_brew_package_installed.assert_called_once_with("docker")
+        mock_install_missing_brew_packages.assert_not_called()
+
+    @patch(
+        "installer.repository_manager.RepositoryManager."
+        "install_missing_brew_packages"
+    )
+    @patch(
+        "installer.repository_manager.RepositoryManager."
+        "check_brew_package_installed"
+    )
+    def test_install_required_packages_macos(
+        self,
+        mock_check_brew_package_installed: MagicMock,
+        mock_install_missing_brew_packages: MagicMock,
+    ) -> None:
+        mock_check_brew_package_installed.side_effect = [
+            False,
+            True,
+            False,
+            True,
+        ]
+
+        RepositoryManager.install_required_packages("darwin", None)
+
+        mock_install_missing_brew_packages.assert_called_once_with(
+            ["bc", "curl"]
+        )
 
     @patch("util.Util.run_command")
     def test_install_binary(self, mock_run_command: MagicMock) -> None:
@@ -435,7 +667,7 @@ class TestInstallScript:
 
                 mock_symlink.assert_called_with(
                     f"{self.install_dir}/shepctl",
-                    Path(f"{os.environ['SYMLINK_DIR']}/shepctl"),
+                    Path(os.environ["SYMLINK_DIR"]).resolve() / "shepctl",
                 )
 
 

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -474,6 +474,51 @@ def test_cli_complete(
     assert result.exit_code == 0
 
 
+@pytest.mark.shpd
+def test_cli_root_help(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Usage: cli [OPTIONS] COMMAND [ARGS]..." in result.output
+    assert "env" in result.output
+    assert "svc" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_root_help_bootstraps_default_config_values(
+    tmp_path: Path,
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.delenv("SHPD_CONF", raising=False)
+    monkeypatch.setenv("HOME", str(home_dir))
+
+    result = runner.invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Usage: cli [OPTIONS] COMMAND [ARGS]..." in result.output
+    config_values = home_dir / ".shpd.conf"
+    assert config_values.exists()
+    assert "shpd_path=~/shpd" in config_values.read_text()
+    assert (home_dir / "shpd" / ".shpd.yaml").exists()
+
+
+@pytest.mark.shpd
+def test_cli_env_help(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    result = runner.invoke(cli, ["env", "--help"])
+
+    assert result.exit_code == 0
+    assert "Usage: cli env [OPTIONS] COMMAND [ARGS]..." in result.output
+    assert "list" in result.output
+    assert "get" in result.output
+
+
 # service tests
 
 

--- a/src/tests/test_svc_docker_compose.py
+++ b/src/tests/test_svc_docker_compose.py
@@ -21,6 +21,7 @@ from pytest_mock import MockerFixture
 from test_util import read_fixture
 
 from shepctl import cli
+from util import Util
 
 svc_env_running_ps_output = (
     '{"Service":"container-1-test-test-1","State":"running"}\n'
@@ -30,6 +31,13 @@ svc_env_running_ps_output = (
     '{"Service":"container-1-test-3-test-1","State":"running"}\n'
     '{"Service":"container-1-test-4-test-1","State":"running"}\n'
 )
+
+
+def normalize_expected_bind_paths(content: str) -> str:
+    return content.replace(
+        "/home/test/.ssh:/home/test/.ssh",
+        Util.translate_volume_binding("/home/test/.ssh:/home/test/.ssh"),
+    )
 
 
 def mock_subprocess_with_running_ps(mocker: MockerFixture):
@@ -244,7 +252,10 @@ def test_svc_render_target_compose_service(
     )
 
     y1: str = yaml.dump(yaml.safe_load(result.output), sort_keys=True)
-    y2: str = yaml.dump(yaml.safe_load(expected), sort_keys=True)
+    y2: str = yaml.dump(
+        yaml.safe_load(normalize_expected_bind_paths(expected)),
+        sort_keys=True,
+    )
     assert y1 == y2
 
 

--- a/src/util/util.py
+++ b/src/util/util.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Literal, Optional, Union
 
 import yaml
@@ -24,6 +25,23 @@ from .constants import Constants
 
 JustifyMethod = Literal["default", "left", "center", "right", "full"]
 ColumnJustify = Literal["left", "center", "right"]
+DEFAULT_SHPD_VALUES_TEMPLATE = """# Shepherd workspace directory
+shpd_path=~/shpd
+templates_path=${shpd_path}/templates
+envs_path=${shpd_path}/envs
+volumes_path=${shpd_path}/volumes
+staging_area_volumes_path=${shpd_path}/sa_volumes
+staging_area_images_path=${shpd_path}/sa_images
+
+# Shepherd default environment type
+default_env_type=docker-compose
+
+# Logging Configuration
+log_file=${shpd_path}/logs/shepctl.log
+log_level=WARNING
+log_stdout=false
+log_format=%(asctime)s - %(levelname)s - %(message)s
+"""
 
 
 class Util:
@@ -36,6 +54,13 @@ class Util:
         system: str
         distro: str | None = None
         codename: str | None = None
+
+    @dataclass(frozen=True)
+    class InstallPaths:
+        """Default install locations for the current platform."""
+
+        install_dir: Path
+        symlink_dir: Path
 
     @staticmethod
     def confirm(prompt: str) -> bool:
@@ -356,6 +381,27 @@ class Util:
             Util.ensure_dir(resolved_path, desc)
 
     @staticmethod
+    def ensure_config_values_file(file_values_path: str) -> None:
+        config_values_path = os.path.expanduser(
+            file_values_path or "~/.shpd.conf"
+        )
+        if os.path.exists(config_values_path):
+            return
+
+        parent_dir = os.path.dirname(config_values_path)
+        if parent_dir:
+            os.makedirs(parent_dir, exist_ok=True)
+
+        try:
+            with open(config_values_path, "w", encoding="utf-8") as f:
+                f.write(DEFAULT_SHPD_VALUES_TEMPLATE)
+        except OSError as e:
+            Util.print_error_and_die(
+                f"Failed to create config values file: "
+                f"{config_values_path}\nError: {e}"
+            )
+
+    @staticmethod
     def ensure_config_file(constants: Constants):
         config_file_path = constants.SHPD_CONFIG_FILE
         if os.path.exists(config_file_path):
@@ -457,14 +503,11 @@ class Util:
     def get_os_info() -> "Util.OsInfo":
         """
         Return normalized OS metadata for installer/repository selection.
-
-        Current policy is Linux-only for provisioning flows; Windows/macOS are
-        rejected explicitly to avoid partial/undefined installer behavior.
         """
         system = platform.system().lower()
-        if system in ("windows", "win32", "darwin"):
+        if system in ("windows", "win32"):
             raise ValueError(f"Unsupported operating system: {system}")
-        elif system == "linux":
+        if system == "linux":
             import distro
 
             dist_id = distro.id().lower()
@@ -472,7 +515,83 @@ class Util:
             return Util.OsInfo(
                 system=system, distro=dist_id, codename=code_name
             )
-        return Util.OsInfo(system=system)
+        if system == "darwin":
+            return Util.OsInfo(system=system)
+        raise ValueError(f"Unsupported operating system: {system}")
+
+    @staticmethod
+    def get_default_install_paths(
+        system: Optional[str] = None,
+    ) -> "Util.InstallPaths":
+        current_system = system or platform.system().lower()
+        if current_system == "darwin":
+            brew_prefix = (
+                Path("/opt/homebrew")
+                if platform.machine().lower() in ("arm64", "aarch64")
+                else Path("/usr/local")
+            )
+            return Util.InstallPaths(
+                install_dir=brew_prefix / "opt" / "shepctl",
+                symlink_dir=brew_prefix / "bin",
+            )
+        return Util.InstallPaths(
+            install_dir=Path("/opt/shepctl"),
+            symlink_dir=Path("/usr/local/bin"),
+        )
+
+    @staticmethod
+    def get_home_directory() -> str:
+        return str(Path.home())
+
+    @staticmethod
+    def is_macos() -> bool:
+        return platform.system().lower() == "darwin"
+
+    @staticmethod
+    def translate_host_path(path: str) -> str:
+        """
+        Translate common Linux host-home paths to the active platform.
+
+        Container-internal paths are intentionally left to callers to preserve
+        Linux paths inside images and compose specs.
+        """
+        if not Util.is_macos():
+            return path
+
+        home_dir = Util.get_home_directory()
+        expanded = path
+
+        if path == "~":
+            expanded = home_dir
+        elif path.startswith("~/"):
+            expanded = str(Path(home_dir) / path[2:])
+
+        if expanded.startswith("/home/"):
+            parts = Path(expanded).parts
+            translated = Path(home_dir)
+            if len(parts) > 3:
+                translated = translated.joinpath(*parts[3:])
+            return str(translated)
+
+        return expanded
+
+    @staticmethod
+    def translate_volume_binding(volume: str) -> str:
+        """
+        Translate only the host-side portion of a bind-mount definition.
+        """
+        if not volume:
+            return volume
+
+        if not Util.is_macos():
+            return volume
+
+        parts = volume.split(":")
+        if len(parts) < 2:
+            return Util.translate_host_path(volume)
+
+        parts[0] = Util.translate_host_path(parts[0])
+        return ":".join(parts)
 
     @staticmethod
     def download_package(url: str, dest: str) -> None:


### PR DESCRIPTION
Feature: [#160](https://github.com/MoonyFringers/shepherd/issues/160)

# Description
- Add cross-platform path handling so Linux host paths resolve correctly on macOS while preserving Linux container paths
- Extend the installer to support macOS end to end with Homebrew-based dependency management, platform-aware default install locations, and a non-root macOS install flow
- Update the install script and documentation to reflect the new macOS workflow, and add test coverage for macOS OS detection, install defaults, completion paths, and translated bind mounts.

## Motivation and Context
This change makes Shepherd usable on macOS without forcing users through Linux-specific assumptions in path handling or installation. Before this work, the runtime preserved Linux host paths unchanged, the installer rejected darwin, and the install script always escalated to sudo, which breaks Homebrew-based dependency installation on macOS.

## How Has This Been Tested?

- Manually validated the macOS install flow using a local virtual environment and Homebrew dependencies.
- Added/updated automated tests covering

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
to change)
- [x] Change or update to the documentation (with no functional changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
