### PR TITLE
feat: probe watch mode, env robustness improvements, plugin force-install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ wiki
 shepctl.spec
 build
 AGENTS.md
+CLAUDE.md
+.claude

--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -126,6 +126,7 @@ class CompletionMng(AbstractCompletionMng):
             OptionSpec(tokens=("--details",)),
         ),
         ("probe", "check"): (OptionSpec(tokens=("-a", "--all")),),
+        ("plugin", "install"): (OptionSpec(tokens=("--force",)),),
     }
 
     def __init__(

--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -129,6 +129,8 @@ class CompletionMng(AbstractCompletionMng):
         ("probe", "check"): (
             OptionSpec(tokens=("-a", "--all")),
             OptionSpec(tokens=("-w", "--watch")),
+            OptionSpec(tokens=("--show-commands",)),
+            OptionSpec(tokens=("--show-commands-limit",), takes_value=True),
         ),
         ("plugin", "install"): (OptionSpec(tokens=("--force",)),),
     }

--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -126,7 +126,10 @@ class CompletionMng(AbstractCompletionMng):
             OptionSpec(tokens=("-r", "--resolved")),
             OptionSpec(tokens=("--details",)),
         ),
-        ("probe", "check"): (OptionSpec(tokens=("-a", "--all")),),
+        ("probe", "check"): (
+            OptionSpec(tokens=("-a", "--all")),
+            OptionSpec(tokens=("-w", "--watch")),
+        ),
         ("plugin", "install"): (OptionSpec(tokens=("--force",)),),
     }
 

--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -82,6 +82,7 @@ class CompletionMng(AbstractCompletionMng):
             OptionSpec(tokens=("--show-commands-limit",), takes_value=True),
             OptionSpec(tokens=("--timeout",), takes_value=True),
             OptionSpec(tokens=("-w", "--watch")),
+            OptionSpec(tokens=("--keep-output",)),
         ),
         ("env", "halt"): (OptionSpec(tokens=("--no-wait",)),),
         ("env", "reload"): (

--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -80,7 +80,7 @@ class CompletionMng(AbstractCompletionMng):
         ("env", "up"): (
             OptionSpec(tokens=("--show-commands",)),
             OptionSpec(tokens=("--show-commands-limit",), takes_value=True),
-            OptionSpec(tokens=("--timeout",), takes_value=True),
+            OptionSpec(tokens=("-t", "--timeout"), takes_value=True),
             OptionSpec(tokens=("-w", "--watch")),
             OptionSpec(tokens=("--keep-output",)),
         ),

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -49,7 +49,11 @@ from .render import (
     format_service_gate_glyphs,
     render_env_summary,
 )
-from .status_wait import WaitForEnvStateHooks, wait_for_env_state
+from .status_wait import (
+    WaitForEnvStateHooks,
+    wait_for_env_state,
+    watch_probe_state,
+)
 
 DEFAULT_STATUS_POLL_SECONDS = 1.0
 
@@ -875,8 +879,31 @@ class EnvironmentMng:
         results: list[ProbeRunResult],
         *,
         title: str,
+        probe_error: Optional[dict[str, str]] = None,
     ):
-        return build_probe_status_tree(results, title=title)
+        return build_probe_status_tree(
+            results, title=title, probe_error=probe_error
+        )
+
+    def watch_probes(
+        self,
+        envCfg: EnvironmentCfg,
+        probe_tag: Optional[str],
+        poll_seconds: int = 5,
+    ) -> None:
+        """Continuously run probes and render results until interrupted."""
+        env = self.get_environment_from_cfg(envCfg)
+        if not env.envCfg.status.rendered_config:
+            Util.print_error_and_die(
+                f"Environment '{env.envCfg.tag}' is not started."
+            )
+        title = f"[white]{envCfg.tag}[/white] probes"
+        watch_probe_state(
+            env,
+            probe_tag=probe_tag,
+            title=title,
+            poll_seconds=poll_seconds,
+        )
 
     def status_env(self, envCfg: EnvironmentCfg, watch: bool = False):
         """Get environment status."""

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -415,13 +415,21 @@ class Environment(ABC):
                     f"Service Template: '{service.svcCfg.template}' "
                     f"does not exist."
                 )
-            if svc_t_path := self.configMng.get_service_template_path(
+            svc_t_path = self.configMng.get_service_template_path(
                 service.svcCfg.template
-            ):
+            )
+            if svc_t_path is not None:
+                # Template has file resources: copy them into the env dir.
                 Util.copy_dir(
                     svc_t_path,
                     os.path.join(self.get_path(), service.svcCfg.tag),
                 )
+            # svc_t_path is None only for descriptor-only templates that
+            # carry no file resources (e.g. pure factory/config templates).
+            # If the template was registered but its directory was removed
+            # from disk after installation the path resolver already returns
+            # None rather than a non-existent path, so no extra guard is
+            # needed here.
 
         self.sync_config()
 
@@ -436,11 +444,6 @@ class Environment(ABC):
         self.configMng.remove_environment(self.envCfg.tag)
         self.envCfg.tag = dst_env_tag
         self.sync_config()
-
-    def delete(self):
-        """Delete the environment."""
-        Util.remove_dir(self.get_path())
-        self.configMng.remove_environment(self.envCfg.tag)
 
     def sync_config(self):
         """Sync the environment configuration."""
@@ -912,6 +915,7 @@ class EnvironmentMng:
         envCfg: EnvironmentCfg,
         probe_tag: Optional[str],
         poll_seconds: int = 5,
+        probe_timeout_seconds: int = 120,
     ) -> None:
         """Continuously run probes and render results until interrupted."""
         env = self.get_environment_from_cfg(envCfg)
@@ -925,6 +929,7 @@ class EnvironmentMng:
             probe_tag=probe_tag,
             title=title,
             poll_seconds=poll_seconds,
+            probe_timeout_seconds=probe_timeout_seconds,
         )
 
     def status_env(self, envCfg: EnvironmentCfg, watch: bool = False):

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -190,7 +190,7 @@ class Environment(ABC):
                             break
                     time.sleep(1.0)
                     continue
-        except NonRecoverableStartError as e:
+        except NonRecoverableStartError:
             try:
                 self.stop()
             except BaseException:
@@ -198,11 +198,7 @@ class Environment(ABC):
                     "Failed rollback stop after start failure for env '%s'",
                     self.envCfg.tag,
                 )
-            message = (
-                str(e)
-                or "Environment start failed due to a non-recoverable error."
-            )
-            Util.print_error_and_die(message)
+            raise
 
     def add_command_log(self, command: str) -> None:
         """Add a command entry to the environment log."""
@@ -744,6 +740,7 @@ class EnvironmentMng:
         envCfg: EnvironmentCfg,
         timeout_seconds: Optional[int] = 60,
         watch: bool = False,
+        keep_output: bool = False,
     ):
         """Start an environment."""
         if timeout_seconds is not None and timeout_seconds < 0:
@@ -751,12 +748,21 @@ class EnvironmentMng:
                 "Timeout must be greater than or equal to 0."
             )
         env = self.get_environment_from_cfg(envCfg)
-        self.wait_for_env_up(
-            env,
-            timeout_seconds=timeout_seconds,
-            start_action=lambda: env.start(timeout_seconds=timeout_seconds),
-            watch_after=watch,
-        )
+        try:
+            self.wait_for_env_up(
+                env,
+                timeout_seconds=timeout_seconds,
+                start_action=lambda: env.start(timeout_seconds=timeout_seconds),
+                watch_after=watch,
+                keep_output=keep_output,
+            )
+        except NonRecoverableStartError as e:
+            message = (
+                str(e)
+                or "Environment start failed due to a non-recoverable error."
+            )
+            Util.print_error_and_die(message)
+            return
         Util.print(env.envCfg.tag)
 
     def stop_env(self, envCfg: EnvironmentCfg, wait: bool = True):
@@ -908,6 +914,7 @@ class EnvironmentMng:
         start_action: Optional[Callable[[], Any]] = None,
         watch_after: bool = False,
         progress_label: str = "Starting",
+        keep_output: bool = False,
     ):
         self._wait_for_env_state(
             env,
@@ -916,6 +923,7 @@ class EnvironmentMng:
             wait_until_up=True,
             watch_after=watch_after,
             progress_label=progress_label,
+            keep_output=keep_output,
         )
 
     def wait_for_env_down(
@@ -941,6 +949,7 @@ class EnvironmentMng:
         wait_until_up: bool,
         watch_after: bool = False,
         progress_label: str = "Starting",
+        keep_output: bool = False,
     ):
         hooks = WaitForEnvStateHooks(
             status_poll_seconds=self._status_poll_seconds,
@@ -958,6 +967,7 @@ class EnvironmentMng:
             wait_until_up=wait_until_up,
             watch_after=watch_after,
             progress_label=progress_label,
+            keep_output=keep_output,
             hooks=hooks,
         )
 

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
+import subprocess
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -640,8 +642,81 @@ class EnvironmentMng:
                     return
 
             env = self.envFactory.new_environment_cfg(envCfg)
-            env.delete()
+            self._delete_environment_dir(env.get_path())
+            self.configMng.remove_environment(env.envCfg.tag)
             Util.print(env.envCfg.tag)
+
+    def _delete_environment_dir(self, env_dir: str) -> None:
+        """Delete one environment directory with optional sudo retry."""
+        try:
+            shutil.rmtree(env_dir)
+            return
+        except PermissionError as exc:
+            if not self._can_retry_delete_with_sudo():
+                Util.print_error_and_die(
+                    f"Failed to remove directory: {env_dir}\nError: {exc}"
+                )
+            if not Util.confirm(
+                "Permission denied while deleting environment files. "
+                "Retry with elevated privileges using sudo?"
+            ):
+                Util.print_error_and_die(
+                    f"Failed to remove directory: {env_dir}\nError: {exc}"
+                )
+            self._delete_dir_with_sudo(env_dir)
+            return
+        except OSError as exc:
+            Util.print_error_and_die(
+                f"Failed to remove directory: {env_dir}\nError: {exc}"
+            )
+
+    def _can_retry_delete_with_sudo(self) -> bool:
+        """Return true when a sudo retry can be offered on this host.
+
+        Only POSIX systems with sudo available support the elevated-permission
+        retry path. Windows is excluded both because sudo does not exist there
+        and because Docker Desktop on Windows manages bind-mount paths inside
+        a WSL2/Hyper-V VM, so the root-owned file problem does not arise on
+        the host filesystem.
+        """
+        return os.name == "posix" and shutil.which("sudo") is not None
+
+    def _delete_dir_with_sudo(self, env_dir: str) -> None:
+        """Delete one environment directory using a two-step elevated approach.
+
+        Rather than running `sudo rm -rf` directly, we use sudo only to
+        transfer ownership of the directory tree to the current user
+        (`sudo chown -R <uid>:<gid>`), then let the Python process remove the
+        tree with `shutil.rmtree`. This limits the blast radius of the
+        elevated call: sudo only touches ownership on a Shepherd-managed path
+        and rm never runs as root.
+
+        Note: `chmod u+rwX` is not sufficient here because `u` refers to the
+        owner of each file (typically root when Docker writes bind-mount
+        volumes), not to the current user. Transferring ownership is the
+        correct fix.
+        """
+        uid = os.getuid()
+        gid = os.getgid()
+        chown_result = subprocess.run(
+            ["sudo", "chown", "-R", f"{uid}:{gid}", env_dir],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        if chown_result.returncode != 0:
+            stderr = (chown_result.stderr or "").strip()
+            Util.print_error_and_die(
+                "Failed to transfer ownership with sudo: "
+                f"{env_dir}" + (f"\nError: {stderr}" if stderr else "")
+            )
+        try:
+            shutil.rmtree(env_dir)
+        except OSError as exc:
+            Util.print_error_and_die(
+                f"Failed to remove directory after sudo chown: "
+                f"{env_dir}\nError: {exc}"
+            )
 
     def list_envs(self):
         """List all available environments."""

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -407,17 +407,17 @@ class Environment(ABC):
         )
 
         for service in self.services:
+            if not self.configMng.get_service_template(service.svcCfg.template):
+                Util.print_error_and_die(
+                    f"Service Template: '{service.svcCfg.template}' "
+                    f"does not exist."
+                )
             if svc_t_path := self.configMng.get_service_template_path(
                 service.svcCfg.template
             ):
                 Util.copy_dir(
                     svc_t_path,
                     os.path.join(self.get_path(), service.svcCfg.tag),
-                )
-            else:
-                Util.print_error_and_die(
-                    f"Service Template: '{service.svcCfg.template}' "
-                    f"does not exist."
                 )
 
         self.sync_config()

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -42,6 +42,7 @@ from .render import (
     build_command_log_panel,
     build_env_details_tree,
     build_env_status_tree,
+    build_probe_error_from_results,
     build_probe_status_tree,
     collect_env_status,
     dump_grouped_yaml,
@@ -865,7 +866,22 @@ class EnvironmentMng:
         )
 
         title = f"[white]{envCfg.tag}[/white] probes"
-        Util.console.print(self._build_probe_status_tree(results, title=title))
+        probe_error = build_probe_error_from_results(results)
+        command_log = (
+            env.get_command_log() if env.is_command_log_enabled() else None
+        )
+        command_log_limit = (
+            env.get_command_log_limit() if command_log is not None else None
+        )
+        Util.console.print(
+            self._build_probe_status_tree(
+                results,
+                title=title,
+                probe_error=probe_error,
+                command_log=command_log,
+                command_log_limit=command_log_limit,
+            )
+        )
 
         # ---- aggregate exit code ----
         for r in results:
@@ -880,9 +896,15 @@ class EnvironmentMng:
         *,
         title: str,
         probe_error: Optional[dict[str, str]] = None,
+        command_log: Optional[list[str]] = None,
+        command_log_limit: Optional[int] = None,
     ):
         return build_probe_status_tree(
-            results, title=title, probe_error=probe_error
+            results,
+            title=title,
+            probe_error=probe_error,
+            command_log=command_log,
+            command_log_limit=command_log_limit,
         )
 
     def watch_probes(

--- a/src/environment/render.py
+++ b/src/environment/render.py
@@ -506,6 +506,8 @@ def build_probe_status_tree(
     title: str,
     flashing_summary_keys: Optional[set[str]] = None,
     probe_error: Optional[dict[str, str]] = None,
+    command_log: Optional[list[str]] = None,
+    command_log_limit: Optional[int] = None,
 ) -> Any:
     """Render probe check results as a tree of color-coded probe tags."""
     tree = Tree(title, guide_style="dim")
@@ -514,6 +516,8 @@ def build_probe_status_tree(
         color = probe_status_color_tag(key)
         tree.add(f"[{color}]{r.tag}[/{color}]")
     extras: list[Any] = []
+    if command_log is not None and command_log_limit is not None:
+        extras.append(build_command_log_panel(command_log, command_log_limit))
     if probe_error:
         extras.append(build_command_error_panel(probe_error, None))
     return build_tree_summary_group(

--- a/src/environment/render.py
+++ b/src/environment/render.py
@@ -476,11 +476,36 @@ def _flash_markup(markup: str) -> str:
     return f"[bold black on white]{plain}[/bold black on white]"
 
 
+def build_probe_error_from_results(
+    results: Sequence[ProbeRunResultLike],
+) -> Optional[dict[str, str]]:
+    """Build an error panel dict from the first failed or timed-out probe."""
+    for r in results:
+        if r.exit_code == 0 and not r.timed_out:
+            continue
+        parts: list[str] = []
+        if r.timed_out:
+            parts.append("[yellow]Probe timed out.[/yellow]")
+        if r.stdout and r.stdout.strip():
+            parts.append(f"--- stdout ---\n{r.stdout.strip()}")
+        if r.stderr and r.stderr.strip():
+            parts.append(f"--- stderr ---\n{r.stderr.strip()}")
+        if not parts:
+            return None
+        label = "timed out" if r.timed_out else "failed"
+        return {
+            "title": f"Probe '{r.tag}' {label}",
+            "body": "\n".join(parts),
+        }
+    return None
+
+
 def build_probe_status_tree(
     results: Sequence[ProbeRunResultLike],
     *,
     title: str,
     flashing_summary_keys: Optional[set[str]] = None,
+    probe_error: Optional[dict[str, str]] = None,
 ) -> Any:
     """Render probe check results as a tree of color-coded probe tags."""
     tree = Tree(title, guide_style="dim")
@@ -488,9 +513,13 @@ def build_probe_status_tree(
         key = probe_status_key(r)
         color = probe_status_color_tag(key)
         tree.add(f"[{color}]{r.tag}[/{color}]")
+    extras: list[Any] = []
+    if probe_error:
+        extras.append(build_command_error_panel(probe_error, None))
     return build_tree_summary_group(
         tree,
         build_probe_status_summary(results),
+        extras=extras,
         flashing_summary_keys=flashing_summary_keys,
     )
 

--- a/src/environment/render.py
+++ b/src/environment/render.py
@@ -491,7 +491,7 @@ def build_probe_error_from_results(
         if r.stderr and r.stderr.strip():
             parts.append(f"--- stderr ---\n{r.stderr.strip()}")
         if not parts:
-            return None
+            parts.append("[dim]No output captured.[/dim]")
         label = "timed out" if r.timed_out else "failed"
         return {
             "title": f"Probe '{r.tag}' {label}",

--- a/src/environment/status_wait.py
+++ b/src/environment/status_wait.py
@@ -23,6 +23,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, TypeAlias
 
+from rich.console import Group
 from rich.live import Live
 from rich.markup import escape
 from rich.text import Text
@@ -245,6 +246,9 @@ def wait_for_env_state(
     container_transition_started_at: dict[str, float] = {}
     probe_transition_started_at: dict[tuple[str, str], float] = {}
     summary_transition_started_at: dict[str, float] = {}
+    # Flips to True when keep_output is active and an error has been set,
+    # so the UI can render a "Press Ctrl+C to exit" hint.
+    keep_output_hint_active = False
 
     if wait_until_up:
         # Only "up" waits care about readiness probes. "Down" waits complete
@@ -354,7 +358,7 @@ def wait_for_env_state(
         }
         # Centralize all table-side decorations so the render loops can focus
         # on state transitions instead of repeatedly wiring optional panels.
-        return hooks.build_env_status(
+        renderable = hooks.build_env_status(
             env.envCfg.tag,
             grouped,
             hidden_columns=hidden_columns,
@@ -379,6 +383,12 @@ def wait_for_env_state(
             flashing_probes=flashing_probes,
             flashing_summary_keys=flashing_summary_keys,
         )
+        if keep_output_hint_active:
+            return Group(
+                renderable,
+                Text("Press Ctrl+C to exit", style="dim"),
+            )
+        return renderable
 
     def render_progress_text(remaining: Optional[int], tick: int) -> str:
         # Used only when there is not yet a stable table snapshot to render,
@@ -595,6 +605,9 @@ def wait_for_env_state(
                         raise action_error
                     # keep_output: keep the display live until Ctrl+C so
                     # the user can inspect the command log at leisure.
+                    # The renderable is updated on every tick below, so
+                    # the display stays fresh. Exit via KeyboardInterrupt.
+                    keep_output_hint_active = True
                 if poll_error is not None:
                     raise poll_error
                 with snapshot_lock:
@@ -724,6 +737,8 @@ def wait_for_env_state(
                 ui_tick_count += 1
                 sleep_for = max(0.0, next_ui_tick_at - time.monotonic())
                 time.sleep(sleep_for)
+        except KeyboardInterrupt:
+            pass
         finally:
             stop_polling.set()
             poll_thread.join(timeout=1.0)
@@ -735,6 +750,7 @@ def watch_probe_state(
     probe_tag: Optional[str],
     title: str,
     poll_seconds: int = 5,
+    probe_timeout_seconds: int = 120,
 ) -> None:
     """
     Continuously run probes and render results via a Rich Live display.
@@ -759,7 +775,7 @@ def watch_probe_state(
         results = env.check_probes(
             probe_tag=probe_tag,
             fail_fast=False,
-            timeout_seconds=120,
+            timeout_seconds=probe_timeout_seconds,
         )
         with results_lock:
             last_results[:] = results

--- a/src/environment/status_wait.py
+++ b/src/environment/status_wait.py
@@ -27,7 +27,11 @@ from rich.live import Live
 from rich.markup import escape
 from rich.text import Text
 
-from environment.render import build_env_status_summary
+from environment.render import (
+    build_env_status_summary,
+    build_probe_error_from_results,
+    build_probe_status_tree,
+)
 from util.util import Util
 
 GroupedStatus: TypeAlias = dict[str, list[list[str]]]
@@ -723,3 +727,44 @@ def wait_for_env_state(
         finally:
             stop_polling.set()
             poll_thread.join(timeout=1.0)
+
+
+def watch_probe_state(
+    env: Any,
+    *,
+    probe_tag: Optional[str],
+    title: str,
+    poll_seconds: int = 5,
+) -> None:
+    """
+    Continuously run probes and render results via a Rich Live display.
+
+    Runs until the user interrupts with Ctrl+C. On each cycle probes are
+    executed synchronously and the display is refreshed with the latest
+    results. If any probe fails or times out, its output is shown in a
+    red error panel below the probe tree.
+    """
+    with Live(
+        refresh_per_second=4,
+        console=Util.console,
+        transient=True,
+        screen=False,
+    ) as live:
+        try:
+            while True:
+                results = env.check_probes(
+                    probe_tag=probe_tag,
+                    fail_fast=False,
+                    timeout_seconds=120,
+                )
+                probe_error = build_probe_error_from_results(results)
+                live.update(
+                    build_probe_status_tree(
+                        results,
+                        title=title,
+                        probe_error=probe_error,
+                    )
+                )
+                time.sleep(poll_seconds)
+        except KeyboardInterrupt:
+            pass

--- a/src/environment/status_wait.py
+++ b/src/environment/status_wait.py
@@ -739,32 +739,88 @@ def watch_probe_state(
     """
     Continuously run probes and render results via a Rich Live display.
 
-    Runs until the user interrupts with Ctrl+C. On each cycle probes are
-    executed synchronously and the display is refreshed with the latest
-    results. If any probe fails or times out, its output is shown in a
-    red error panel below the probe tree.
+    Runs until the user interrupts with Ctrl+C. Checks run in a background
+    thread so the UI can animate while a check is in progress. The poll
+    interval is measured from when the previous check finished, so slow
+    probes never cause back-to-back runs. While a check is running the
+    title is animated and the error panel is hidden (it belongs to the
+    previous cycle). When command logging is enabled the recent-commands
+    panel is rendered below the probe tree.
     """
+    ui_tick_seconds = 1.0 / MIN_LIVE_REFRESH_PER_SECOND
+
+    results_lock = threading.Lock()
+    last_results: list[Any] = []
+    # 0.0 ensures the first check fires immediately on entry.
+    last_check_finished_at: list[float] = [0.0]
+    check_running = threading.Event()
+
+    def run_check() -> None:
+        results = env.check_probes(
+            probe_tag=probe_tag,
+            fail_fast=False,
+            timeout_seconds=120,
+        )
+        with results_lock:
+            last_results[:] = results
+        last_check_finished_at[0] = time.monotonic()
+        check_running.clear()
+
     with Live(
-        refresh_per_second=4,
+        refresh_per_second=MIN_LIVE_REFRESH_PER_SECOND,
         console=Util.console,
         transient=True,
         screen=False,
     ) as live:
         try:
+            tick = 0
             while True:
-                results = env.check_probes(
-                    probe_tag=probe_tag,
-                    fail_fast=False,
-                    timeout_seconds=120,
+                now = time.monotonic()
+
+                # Kick off a new check when idle and the poll interval
+                # has elapsed since the last check finished.
+                if not check_running.is_set() and (
+                    now >= last_check_finished_at[0] + poll_seconds
+                ):
+                    check_running.set()
+                    threading.Thread(target=run_check, daemon=True).start()
+
+                running = check_running.is_set()
+                with results_lock:
+                    current_results = list(last_results)
+
+                animated_title = (
+                    f"{title} " f"{render_moving_shadow_text('Checking', tick)}"
+                    if running
+                    else title
                 )
-                probe_error = build_probe_error_from_results(results)
+                # Suppress the error panel while a new check is in flight
+                # to avoid showing stale output from the previous cycle.
+                probe_error = (
+                    None
+                    if running
+                    else build_probe_error_from_results(current_results)
+                )
+                command_log = (
+                    env.get_command_log()
+                    if env.is_command_log_enabled()
+                    else None
+                )
+                command_log_limit = (
+                    env.get_command_log_limit()
+                    if command_log is not None
+                    else None
+                )
                 live.update(
                     build_probe_status_tree(
-                        results,
-                        title=title,
+                        current_results,
+                        title=animated_title,
                         probe_error=probe_error,
+                        command_log=command_log,
+                        command_log_limit=command_log_limit,
                     )
                 )
-                time.sleep(poll_seconds)
+                time.sleep(ui_tick_seconds)
+                tick += 1
         except KeyboardInterrupt:
             pass

--- a/src/environment/status_wait.py
+++ b/src/environment/status_wait.py
@@ -167,6 +167,7 @@ def wait_for_env_state(
     wait_until_up: bool,
     watch_after: bool,
     progress_label: str = "Starting",
+    keep_output: bool = False,
     *,
     hooks: WaitForEnvStateHooks,
 ) -> None:
@@ -582,7 +583,14 @@ def wait_for_env_state(
         seen_snapshot_revision: int = -1
         try:
             while True:
-                raise_action_error()
+                if action_error is not None:
+                    # Preserve the last rendered state so the user can
+                    # read the command log and error context after exit.
+                    live.transient = False
+                    if not keep_output:
+                        raise action_error
+                    # keep_output: keep the display live until Ctrl+C so
+                    # the user can inspect the command log at leisure.
                 if poll_error is not None:
                     raise poll_error
                 with snapshot_lock:

--- a/src/plugin/plugin.py
+++ b/src/plugin/plugin.py
@@ -91,7 +91,7 @@ class PluginMng:
         self.configMng.remove_plugin(plugin.id)
         Util.print(f"Plugin '{plugin.id}' removed.")
 
-    def install_plugin(self, archive_path: str) -> None:
+    def install_plugin(self, archive_path: str, force: bool = False) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             extracted_dir = os.path.join(tmp_dir, "plugin")
             os.makedirs(extracted_dir, exist_ok=True)
@@ -100,10 +100,17 @@ class PluginMng:
             descriptor = self._load_descriptor(descriptor_path)
             self._validate_reserved_plugin_id(descriptor.id)
 
-            if self.configMng.get_plugin(descriptor.id) is not None:
-                Util.print_error_and_die(
-                    f"Plugin '{descriptor.id}' is already installed."
-                )
+            existing = self.configMng.get_plugin(descriptor.id)
+            if existing is not None:
+                if not force:
+                    Util.print_error_and_die(
+                        f"Plugin '{descriptor.id}' is already installed. "
+                        "Use --force to replace it."
+                    )
+                target_dir = self.configMng.get_plugin_dir(descriptor.id)
+                if os.path.isdir(target_dir):
+                    shutil.rmtree(target_dir)
+                self.configMng.remove_plugin(descriptor.id)
 
             descriptor_dir = os.path.dirname(descriptor_path)
             target_dir = self.configMng.get_plugin_dir(descriptor.id)
@@ -113,12 +120,18 @@ class PluginMng:
                 )
 
             shutil.move(descriptor_dir, target_dir)
+            new_config = (
+                existing.config
+                if existing is not None
+                else descriptor.default_config
+            )
+            new_enabled = existing.enabled if existing is not None else "true"
             self.configMng.set_plugin(
                 PluginCfg(
                     id=descriptor.id,
-                    enabled="true",
+                    enabled=new_enabled,
                     version=descriptor.version,
-                    config=descriptor.default_config,
+                    config=new_config,
                 )
             )
         Util.print(f"Plugin '{descriptor.id}' installed.")

--- a/src/plugin/plugin.py
+++ b/src/plugin/plugin.py
@@ -92,6 +92,14 @@ class PluginMng:
         Util.print(f"Plugin '{plugin.id}' removed.")
 
     def install_plugin(self, archive_path: str, force: bool = False) -> None:
+        """Install a plugin from a tar archive.
+
+        Note: when `force=True`, the existing plugin directory and config entry
+        are removed before the new archive is installed. If the subsequent
+        `shutil.move` fails (e.g. cross-device rename), the plugin will be in a
+        torn state — removed but not replaced. In that case re-run the install
+        to recover.
+        """
         with tempfile.TemporaryDirectory() as tmp_dir:
             extracted_dir = os.path.join(tmp_dir, "plugin")
             os.makedirs(extracted_dir, exist_ok=True)

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -20,6 +20,7 @@ import builtins
 import functools
 import logging
 import os
+import sys
 from typing import Any, Callable, List, Optional
 
 import click
@@ -377,7 +378,10 @@ def checkout(shepherd: ShepherdMng, tag: str):
 @click.argument("tag", required=True)
 @click.pass_obj
 def delete_env(shepherd: ShepherdMng, tag: str):
-    """Delete an environment."""
+    """Delete an environment.
+
+    May prompt for sudo to recover ownership of container-written files.
+    """
     shepherd.environmentMng.delete_env(tag)
 
 
@@ -739,7 +743,10 @@ def get_probe(
     "-w",
     "--watch",
     is_flag=True,
-    help="Continuously re-run probes and keep the display updated.",
+    help=(
+        "Continuously re-run probes and keep the display updated. "
+        "Interactive only — exits 0 on Ctrl+C regardless of probe state."
+    ),
 )
 @click.option(
     "--show-commands",
@@ -772,7 +779,7 @@ def check_probe(
         shepherd.environmentMng.watch_probes(envCfg, probe_tag)
         return
     exit_code = shepherd.environmentMng.check_probes(envCfg, probe_tag)
-    exit(exit_code)
+    sys.exit(exit_code)
 
 
 # =====================================================

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -776,10 +776,16 @@ def get_plugin(shepherd: ShepherdMng, plugin_id: str, output: str):
     required=True,
     type=click.Path(exists=True, dir_okay=False, path_type=str),
 )
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Replace an already-installed plugin.",
+)
 @click.pass_obj
-def install_plugin(shepherd: ShepherdMng, archive_path: str):
+def install_plugin(shepherd: ShepherdMng, archive_path: str, force: bool):
     """Install a plugin archive into the managed plugin root."""
-    shepherd.pluginMng.install_plugin(archive_path)
+    shepherd.pluginMng.install_plugin(archive_path, force=force)
 
 
 @plugin.command(name="enable")

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -735,6 +735,12 @@ def get_probe(
 @probe.command(name="check")
 @click.argument("probe_tag", required=False)
 @click.option("-a", "--all", is_flag=True, help="Check all probes.")
+@click.option(
+    "-w",
+    "--watch",
+    is_flag=True,
+    help="Continuously re-run probes and keep the display updated.",
+)
 @click.pass_obj
 @require_active_env
 def check_probe(
@@ -742,10 +748,14 @@ def check_probe(
     envCfg: EnvironmentCfg,
     probe_tag: Optional[str],
     all: bool,
+    watch: bool,
 ):
     """Run probe checks and return a process exit code based on results."""
     if all:
         probe_tag = None
+    if watch:
+        shepherd.environmentMng.watch_probes(envCfg, probe_tag)
+        return
     exit_code = shepherd.environmentMng.check_probes(envCfg, probe_tag)
     exit(exit_code)
 

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -420,6 +420,15 @@ def list(shepherd: ShepherdMng):
     is_flag=True,
     help="Keep updating the output until interrupted.",
 )
+@click.option(
+    "--keep-output",
+    is_flag=True,
+    help=(
+        "On start failure, preserve the status display and keep "
+        "updating it until interrupted. Useful with --show-commands "
+        "to inspect the command log after an init script error."
+    ),
+)
 @click.pass_obj
 @require_active_env
 def up_env(
@@ -429,11 +438,12 @@ def up_env(
     show_commands_limit: int,
     timeout: Optional[int],
     watch: bool,
+    keep_output: bool,
 ):
     """Start environment."""
     _apply_show_commands_flags(shepherd, show_commands, show_commands_limit)
     shepherd.environmentMng.start_env(
-        envCfg, timeout_seconds=timeout, watch=watch
+        envCfg, timeout_seconds=timeout, watch=watch, keep_output=keep_output
     )
 
 

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -408,9 +408,10 @@ def list(shepherd: ShepherdMng):
     help="Number of recent commands to display.",
 )
 @click.option(
+    "-t",
     "--timeout",
     type=int,
-    default=60,
+    default=120,
     show_default=True,
     help="Maximum seconds to wait for all containers to be running.",
 )

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -741,6 +741,18 @@ def get_probe(
     is_flag=True,
     help="Continuously re-run probes and keep the display updated.",
 )
+@click.option(
+    "--show-commands",
+    is_flag=True,
+    help="Show recent probe commands in the output panel.",
+)
+@click.option(
+    "--show-commands-limit",
+    type=int,
+    default=DEFAULT_COMPOSE_COMMAND_LOG_LIMIT,
+    show_default=True,
+    help="Number of recent commands to display.",
+)
 @click.pass_obj
 @require_active_env
 def check_probe(
@@ -749,10 +761,13 @@ def check_probe(
     probe_tag: Optional[str],
     all: bool,
     watch: bool,
+    show_commands: bool,
+    show_commands_limit: int,
 ):
     """Run probe checks and return a process exit code based on results."""
     if all:
         probe_tag = None
+    _apply_show_commands_flags(shepherd, show_commands, show_commands_limit)
     if watch:
         shepherd.environmentMng.watch_probes(envCfg, probe_tag)
         return

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -561,6 +561,7 @@ def test_completion_start_env(
     assert completions == [
         "--show-commands",
         "--show-commands-limit",
+        "-t",
         "--timeout",
         "-w",
         "--watch",

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -1245,3 +1245,14 @@ def test_completion_get_probe(
         "db-live",
         "db-ready",
     ], "Expected get probe completion"
+
+
+@pytest.mark.compl
+def test_completion_plugin_install_shows_force_flag(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    sm = ShepherdMng(load_runtime_plugins=False)
+    completions = sm.completionMng.get_completions(["plugin", "install", ""])
+    assert "--force" in completions

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -1269,3 +1269,15 @@ def test_completion_env_up_shows_keep_output_flag(
     sm = ShepherdMng(load_runtime_plugins=False)
     completions = sm.completionMng.get_completions(["env", "up", ""])
     assert "--keep-output" in completions
+
+
+@pytest.mark.compl
+def test_completion_probe_check_shows_watch_flag(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    sm = ShepherdMng(load_runtime_plugins=False)
+    completions = sm.completionMng.get_completions(["probe", "check", ""])
+    assert "-w" in completions
+    assert "--watch" in completions

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -564,6 +564,7 @@ def test_completion_start_env(
         "--timeout",
         "-w",
         "--watch",
+        "--keep-output",
     ], "Expected env up flags"
 
 
@@ -1256,3 +1257,14 @@ def test_completion_plugin_install_shows_force_flag(
     sm = ShepherdMng(load_runtime_plugins=False)
     completions = sm.completionMng.get_completions(["plugin", "install", ""])
     assert "--force" in completions
+
+
+@pytest.mark.compl
+def test_completion_env_up_shows_keep_output_flag(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    sm = ShepherdMng(load_runtime_plugins=False)
+    completions = sm.completionMng.get_completions(["env", "up", ""])
+    assert "--keep-output" in completions

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -1281,3 +1281,4 @@ def test_completion_probe_check_shows_watch_flag(
     completions = sm.completionMng.get_completions(["probe", "check", ""])
     assert "-w" in completions
     assert "--watch" in completions
+    assert "--show-commands-limit" in completions

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -802,19 +802,15 @@ def test_start_rolls_back_with_stop_on_non_recoverable_gate_failure(
         ],
     )
 
-    die_mock = mocker.patch(
-        "environment.environment.Util.print_error_and_die",
-        side_effect=RuntimeError("die"),
-    )
-    with pytest.raises(RuntimeError, match="die"):
+    with pytest.raises(
+        NonRecoverableStartError,
+        match="Failed to start gate 'ungated' for environment 'rollback-env'.",
+    ):
         env.start(timeout_seconds=5)
 
     assert run_compose_mock.call_count == 2
     assert run_compose_mock.call_args_list[0].args[1:3] == ("up", "-d")
     assert run_compose_mock.call_args_list[1].args[1:2] == ("down",)
-    die_mock.assert_called_once_with(
-        "Failed to start gate 'ungated' for environment 'rollback-env'."
-    )
 
 
 @pytest.mark.docker
@@ -1065,11 +1061,13 @@ def test_start_records_init_compose_failure_output(mocker: MockerFixture):
         ],
     )
 
-    die_mock = mocker.patch(
-        "environment.environment.Util.print_error_and_die",
-        side_effect=RuntimeError("die"),
-    )
-    with pytest.raises(RuntimeError, match="die"):
+    with pytest.raises(
+        NonRecoverableStartError,
+        match=(
+            "Failed to run init 'seed' for container 'api' in environment "
+            "'init-fail-env'."
+        ),
+    ):
         env.start(timeout_seconds=5)
 
     assert run_compose_mock.call_count == 3
@@ -1081,10 +1079,6 @@ def test_start_records_init_compose_failure_output(mocker: MockerFixture):
     assert "--- stderr ---" in err["body"]
     assert "init-err" in err["body"]
     assert run_compose_mock.call_args_list[2].args[1:2] == ("down",)
-    die_mock.assert_called_once_with(
-        "Failed to run init 'seed' for container 'api' in environment "
-        "'init-fail-env'."
-    )
 
 
 @pytest.mark.docker

--- a/src/tests/test_environment.py
+++ b/src/tests/test_environment.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -249,6 +250,74 @@ def test_delete_env_no(
     assert os.path.exists(
         env_dir
     ), f"directory {env_dir} does not exist after delete-no."
+
+
+@pytest.mark.env
+def test_delete_env_permission_denied_retry_with_sudo(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    result = runner.invoke(cli, ["env", "add", "default", "test-perm-1"])
+    assert result.exit_code == 0
+
+    mocker.patch("builtins.input", side_effect=["y", "y"])
+    mocker.patch(
+        "environment.environment.shutil.rmtree",
+        side_effect=[
+            PermissionError(13, "Permission denied", "data"),
+            None,
+        ],
+    )
+    mocker.patch(
+        "environment.environment.shutil.which", return_value="/usr/bin/sudo"
+    )
+    mock_run = mocker.patch(
+        "environment.environment.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=["sudo", "chown", "-R", "1000:1000", "/tmp/x"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        ),
+    )
+
+    result = runner.invoke(cli, ["env", "delete", "test-perm-1"])
+    assert result.exit_code == 0
+    assert "test-perm-1" in result.output
+
+    sm = ShepherdMng()
+    assert sm.configMng.get_environment("test-perm-1") is None
+    mock_run.assert_called_once()
+    assert mock_run.call_args[0][0][:3] == ["sudo", "chown", "-R"]
+
+
+@pytest.mark.env
+def test_delete_env_permission_denied_retry_declined(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    result = runner.invoke(cli, ["env", "add", "default", "test-perm-2"])
+    assert result.exit_code == 0
+
+    mocker.patch("builtins.input", side_effect=["y", "n"])
+    mocker.patch(
+        "environment.environment.shutil.rmtree",
+        side_effect=PermissionError(13, "Permission denied", "data"),
+    )
+    mocker.patch(
+        "environment.environment.shutil.which", return_value="/usr/bin/sudo"
+    )
+    mock_run = mocker.patch("environment.environment.subprocess.run")
+
+    result = runner.invoke(cli, ["env", "delete", "test-perm-2"])
+    assert result.exit_code == 1
+    assert "Failed to remove directory" in result.output
+
+    sm = ShepherdMng()
+    assert sm.configMng.get_environment("test-perm-2") is not None
+    mock_run.assert_not_called()
 
 
 @pytest.mark.env

--- a/src/tests/test_environment_mng.py
+++ b/src/tests/test_environment_mng.py
@@ -38,6 +38,7 @@ from environment.status_wait import (
     WaitForEnvStateHooks,
     render_moving_shadow_text,
     wait_for_env_state,
+    watch_probe_state,
 )
 from util.util import Util
 
@@ -1516,3 +1517,250 @@ def test_describe_env_with_details_renders_tree(mocker: MockerFixture):
 
     render_table.assert_called_once()
     console_print.assert_called_once_with("tree")
+
+
+# ---------------------------------------------------------------------------
+# watch_probe_state tests
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_live(mocker: MockerFixture) -> Any:
+    """Return a MagicMock that acts as a Live context manager."""
+    fake_live = mocker.MagicMock()
+    fake_live.__enter__ = mocker.Mock(return_value=fake_live)
+    fake_live.__exit__ = mocker.Mock(return_value=False)
+    mocker.patch("environment.status_wait.Live", return_value=fake_live)
+    return fake_live
+
+
+def test_watch_probe_state_fires_check_immediately(mocker: MockerFixture):
+    """check_probes is called on the first iteration."""
+    import threading
+
+    env = mocker.Mock()
+    env.is_command_log_enabled.return_value = False
+
+    check_done = threading.Event()
+
+    def fake_check(**kwargs: Any) -> list[Any]:
+        check_done.set()
+        return []
+
+    env.check_probes.side_effect = fake_check
+
+    fake_live = _make_fake_live(mocker)
+    mocker.patch(
+        "environment.status_wait.build_probe_status_tree",
+        return_value="rendered",
+    )
+
+    sleep_calls: dict[str, int] = {"count": 0}
+
+    def fake_sleep(seconds: float) -> None:
+        sleep_calls["count"] += 1
+        check_done.wait(timeout=2.0)
+        raise KeyboardInterrupt()
+
+    mocker.patch("environment.status_wait.time.sleep", side_effect=fake_sleep)
+
+    watch_probe_state(env, probe_tag=None, title="probes", poll_seconds=0)
+
+    env.check_probes.assert_called_once_with(
+        probe_tag=None, fail_fast=False, timeout_seconds=120
+    )
+    fake_live.update.assert_called()
+
+
+def test_watch_probe_state_passes_probe_tag(mocker: MockerFixture):
+    """probe_tag is forwarded verbatim to check_probes."""
+    import threading
+
+    env = mocker.Mock()
+    env.is_command_log_enabled.return_value = False
+
+    check_done = threading.Event()
+
+    def fake_check(**kwargs: Any) -> list[Any]:
+        check_done.set()
+        return []
+
+    env.check_probes.side_effect = fake_check
+
+    _make_fake_live(mocker)
+    mocker.patch(
+        "environment.status_wait.build_probe_status_tree",
+        return_value="rendered",
+    )
+
+    def fake_sleep(seconds: float) -> None:
+        check_done.wait(timeout=2.0)
+        raise KeyboardInterrupt()
+
+    mocker.patch("environment.status_wait.time.sleep", side_effect=fake_sleep)
+
+    watch_probe_state(env, probe_tag="health", title="probes", poll_seconds=0)
+
+    env.check_probes.assert_called_once_with(
+        probe_tag="health", fail_fast=False, timeout_seconds=120
+    )
+
+
+def test_watch_probe_state_suppresses_error_panel_while_check_running(
+    mocker: MockerFixture,
+):
+    """probe_error is None while a check is in flight."""
+    import threading
+
+    env = mocker.Mock()
+    env.is_command_log_enabled.return_value = False
+
+    check_started = threading.Event()
+    allow_finish = threading.Event()
+
+    def slow_check(**kwargs: Any) -> list[Any]:
+        check_started.set()
+        allow_finish.wait(timeout=2.0)
+        return []
+
+    env.check_probes.side_effect = slow_check
+
+    _make_fake_live(mocker)
+    build_mock = mocker.patch(
+        "environment.status_wait.build_probe_status_tree",
+        return_value="rendered",
+    )
+
+    def fake_sleep(seconds: float) -> None:
+        # Wait until the check has started, then interrupt before it finishes.
+        check_started.wait(timeout=2.0)
+        raise KeyboardInterrupt()
+
+    mocker.patch("environment.status_wait.time.sleep", side_effect=fake_sleep)
+
+    watch_probe_state(env, probe_tag=None, title="probes", poll_seconds=0)
+
+    # All renders while the check is in flight must have probe_error=None.
+    for call in build_mock.call_args_list:
+        assert call.kwargs.get("probe_error") is None
+
+    allow_finish.set()
+
+
+def test_watch_probe_state_shows_error_panel_after_failed_check(
+    mocker: MockerFixture,
+):
+    """probe_error is set in the render cycle after a failed check completes."""
+    import threading
+
+    env = mocker.Mock()
+    env.is_command_log_enabled.return_value = False
+
+    failed_result = SimpleNamespace(
+        tag="health",
+        exit_code=1,
+        stdout="out",
+        stderr="err",
+        timed_out=False,
+        duration_ms=50,
+    )
+
+    check_done = threading.Event()
+
+    def failing_check(**kwargs: Any) -> list[Any]:
+        result = [failed_result]
+        check_done.set()
+        return result
+
+    env.check_probes.side_effect = failing_check
+
+    _make_fake_live(mocker)
+    build_mock = mocker.patch(
+        "environment.status_wait.build_probe_status_tree",
+        return_value="rendered",
+    )
+
+    sleep_calls: dict[str, int] = {"count": 0}
+
+    def fake_sleep(seconds: float) -> None:
+        sleep_calls["count"] += 1
+        if sleep_calls["count"] == 1:
+            # Let the check finish before returning from the first sleep.
+            check_done.wait(timeout=2.0)
+        else:
+            raise KeyboardInterrupt()
+
+    mocker.patch("environment.status_wait.time.sleep", side_effect=fake_sleep)
+
+    watch_probe_state(env, probe_tag=None, title="probes", poll_seconds=0)
+
+    # At least one render after the check finished must carry probe_error.
+    error_renders = [
+        c
+        for c in build_mock.call_args_list
+        if c.kwargs.get("probe_error") is not None
+    ]
+    assert error_renders, "expected at least one render with probe_error set"
+
+
+def test_watch_probe_state_passes_command_log_when_enabled(
+    mocker: MockerFixture,
+):
+    """command_log and limit are forwarded to build_probe_status_tree."""
+    import threading
+
+    env = mocker.Mock()
+    env.is_command_log_enabled.return_value = True
+    env.get_command_log.return_value = ["cmd1", "cmd2"]
+    env.get_command_log_limit.return_value = 5
+
+    check_done = threading.Event()
+
+    def fake_check(**kwargs: Any) -> list[Any]:
+        check_done.set()
+        return []
+
+    env.check_probes.side_effect = fake_check
+
+    _make_fake_live(mocker)
+    build_mock = mocker.patch(
+        "environment.status_wait.build_probe_status_tree",
+        return_value="rendered",
+    )
+
+    sleep_calls: dict[str, int] = {"count": 0}
+
+    def fake_sleep(seconds: float) -> None:
+        sleep_calls["count"] += 1
+        check_done.wait(timeout=2.0)
+        raise KeyboardInterrupt()
+
+    mocker.patch("environment.status_wait.time.sleep", side_effect=fake_sleep)
+
+    watch_probe_state(env, probe_tag=None, title="probes", poll_seconds=0)
+
+    assert build_mock.called
+    last_call = build_mock.call_args
+    assert last_call.kwargs.get("command_log") == ["cmd1", "cmd2"]
+    assert last_call.kwargs.get("command_log_limit") == 5
+
+
+def test_watch_probe_state_keyboard_interrupt_exits_cleanly(
+    mocker: MockerFixture,
+):
+    """KeyboardInterrupt must not propagate out of watch_probe_state."""
+    env = mocker.Mock()
+    env.is_command_log_enabled.return_value = False
+    env.check_probes.return_value = []
+
+    _make_fake_live(mocker)
+    mocker.patch(
+        "environment.status_wait.build_probe_status_tree",
+        return_value="rendered",
+    )
+    mocker.patch(
+        "environment.status_wait.time.sleep",
+        side_effect=KeyboardInterrupt(),
+    )
+
+    # Must return normally — no exception.
+    watch_probe_state(env, probe_tag=None, title="probes", poll_seconds=0)

--- a/src/tests/test_plugin_runtime.py
+++ b/src/tests/test_plugin_runtime.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import os
 import shutil
 import tarfile
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -59,6 +58,7 @@ def _write_plugin_inventory(
 
 
 def _make_plugin_archive(
+    tmp_dir: str,
     plugin_id: str = "runtime-plugin",
     version: str = "1.0.0",
 ) -> str:
@@ -68,7 +68,6 @@ def _make_plugin_archive(
         / "plugins"
         / "runtime_plugin"
     )
-    tmp_dir = tempfile.mkdtemp()
     plugin_copy = os.path.join(tmp_dir, plugin_id)
     shutil.copytree(fixture_root, plugin_copy)
 
@@ -537,10 +536,13 @@ def test_startup_fails_for_invalid_plugin_entrypoint(
 
 @pytest.mark.shpd
 def test_plugin_install_rejects_duplicate_without_force(
-    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+    tmp_path: Path,
 ):
     """Installing an already-installed plugin without --force is an error."""
-    archive = _make_plugin_archive()
+    archive = _make_plugin_archive(str(tmp_path))
     runner.invoke(cli, ["plugin", "install", archive])
 
     result = runner.invoke(cli, ["plugin", "install", archive])
@@ -552,15 +554,18 @@ def test_plugin_install_rejects_duplicate_without_force(
 
 @pytest.mark.shpd
 def test_plugin_install_force_replaces_existing_plugin(
-    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+    tmp_path: Path,
 ):
     """--force replaces the plugin directory and updates the version."""
     shpd_path = shpd_conf[0]
     shpd_yaml = shpd_path / ".shpd.yaml"
-    archive_v1 = _make_plugin_archive(version="1.0.0")
+    archive_v1 = _make_plugin_archive(str(tmp_path / "v1"), version="1.0.0")
     runner.invoke(cli, ["plugin", "install", archive_v1])
 
-    archive_v2 = _make_plugin_archive(version="2.0.0")
+    archive_v2 = _make_plugin_archive(str(tmp_path / "v2"), version="2.0.0")
     result = runner.invoke(cli, ["plugin", "install", "--force", archive_v2])
 
     assert result.exit_code == 0
@@ -572,12 +577,15 @@ def test_plugin_install_force_replaces_existing_plugin(
 
 @pytest.mark.shpd
 def test_plugin_install_force_preserves_enabled_state_and_config(
-    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+    tmp_path: Path,
 ):
     """--force keeps the existing enabled flag and user config intact."""
     shpd_path = shpd_conf[0]
     shpd_yaml = shpd_path / ".shpd.yaml"
-    archive = _make_plugin_archive()
+    archive = _make_plugin_archive(str(tmp_path))
     runner.invoke(cli, ["plugin", "install", archive])
     runner.invoke(cli, ["plugin", "disable", "runtime-plugin"])
     stored = yaml.safe_load(shpd_yaml.read_text())

--- a/src/tests/test_plugin_runtime.py
+++ b/src/tests/test_plugin_runtime.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import os
 import shutil
+import tarfile
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -54,6 +56,32 @@ def _write_plugin_inventory(
     shpd_config = yaml.safe_load(read_fixture("shpd", "shpd.yaml"))
     shpd_config["plugins"] = plugins
     config_path.write_text(yaml.dump(shpd_config, sort_keys=False))
+
+
+def _make_plugin_archive(
+    plugin_id: str = "runtime-plugin",
+    version: str = "1.0.0",
+) -> str:
+    fixture_root = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "plugins"
+        / "runtime_plugin"
+    )
+    tmp_dir = tempfile.mkdtemp()
+    plugin_copy = os.path.join(tmp_dir, plugin_id)
+    shutil.copytree(fixture_root, plugin_copy)
+
+    descriptor_path = os.path.join(plugin_copy, "plugin.yaml")
+    descriptor = yaml.safe_load(Path(descriptor_path).read_text())
+    descriptor["id"] = plugin_id
+    descriptor["version"] = version
+    Path(descriptor_path).write_text(yaml.dump(descriptor, sort_keys=False))
+
+    archive_path = os.path.join(tmp_dir, f"{plugin_id}.tar.gz")
+    with tarfile.open(archive_path, "w:gz") as tar:
+        tar.add(plugin_copy, arcname=plugin_id)
+    return archive_path
 
 
 def _install_fixture_plugin(
@@ -505,3 +533,61 @@ def test_startup_fails_for_invalid_plugin_entrypoint(
 
     assert result.exit_code == 1
     assert "must implement ShepherdPlugin" in result.output
+
+
+@pytest.mark.shpd
+def test_plugin_install_rejects_duplicate_without_force(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    """Installing an already-installed plugin without --force is an error."""
+    archive = _make_plugin_archive()
+    runner.invoke(cli, ["plugin", "install", archive])
+
+    result = runner.invoke(cli, ["plugin", "install", archive])
+
+    assert result.exit_code == 1
+    assert "already installed" in result.output
+    assert "--force" in result.output
+
+
+@pytest.mark.shpd
+def test_plugin_install_force_replaces_existing_plugin(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    """--force replaces the plugin directory and updates the version."""
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    archive_v1 = _make_plugin_archive(version="1.0.0")
+    runner.invoke(cli, ["plugin", "install", archive_v1])
+
+    archive_v2 = _make_plugin_archive(version="2.0.0")
+    result = runner.invoke(cli, ["plugin", "install", "--force", archive_v2])
+
+    assert result.exit_code == 0
+    assert "installed" in result.output
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    plugin = next(p for p in stored["plugins"] if p["id"] == "runtime-plugin")
+    assert plugin["version"] == "2.0.0"
+
+
+@pytest.mark.shpd
+def test_plugin_install_force_preserves_enabled_state_and_config(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    """--force keeps the existing enabled flag and user config intact."""
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    archive = _make_plugin_archive()
+    runner.invoke(cli, ["plugin", "install", archive])
+    runner.invoke(cli, ["plugin", "disable", "runtime-plugin"])
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    stored["plugins"][0]["config"] = {"region": "us-east-1"}
+    shpd_yaml.write_text(yaml.dump(stored, sort_keys=False))
+
+    result = runner.invoke(cli, ["plugin", "install", "--force", archive])
+
+    assert result.exit_code == 0
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    plugin = next(p for p in stored["plugins"] if p["id"] == "runtime-plugin")
+    assert plugin["enabled"] is False
+    assert plugin["config"] == {"region": "us-east-1"}

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -929,7 +929,7 @@ def test_cli_start_env(
     result = runner.invoke(cli, ["env", "up"])
     assert result.exit_code == 0
     mock_start.assert_called_once_with(
-        mocker.ANY, timeout_seconds=60, watch=False, keep_output=False
+        mocker.ANY, timeout_seconds=120, watch=False, keep_output=False
     )
 
 
@@ -947,7 +947,7 @@ def test_cli_start_env_watch(
     result = runner.invoke(cli, ["env", "up", "--watch"])
     assert result.exit_code == 0
     mock_start.assert_called_once_with(
-        mocker.ANY, timeout_seconds=60, watch=True, keep_output=False
+        mocker.ANY, timeout_seconds=120, watch=True, keep_output=False
     )
 
 

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -1291,3 +1291,37 @@ def test_cli_check_probe_flag_all_with_probe_tag(
     result = runner.invoke(cli, ["probe", "check", "db-ready", "--all"])
     assert result.exit_code == 0
     check_probes.assert_called_once()
+
+
+@pytest.mark.shpd
+def test_cli_check_probe_watch(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    watch_probes = mocker.patch.object(EnvironmentMng, "watch_probes")
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(read_fixture("shpd", "shpd.yaml"))
+
+    result = runner.invoke(cli, ["probe", "check", "--watch"])
+    assert result.exit_code == 0
+    watch_probes.assert_called_once()
+    _, probe_tag = watch_probes.call_args.args
+    assert probe_tag is None
+
+
+@pytest.mark.shpd
+def test_cli_check_probe_watch_with_probe_tag(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    watch_probes = mocker.patch.object(EnvironmentMng, "watch_probes")
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(read_fixture("shpd", "shpd.yaml"))
+
+    result = runner.invoke(cli, ["probe", "check", "db-ready", "--watch"])
+    assert result.exit_code == 0
+    watch_probes.assert_called_once()
+    _, probe_tag = watch_probes.call_args.args
+    assert probe_tag == "db-ready"

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -929,7 +929,7 @@ def test_cli_start_env(
     result = runner.invoke(cli, ["env", "up"])
     assert result.exit_code == 0
     mock_start.assert_called_once_with(
-        mocker.ANY, timeout_seconds=60, watch=False
+        mocker.ANY, timeout_seconds=60, watch=False, keep_output=False
     )
 
 
@@ -947,7 +947,7 @@ def test_cli_start_env_watch(
     result = runner.invoke(cli, ["env", "up", "--watch"])
     assert result.exit_code == 0
     mock_start.assert_called_once_with(
-        mocker.ANY, timeout_seconds=60, watch=True
+        mocker.ANY, timeout_seconds=60, watch=True, keep_output=False
     )
 
 
@@ -968,6 +968,7 @@ def test_cli_start_env_with_timeout(
     assert mock_start.call_args.kwargs == {
         "timeout_seconds": 30,
         "watch": False,
+        "keep_output": False,
     }
 
 


### PR DESCRIPTION
## Summary

- `probe check -w/--watch`: live probe re-run loop with Rich animation and error panel
- `probe check --show-commands`: render recent commands panel in one-shot and watch modes
- `env up`: raise default timeout to 120 s, add `-t` shorthand, add `--keep-output`
- `env up`: fix race between `NonRecoverableStartError` and Rich Live display
- `env delete`: `sudo chown -R` recovery for Docker-written permission errors
- `plugin install --force`: force-reinstall preserving enabled state and user config
- `realize()`: make template file resources optional (descriptor-only templates)

## Test plan

- [ ] `cd src && pytest`
- [ ] `black src && isort src`
- [ ] `pyright src`
- [ ] Manual: `shepctl probe check -w`
- [ ] Manual: `shepctl env up --keep-output` on a failing env
- [ ] Manual: `shepctl plugin install --force <plugin>`

Fixes: #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)