### PR TITLE
feat(legal): introduce dual-license model (AGPL-3.0-only + commercial) with CLA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,3 +31,9 @@ to help! -->
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
+
+## Contributor License Agreement
+<!--- All contributors must sign the CLA before this PR can be merged. -->
+<!--- The CLA Assistant bot will post instructions if you have not yet signed. -->
+- [ ] I have signed the [Contributor License Agreement](../CLA.md)
+      (or I will follow the CLA Assistant bot instructions posted in this PR).

--- a/.github/cla_signatures.json
+++ b/.github/cla_signatures.json
@@ -1,0 +1,3 @@
+{
+  "signedContributors": []
+}

--- a/.github/cla_signatures.json
+++ b/.github/cla_signatures.json
@@ -1,3 +1,36 @@
 {
-  "signedContributors": []
+  "signedContributors": [
+    {
+      "name": "Giuseppe Baccini",
+      "id": 99738959,
+      "comment_id": 4158001267,
+      "created_at": "2026-03-30T20:33:11Z",
+      "repoId": "MoonyFringers/shepherd",
+      "pullRequestNo": 0
+    },
+    {
+      "name": "Alessio Pascucci",
+      "id": 4531376,
+      "comment_id": 4172878988,
+      "created_at": "2026-04-01T20:48:26Z",
+      "repoId": "MoonyFringers/shepherd",
+      "pullRequestNo": 0
+    },
+    {
+      "name": "Andrea Trasacco",
+      "id": 66999436,
+      "comment_id": 4172880767,
+      "created_at": "2026-04-01T20:48:47Z",
+      "repoId": "MoonyFringers/shepherd",
+      "pullRequestNo": 0
+    },
+    {
+      "name": "Luca Canessa",
+      "id": 56563397,
+      "comment_id": 4175236271,
+      "created_at": "2026-04-02T07:25:44Z",
+      "repoId": "MoonyFringers/shepherd",
+      "pullRequestNo": 0
+    }
+  ]
 }

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,60 @@
+name: CLA Assistant
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  pull-requests: write
+  statuses: write
+  contents: write
+
+jobs:
+  cla-check:
+    runs-on: ubuntu-latest
+
+    # Run on PR events or on comments posted to PRs (not plain issues).
+    if: >
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null)
+
+    steps:
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PAT with repo scope is required to write cla_signatures.json
+          # and post status checks on PRs from forks.
+          # Configure this secret in: Settings → Secrets → Actions.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: ".github/cla_signatures.json"
+          path-to-document: "https://github.com/MoonyFringers/shepherd/blob/main/CLA.md"
+          branch: "main"
+          # Bots that should be exempted from the CLA requirement.
+          allowlist: >
+            dependabot[bot],
+            github-actions[bot],
+            renovate[bot]
+          lock-pullrequest-aftermerge: false
+          custom-notsigned-prcomment: >
+            Thank you for your contribution!
+
+            Before this pull request can be reviewed and merged, you must sign
+            the **Shepherd Contributor License Agreement**.
+
+            Please read
+            [CLA.md](https://github.com/MoonyFringers/shepherd/blob/main/CLA.md)
+            and then reply to this comment with the exact phrase:
+
+            `I have read the CLA Document and I hereby sign the CLA`
+          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
+          custom-allsigned-prcomment: >
+            All contributors have signed the CLA. Thank you!

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -13,6 +13,16 @@ on:
 permissions:
   pull-requests: write
   statuses: write
+  # contents: write is required so the action can commit updated
+  # cla_signatures.json back to the repository when a contributor signs.
+  #
+  # Security note: this workflow uses pull_request_target (not pull_request)
+  # so it runs in the base-repo context with write access even for fork PRs.
+  # This is intentional and safe here because the action only reads PR
+  # metadata and posts comments — it never checks out or executes code from
+  # the contributor's branch. Do NOT add a checkout step to this workflow
+  # without carefully scoping it to the base branch (refs/heads/main), as
+  # that would open a supply-chain injection vector.
   contents: write
 
 jobs:
@@ -27,7 +37,12 @@ jobs:
 
     steps:
       - name: CLA Assistant
-        uses: contributor-assistant/github-action@v2.6.1
+        # Pinned to the exact commit SHA for supply-chain safety.
+        # contributor-assistant/github-action is archived (last release v2.6.1,
+        # 2024-09-26). The archived state means this SHA is immutable — no
+        # force-pushes possible — but also means no future security patches.
+        # If a maintained alternative becomes available, evaluate migrating.
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08  # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # A PAT with repo scope is required to write cla_signatures.json

--- a/CLA.md
+++ b/CLA.md
@@ -156,10 +156,9 @@ dedicated GitHub issue or release note) before the new version takes effect.
 ## 10. Governing Law
 
 This Agreement shall be governed by and construed in accordance with the laws
-of **[JURISDICTION — configure before publishing]**, without regard to its
-conflict-of-law provisions. Any dispute arising out of or in connection with
-this Agreement shall be subject to the exclusive jurisdiction of the courts
-of that jurisdiction.
+of **Italy**, without regard to its conflict-of-law provisions. Any dispute
+arising out of or in connection with this Agreement shall be subject to the
+exclusive jurisdiction of the **Tribunale di Pisa** (Court of Pisa).
 
 ---
 

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,148 @@
+# Shepherd Contributor License Agreement
+
+Version 1.0
+
+This Contributor License Agreement ("Agreement") is between
+**Moony Fringers** ("We", "Us", "Our") and the individual or legal entity
+making a Contribution ("You").
+
+By submitting a Contribution to this repository You accept and agree to the
+following terms for Your present and future Contributions. If You do not agree,
+do not submit Contributions.
+
+---
+
+## 1. Definitions
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that You intentionally submit
+to Moony Fringers for inclusion in, or documentation of, any of the projects
+owned or managed by Moony Fringers (the "Work"). "Submit" means any form of
+electronic, verbal, or written communication sent to Moony Fringers or its
+representatives, including but not limited to communication on electronic
+mailing lists, source code control systems, and issue tracking systems managed
+by or on behalf of Moony Fringers.
+
+---
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+Moony Fringers and to recipients of software distributed by Moony Fringers a
+**perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright
+license** to reproduce, prepare derivative works of, publicly display,
+publicly perform, **sublicense** (including under terms other than the AGPL,
+such as proprietary or commercial license terms chosen by Moony Fringers), and
+distribute Your Contributions and such derivative works in source or object
+form.
+
+> **Note for contributors:** You retain full copyright ownership of Your
+> Contributions. This is a license grant, not a copyright assignment. The
+> sublicensable nature of this grant is what enables Moony Fringers to offer
+> the Work under a dual-licensing model (open-source AGPL and commercial).
+
+---
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+Moony Fringers and to recipients of software distributed by Moony Fringers a
+**perpetual, worldwide, non-exclusive, royalty-free, irrevocable patent
+license** to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work. This license applies only to those patent claims licensable
+by You that are necessarily infringed by Your Contribution(s) alone or by the
+combination of Your Contribution(s) with the Work to which such
+Contribution(s) was submitted.
+
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Work to which You have contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Work shall terminate as of
+the date such litigation is filed.
+
+---
+
+## 4. You Retain Copyright
+
+This Agreement is a **license grant, not a copyright assignment**. You retain
+full copyright ownership of Your Contributions. Nothing in this Agreement
+restricts Your right to use, reproduce, modify, or license Your Contributions
+to any third party under any terms You choose.
+
+---
+
+## 5. Representations
+
+You represent that:
+
+**(a) Right to grant.** You are legally entitled to grant the licenses above.
+If Your employer has rights to intellectual property that You create (for
+example, as part of Your employment), You represent that: (i) You have received
+explicit permission from Your employer to make Contributions on behalf of that
+employer and to grant the licenses above, or (ii) Your employer has waived
+such rights for Your Contributions, or (iii) Your employer has executed a
+separate Corporate Contributor License Agreement with Moony Fringers.
+
+**(b) Original creation.** Your Contribution is Your original creation, or You
+have sufficient rights to submit it under this Agreement.
+
+**(c) No known encumbrances.** To the best of Your knowledge, Your Contribution
+does not violate the rights of any third party, including copyright, patent,
+trademark, or other intellectual property rights, and is not subject to any
+conflicting licenses.
+
+**(d) Duty to notify.** You agree to notify Moony Fringers promptly if any of
+the above representations become inaccurate in any respect.
+
+---
+
+## 6. Third-Party Contributions
+
+If You wish to submit work that is not Your original creation, You may submit
+it separately from any Contribution, identifying the complete details of its
+source and of any license or other restriction (including, but not limited to,
+related patents, trademarks, and license agreements) of which You are
+personally aware. Submit such third-party material as: "Submitted on behalf of
+a third party: [name] — original license: [license]".
+
+---
+
+## 7. No Obligation to Use
+
+This Agreement does not obligate Moony Fringers to accept, include, or use Your
+Contribution in any product or project. Moony Fringers may, in its sole
+discretion, decline to accept any Contribution.
+
+---
+
+## 8. Disclaimer of Warranties
+
+Unless required by applicable law or agreed to in writing, You provide Your
+Contributions on an **"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND**, either express or implied, including, without limitation, any warranties
+or conditions of title, non-infringement, merchantability, or fitness for a
+particular purpose.
+
+---
+
+## 9. How to Sign
+
+To sign this CLA, simply open a pull request against the
+[MoonyFringers/shepherd](https://github.com/MoonyFringers/shepherd) repository.
+The CLA Assistant bot will post a comment on your PR asking you to sign.
+
+To confirm your agreement, reply to the bot comment with the exact phrase:
+
+> **I have read the CLA Document and I hereby sign the CLA**
+
+Your GitHub username and the timestamp of your signature will be recorded in
+`.github/cla_signatures.json`. Your signature covers all past and future
+Contributions you submit to this repository.
+
+**Employed contributors:** If Section 5(a) applies to you, please ensure you
+have the appropriate employer authorization before signing.
+
+---
+
+*Moony Fringers — [github.com/MoonyFringers](https://github.com/MoonyFringers)*

--- a/CLA.md
+++ b/CLA.md
@@ -54,12 +54,18 @@ by You that are necessarily infringed by Your Contribution(s) alone or by the
 combination of Your Contribution(s) with the Work to which such
 Contribution(s) was submitted.
 
-If any entity institutes patent litigation against You or any other entity
-(including a cross-claim or counterclaim in a lawsuit) alleging that Your
-Contribution, or the Work to which You have contributed, constitutes direct or
-contributory patent infringement, then any patent licenses granted to that
-entity under this Agreement for that Contribution or Work shall terminate as of
-the date such litigation is filed.
+If any entity institutes patent litigation against any other entity (including
+a cross-claim or counterclaim in a lawsuit) alleging that Your Contribution,
+or the Work to which You have contributed, constitutes direct or contributory
+patent infringement, then:
+
+**(a)** any patent licenses granted to that entity under this Agreement for
+that Contribution or Work shall terminate as of the date such litigation is
+filed; and
+
+**(b)** if Moony Fringers institutes such litigation against You, all licenses
+granted to Moony Fringers under this Agreement with respect to Your
+Contributions shall likewise terminate as of the date such litigation is filed.
 
 ---
 
@@ -126,7 +132,38 @@ particular purpose.
 
 ---
 
-## 9. How to Sign
+## 9. Versioning and Amendments
+
+This Agreement is versioned. The version number appears at the top of this
+document. Moony Fringers may publish revised versions of the CLA from time to
+time.
+
+- **Past contributions** remain governed by the version of the CLA that was in
+  effect at the time of signing. A new version does not retroactively change
+  the terms under which prior contributions were made.
+- **Future contributions** submitted after a new version is published are
+  governed by the new version. If You do not agree to a new version, You must
+  stop submitting Contributions.
+- **Re-signature** is required when the version of the CLA changes. The CLA
+  Assistant bot will prompt unsigned contributors when a new version is in
+  effect.
+
+Moony Fringers will announce material changes via the repository (e.g., a
+dedicated GitHub issue or release note) before the new version takes effect.
+
+---
+
+## 10. Governing Law
+
+This Agreement shall be governed by and construed in accordance with the laws
+of **[JURISDICTION — configure before publishing]**, without regard to its
+conflict-of-law provisions. Any dispute arising out of or in connection with
+this Agreement shall be subject to the exclusive jurisdiction of the courts
+of that jurisdiction.
+
+---
+
+## 11. How to Sign
 
 To sign this CLA, simply open a pull request against the
 [MoonyFringers/shepherd](https://github.com/MoonyFringers/shepherd) repository.

--- a/CONTRIBUTION_GUIDELINES.md
+++ b/CONTRIBUTION_GUIDELINES.md
@@ -169,11 +169,34 @@ ensure a welcoming environment for all contributors.
 3. **Test your code**: Ensure that your changes do not break
    existing functionality by running tests locally.
 
-## Licensing
+## Licensing and Contributor License Agreement
 
-By contributing to this project, you agree that your
-contributions will be licensed under the project's
-[LICENSE](LICENSE).
+Shepherd Core Stack is dual-licensed under the
+[GNU Affero General Public License v3](LICENSE) (open source) and a
+[proprietary commercial license](LICENSE-COMMERCIAL) offered by Moony Fringers.
+
+To enable this dual-licensing model, **all contributors must sign the
+Shepherd [Contributor License Agreement](CLA.md) (CLA)** before their
+contributions can be accepted. The CLA grants Moony Fringers a perpetual,
+worldwide, sublicensable copyright and patent license over your contributions.
+**You retain full copyright ownership.**
+
+### How to sign
+
+The CLA is enforced automatically on every pull request via the CLA Assistant
+bot. When you open a PR, the bot will post a comment if you have not yet signed.
+To sign, read [CLA.md](CLA.md) and reply to the bot comment with:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your GitHub username is then recorded in `.github/cla_signatures.json`.
+
+**Employed contributors:** If you are contributing as part of your employment
+and your employer may have rights to your work, please review Section 5(a) of
+the CLA before signing and ensure you have the appropriate authorization.
+
+See [ADR-0005](docs/decisions/0005-dual-license-model.md) for the rationale
+behind this licensing model.
 
 Thank you for contributing! Together, we can make this project
 even better. If you have any questions, feel free to reach out.

--- a/LICENSE-COMMERCIAL
+++ b/LICENSE-COMMERCIAL
@@ -45,7 +45,7 @@ without the obligations of the AGPL.
 
 To inquire about a commercial license, contact Moony Fringers at:
 
-  licensing@moonyfringers.io        <-- CONFIGURE BEFORE PUBLISHING
+  licensing@moonyfringers.net        <-- CONFIGURE BEFORE PUBLISHING
 
 Please include in your message:
 

--- a/LICENSE-COMMERCIAL
+++ b/LICENSE-COMMERCIAL
@@ -45,7 +45,7 @@ without the obligations of the AGPL.
 
 To inquire about a commercial license, contact Moony Fringers at:
 
-  licensing@moonyfringers.net        <-- CONFIGURE BEFORE PUBLISHING
+  licensing@moonyfringers.net
 
 Please include in your message:
 

--- a/LICENSE-COMMERCIAL
+++ b/LICENSE-COMMERCIAL
@@ -1,0 +1,86 @@
+Shepherd Core Stack — Commercial License
+
+Copyright (c) 2025 Moony Fringers. All rights reserved.
+
+================================================================================
+
+1. Open-Source License
+----------------------
+
+Shepherd Core Stack is available as free, open-source software under the
+GNU Affero General Public License v3.0 (AGPL-3.0-only). The full text of
+this license is provided in the LICENSE file at the root of this repository.
+
+Under the AGPL, you may use, modify, and distribute Shepherd freely, provided
+that:
+
+  - All modifications and derivative works are distributed under the same AGPL
+    license.
+  - If you run a modified version of Shepherd to provide a network-accessible
+    service, you must make the complete corresponding source code available to
+    users of that service.
+
+2. Commercial License
+---------------------
+
+Moony Fringers offers a separate commercial license for individuals and
+organizations that cannot or do not wish to comply with the obligations of
+the AGPL-3.0, including but not limited to the following use cases:
+
+  - Incorporating Shepherd into proprietary, closed-source products or services.
+  - Distributing Shepherd as part of a product without fulfilling the AGPL
+    requirement to disclose corresponding source code modifications.
+  - Offering Shepherd-based functionality as a hosted service (SaaS) without
+    complying with the AGPL network-use source disclosure obligation.
+  - Redistributing Shepherd in compiled or binary form without meeting AGPL
+    source availability requirements.
+  - OEM, embedded, or white-label use of Shepherd in commercial products.
+
+The commercial license grants you the right to use, modify, and distribute
+Shepherd for these purposes under terms agreed upon with Moony Fringers,
+without the obligations of the AGPL.
+
+3. How to Obtain a Commercial License
+--------------------------------------
+
+To inquire about a commercial license, contact Moony Fringers at:
+
+  licensing@moonyfringers.io        <-- CONFIGURE BEFORE PUBLISHING
+
+Please include in your message:
+
+  - A description of your intended use case.
+  - Your organization name and size.
+  - Your preferred contact information.
+
+We will respond with applicable license terms and pricing.
+
+4. Contributor License Agreement
+---------------------------------
+
+All contributions to Shepherd require signing the Contributor License Agreement
+(CLA.md) located in this repository. The CLA grants Moony Fringers the
+sublicensable rights necessary to offer this dual-licensing model. Contributors
+retain full copyright ownership of their contributions.
+
+5. Third-Party Components
+--------------------------
+
+This commercial license applies only to Shepherd source code owned by
+Moony Fringers. Third-party components embedded in this repository remain
+subject to their original open-source licenses. A list of third-party
+dependencies and their licenses is available via the project's requirements
+files.
+
+6. No Warranty
+--------------
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. TO THE MAXIMUM EXTENT
+PERMITTED BY APPLICABLE LAW, MOONY FRINGERS SHALL NOT BE LIABLE FOR ANY
+CLAIM, DAMAGES, OR OTHER LIABILITY ARISING FROM THE USE OF THE SOFTWARE.
+
+================================================================================
+
+Moony Fringers — https://github.com/MoonyFringers

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Shepherd
 
-[![license](https://img.shields.io/badge/license-AGPL%20V3-blue)](https://github.com/MoonyFringers/shepherd/blob/master/LICENSE)
+[![license: AGPL v3](https://img.shields.io/badge/license-AGPL%20v3-blue)](LICENSE)
+[![Commercial License Available](https://img.shields.io/badge/license-Commercial-orange)](LICENSE-COMMERCIAL)
 [![codecov](https://codecov.io/gh/MoonyFringers/shepherd/branch/main/graph/badge.svg)](https://codecov.io/gh/MoonyFringers/shepherd)
 
 Shepherd is a specialized orchestration platform designed to streamline
@@ -91,6 +92,21 @@ local environment evolves independently for each developer.
 ## Develop Shepherd
 
 See our [development][development] documentation.
+
+## License
+
+Shepherd Core Stack is dual-licensed:
+
+- **Open Source (AGPL v3):** Free to use, modify, and distribute under the
+  terms of the [GNU Affero General Public License v3](LICENSE). Any
+  modifications used in network-accessible services must be made available
+  under the same license.
+- **Commercial:** A proprietary license is available for organizations that
+  require closed-source use, SaaS deployment without AGPL obligations, or
+  redistribution without source disclosure. See [LICENSE-COMMERCIAL](LICENSE-COMMERCIAL)
+  for details and contact information.
+
+All contributions require signing the [Contributor License Agreement](CLA.md).
 
 [issues]: https://github.com/MoonyFringers/shepherd/issues
 [Consuming Environment Images]: docs/env-consume.md

--- a/docs/decisions/0005-dual-license-model.md
+++ b/docs/decisions/0005-dual-license-model.md
@@ -1,0 +1,148 @@
+---
+status: "accepted"
+date: 2026-03-30
+decision-makers:
+  - '@luca-c-xcv'
+  - '@feed3r'
+  - '@giubacc'
+consulted: []
+informed: []
+---
+
+# Introduce Dual-Licensing Model (AGPL-3.0-only + Proprietary Commercial) with CLA
+
+## Context and Problem Statement
+
+Shepherd Core Stack is distributed exclusively under the GNU Affero General
+Public License v3 (ADR-0001). The AGPL fulfils the project's commitment to
+software freedom but prevents commercial adoption by organizations that cannot
+or will not comply with its copyleft and network-use source-disclosure
+obligations.
+
+To sustain the project financially while preserving the open-source
+distribution, Moony Fringers will offer a separate proprietary commercial
+license as a second tier alongside the AGPL. Dual-licensing under this model
+requires that Moony Fringers holds sufficient rights over all Contributions —
+specifically, the ability to sublicense contributions under terms other than
+the AGPL. This right cannot be assumed from a simple "contributions are
+licensed under the project license" statement; a formal Contributor License
+Agreement (CLA) is required.
+
+Additionally, this ADR establishes the AGPL variant as `AGPL-3.0-only`
+(replacing the prior "version 3 or any later version" phrasing in source
+headers). Locking to a specific version prevents ambiguity if a future AGPL
+release changes terms in a way that conflicts with the commercial tier.
+
+## Decision Drivers
+
+* The AGPL's copyleft obligations deter commercial adoption.
+* Moony Fringers needs a sustainable revenue model to fund continued
+  development.
+* Contributors must retain copyright ownership; full assignment is not
+  acceptable.
+* The dual-licensing model is legally sound only if Moony Fringers holds a
+  sublicensable license over all Contributions.
+* The CLA must be enforced automatically on new PRs to prevent coverage gaps.
+* Existing contributors must retroactively confirm consent before the commercial
+  tier can apply to their past contributions.
+
+## Considered Options
+
+* Keep AGPL-only — no commercial tier.
+* Dual-license with copyright assignment CLA (contributors transfer full
+  ownership to Moony Fringers).
+* **Dual-license with license-grant CLA** (contributors keep copyright, grant
+  Moony Fringers a broad sublicensable license). ← chosen
+* Adopt a source-available non-AGPL license (e.g., BSL, SSPL) instead of a
+  true proprietary commercial tier.
+
+## Decision Outcome
+
+Chosen option: **"Dual-license with license-grant CLA"**, because it enables
+the commercial tier without requiring contributors to surrender copyright.
+The license-grant model is well-precedented (Apache ICLA, MongoDB CLA,
+HashiCorp CLA) and legally sufficient for sublicensing to commercial customers.
+
+The CLA (see `CLA.md`) grants Moony Fringers a perpetual, worldwide,
+non-exclusive, royalty-free, irrevocable, sublicensable copyright and patent
+license over each Contribution, while the contributor retains full copyright
+ownership.
+
+### Consequences
+
+* **Good**, because AGPL distribution is unchanged — all open-source users
+  continue to receive the same rights they have today.
+* **Good**, because contributors retain copyright; the ask is smaller and more
+  contributor-friendly than full assignment.
+* **Good**, because the CLA Assistant GitHub Action automates enforcement for
+  all future contributions without manual gating.
+* **Good**, because the commercial tier provides a sustainable revenue path
+  without forking or fragmenting the codebase.
+* **Bad**, because retroactive consent is required from all existing
+  contributors. If any contributor refuses, their contributions must be audited
+  and either rewritten or a separate resolution reached before the commercial
+  tier can cover that code.
+* **Bad**, because new contributors must sign the CLA before their first PR is
+  merged, adding a small onboarding step.
+* **Bad**, because the CLA Assistant requires a `PERSONAL_ACCESS_TOKEN` secret
+  with `repo` scope in the repository settings.
+
+### Confirmation
+
+* `CLA.md` exists at the repository root and is referenced by the CLA
+  Assistant workflow.
+* `LICENSE-COMMERCIAL` exists at the repository root.
+* `.github/workflows/cla.yaml` is active and blocks PR merges for unsigned
+  contributors.
+* `.github/cla_signatures.json` captures all signatures (including retroactive
+  consent from existing contributors).
+* All existing contributors have signed or a documented resolution exists for
+  any exceptions.
+* `CONTRIBUTION_GUIDELINES.md` references the CLA and explains the signing
+  process.
+* `README.md` reflects dual licensing with updated badges and a License section.
+* Python source file headers use `SPDX-License-Identifier: AGPL-3.0-only` and
+  reference both `LICENSE` and `LICENSE-COMMERCIAL`.
+
+## Pros and Cons of the Options
+
+### Keep AGPL-only
+
+* **Good**, because no legal complexity is added.
+* **Good**, because contributor experience is unchanged.
+* **Bad**, because no sustainable commercial revenue path exists.
+
+### Dual-license with copyright assignment CLA
+
+* **Good**, because Moony Fringers gains unrestricted control over the
+  codebase.
+* **Bad**, because full assignment deters contributors who are not willing to
+  surrender copyright.
+* **Bad**, because assignment agreements are more legally burdensome in some
+  jurisdictions.
+
+### Dual-license with license-grant CLA
+
+* **Good**, because contributors retain copyright ownership.
+* **Good**, because it is legally sufficient to enable sublicensing.
+* **Neutral**, because it is a well-known model with abundant precedent.
+* **Bad**, because all existing contributions must be retroactively covered.
+
+### Source-available non-AGPL license (BSL, SSPL)
+
+* **Good**, because it can be implemented without a CLA.
+* **Bad**, because it would break the commitment to AGPL open-source
+  distribution made in ADR-0001.
+* **Bad**, because BSL and SSPL are not OSI-approved; the project would no
+  longer be open-source in the canonical sense.
+
+## More Information
+
+* [CLA.md](../../CLA.md) — the operative Contributor License Agreement
+* [LICENSE-COMMERCIAL](../../LICENSE-COMMERCIAL) — commercial license notice
+  and contact information
+* [ADR-0001](0001-shepherd-core-stack-license.md) — original AGPL license
+  decision
+* [CLA Assistant GitHub Action](https://github.com/contributor-assistant/github-action)
+* [Apache ICLA](https://www.apache.org/licenses/icla.pdf) — reference model
+  for license-grant CLAs

--- a/src/build.py
+++ b/src/build.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 import argparse
 import os

--- a/src/build.py
+++ b/src/build.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 import argparse
 import os

--- a/src/completion/__init__.py
+++ b/src/completion/__init__.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 from .completion import CompletionMng
 

--- a/src/completion/__init__.py
+++ b/src/completion/__init__.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from .completion import CompletionMng
 

--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from dataclasses import dataclass

--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from dataclasses import dataclass

--- a/src/completion/completion_env.py
+++ b/src/completion/completion_env.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from typing import Any, override

--- a/src/completion/completion_env.py
+++ b/src/completion/completion_env.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from typing import Any, override

--- a/src/completion/completion_mng.py
+++ b/src/completion/completion_mng.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from abc import ABC, abstractmethod

--- a/src/completion/completion_mng.py
+++ b/src/completion/completion_mng.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from abc import ABC, abstractmethod

--- a/src/completion/completion_plugin.py
+++ b/src/completion/completion_plugin.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 from typing import Any, override
 

--- a/src/completion/completion_plugin.py
+++ b/src/completion/completion_plugin.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from typing import Any, override
 

--- a/src/completion/completion_probe.py
+++ b/src/completion/completion_probe.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from typing import Any, override

--- a/src/completion/completion_probe.py
+++ b/src/completion/completion_probe.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from typing import Any, override

--- a/src/completion/completion_svc.py
+++ b/src/completion/completion_svc.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from typing import Any, override

--- a/src/completion/completion_svc.py
+++ b/src/completion/completion_svc.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from typing import Any, override

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from .config import (

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from .config import (

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 import json

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 import json

--- a/src/docker/__init__.py
+++ b/src/docker/__init__.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from .docker_compose_env import DockerComposeEnv

--- a/src/docker/__init__.py
+++ b/src/docker/__init__.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from .docker_compose_env import DockerComposeEnv

--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from __future__ import annotations

--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from __future__ import annotations

--- a/src/docker/docker_compose_svc.py
+++ b/src/docker/docker_compose_svc.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from __future__ import annotations

--- a/src/docker/docker_compose_svc.py
+++ b/src/docker/docker_compose_svc.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from __future__ import annotations

--- a/src/docker/docker_compose_util.py
+++ b/src/docker/docker_compose_util.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 import logging
 import subprocess

--- a/src/docker/docker_compose_util.py
+++ b/src/docker/docker_compose_util.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 import logging
 import subprocess

--- a/src/environment/__init__.py
+++ b/src/environment/__init__.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from .environment import Environment, EnvironmentFactory, EnvironmentMng

--- a/src/environment/__init__.py
+++ b/src/environment/__init__.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from .environment import Environment, EnvironmentFactory, EnvironmentMng

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from __future__ import annotations

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from __future__ import annotations

--- a/src/environment/render.py
+++ b/src/environment/render.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from __future__ import annotations
 

--- a/src/environment/render.py
+++ b/src/environment/render.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 from __future__ import annotations
 

--- a/src/environment/status_wait.py
+++ b/src/environment/status_wait.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from __future__ import annotations
 

--- a/src/environment/status_wait.py
+++ b/src/environment/status_wait.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 from __future__ import annotations
 

--- a/src/factory/__init__.py
+++ b/src/factory/__init__.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from factory.shpd_env_factory import ShpdEnvironmentFactory

--- a/src/factory/__init__.py
+++ b/src/factory/__init__.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from factory.shpd_env_factory import ShpdEnvironmentFactory

--- a/src/factory/shpd_env_factory.py
+++ b/src/factory/shpd_env_factory.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from typing import Any, override

--- a/src/factory/shpd_env_factory.py
+++ b/src/factory/shpd_env_factory.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from typing import Any, override

--- a/src/factory/shpd_svc_factory.py
+++ b/src/factory/shpd_svc_factory.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from typing import Any, override

--- a/src/factory/shpd_svc_factory.py
+++ b/src/factory/shpd_svc_factory.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from typing import Any, override

--- a/src/installer/__init__.py
+++ b/src/installer/__init__.py
@@ -3,4 +3,4 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.

--- a/src/installer/__init__.py
+++ b/src/installer/__init__.py
@@ -1,16 +1,6 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.

--- a/src/installer/install.py
+++ b/src/installer/install.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 import os
 import pwd

--- a/src/installer/install.py
+++ b/src/installer/install.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 import os
 import pwd

--- a/src/installer/repository_manager.py
+++ b/src/installer/repository_manager.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 import os
 from typing import List

--- a/src/installer/repository_manager.py
+++ b/src/installer/repository_manager.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+
 import os
 from typing import List
 

--- a/src/plugin/__init__.py
+++ b/src/plugin/__init__.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 """Public plugin APIs shared by the CLI bootstrap and external plugins."""
 

--- a/src/plugin/__init__.py
+++ b/src/plugin/__init__.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 """Public plugin APIs shared by the CLI bootstrap and external plugins."""
 

--- a/src/plugin/api.py
+++ b/src/plugin/api.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from __future__ import annotations
 

--- a/src/plugin/api.py
+++ b/src/plugin/api.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 from __future__ import annotations
 

--- a/src/plugin/context.py
+++ b/src/plugin/context.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 """Stable plugin context API injected into every plugin at startup.
 

--- a/src/plugin/context.py
+++ b/src/plugin/context.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 """Stable plugin context API injected into every plugin at startup.
 

--- a/src/plugin/plugin.py
+++ b/src/plugin/plugin.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from __future__ import annotations
 

--- a/src/plugin/plugin.py
+++ b/src/plugin/plugin.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 from __future__ import annotations
 

--- a/src/plugin/runtime.py
+++ b/src/plugin/runtime.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from __future__ import annotations
 

--- a/src/plugin/runtime.py
+++ b/src/plugin/runtime.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 from __future__ import annotations
 

--- a/src/service/__init__.py
+++ b/src/service/__init__.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from .service import Service, ServiceFactory, ServiceMng

--- a/src/service/__init__.py
+++ b/src/service/__init__.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from .service import Service, ServiceFactory, ServiceMng

--- a/src/service/render.py
+++ b/src/service/render.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/service/render.py
+++ b/src/service/render.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from __future__ import annotations
 

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from __future__ import annotations
 

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 from __future__ import annotations
 

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 import builtins

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 import builtins

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from __future__ import annotations
 

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 from __future__ import annotations
 

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 import os

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 import os

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 # flake8: noqa E501
 

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 # flake8: noqa E501
 

--- a/src/tests/test_environment.py
+++ b/src/tests/test_environment.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from __future__ import annotations
 

--- a/src/tests/test_environment.py
+++ b/src/tests/test_environment.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 from __future__ import annotations
 

--- a/src/tests/test_environment_mng.py
+++ b/src/tests/test_environment_mng.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from __future__ import annotations
 

--- a/src/tests/test_environment_mng.py
+++ b/src/tests/test_environment_mng.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 from __future__ import annotations
 

--- a/src/tests/test_install_utils.py
+++ b/src/tests/test_install_utils.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 import subprocess
 from typing import List

--- a/src/tests/test_install_utils.py
+++ b/src/tests/test_install_utils.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 import subprocess
 from typing import List

--- a/src/tests/test_installer.py
+++ b/src/tests/test_installer.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 import os
 import shutil

--- a/src/tests/test_installer.py
+++ b/src/tests/test_installer.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 import os
 import shutil

--- a/src/tests/test_plugin_runtime.py
+++ b/src/tests/test_plugin_runtime.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from __future__ import annotations
 

--- a/src/tests/test_plugin_runtime.py
+++ b/src/tests/test_plugin_runtime.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 from __future__ import annotations
 

--- a/src/tests/test_service.py
+++ b/src/tests/test_service.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from __future__ import annotations
 

--- a/src/tests/test_service.py
+++ b/src/tests/test_service.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 from __future__ import annotations
 

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from __future__ import annotations
 

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 from __future__ import annotations
 

--- a/src/tests/test_svc_docker_compose.py
+++ b/src/tests/test_svc_docker_compose.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 # flake8: noqa E501
 

--- a/src/tests/test_svc_docker_compose.py
+++ b/src/tests/test_svc_docker_compose.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 # flake8: noqa E501
 

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 from pathlib import Path
 

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 from pathlib import Path
 

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 from .logging import setup_logging

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 from .logging import setup_logging

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 import os

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 import os

--- a/src/util/logging.py
+++ b/src/util/logging.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 import logging
 import os

--- a/src/util/logging.py
+++ b/src/util/logging.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 import logging
 import os

--- a/src/util/util.py
+++ b/src/util/util.py
@@ -1,19 +1,9 @@
 # Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
 #
-# This file is part of Shepherd Core Stack
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
 
 
 import os

--- a/src/util/util.py
+++ b/src/util/util.py
@@ -3,7 +3,7 @@
 #
 # This file is part of Shepherd Core Stack.
 # Open-source: see LICENSE (AGPL-3.0-only).
-# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.io.
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
 import os


### PR DESCRIPTION
## Summary

Introduces a dual-licensing model (AGPL-3.0-only + proprietary commercial) with a Contributor License Agreement enforced via GitHub Actions.

- **`CLA.md`** — license-grant CLA: contributors keep copyright, grant Moony Fringers a perpetual, sublicensable copyright + patent license
- **`LICENSE-COMMERCIAL`** — contact-for-terms commercial license notice
- **`docs/decisions/0005-dual-license-model.md`** — MADR ADR documenting the decision and rationale
- **`.github/workflows/cla.yaml`** — CLA Assistant bot (blocks PRs from unsigned contributors)
- **`.github/cla_signatures.json`** — signature store (pre-seeded empty, populated by the bot)
- Updated `CONTRIBUTION_GUIDELINES.md`, `README.md`, PR template
- All `src/**/*.py` headers migrated from 16-line FSF AGPL format to 6-line SPDX dual-license format

Tracked in #191.

## ⚠️ Blockers before this PR can be merged

- [x] Retroactive CLA consent from all existing contributors (see #191)
- [x] Configure licensing contact email (replace placeholder `licensing@moonyfringers.net` in `LICENSE-COMMERCIAL` and source headers)
- [x] Add `PERSONAL_ACCESS_TOKEN` secret (repo scope) to repository Settings → Secrets → Actions

## Review focus

- CLA terms in `CLA.md` — are the grant scope and representations acceptable?
- `AGPL-3.0-only` lock in source headers (replaces prior "version 3 or any later version")
- Commercial license use cases in `LICENSE-COMMERCIAL`