### PR TITLE
test: improve test suite — readability, integration tests, and CI coverage

### DIFF
--- a/.github/workflows/install-test.yaml
+++ b/.github/workflows/install-test.yaml
@@ -1,0 +1,48 @@
+name: Installation Test
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  install-test:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set up Git repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.12"
+
+      - name: Create virtual environment
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install --upgrade pip
+          pip install -r src/requirements.txt
+
+      - name: Install shepctl from source
+        run: ./scripts/install.sh -m source -s install
+
+      - name: Verify installation
+        run: |
+          test -d /opt/shepctl
+          test -f /usr/local/bin/shepctl
+          shepctl --help
+
+      - name: Uninstall shepctl
+        run: ./scripts/install.sh uninstall
+
+      - name: Verify uninstallation
+        run: |
+          test ! -d /opt/shepctl
+          test ! -f /usr/local/bin/shepctl
+          ! command -v shepctl

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,44 @@
+name: Integration Tests
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Set up Git repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.12"
+
+      - name: Create and activate virtual environment
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install --upgrade pip
+          pip install -r src/requirements.txt -r src/requirements-dev.txt
+          pip install pytest pytest-cov
+
+      - name: Run Integration Tests
+        run: |
+          source .venv/bin/activate
+          cd src && pytest -m integration
+
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./src/coverage.xml
+          flags: integration
+          name: codecov-umbrella

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,9 +50,11 @@ repos:
     hooks:
       - id: flake8
         args: ["--config", "src/.flake8"]
+        exclude: ^src/tests/
 
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.408
     hooks:
       - id: pyright
         args: ["--project", "src/pyproject.toml"]
+        exclude: ^src/tests/

--- a/src/.flake8
+++ b/src/.flake8
@@ -6,6 +6,7 @@ exclude =
     .*,
     __pycache__,
     venv,
+    tests,
     frontend,
     node_modules,
     .tox,

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -36,5 +36,6 @@ addopts = [
   "--cov-report=xml",
   "--cov-report=html",
   "--cov-config=.coveragerc",
+  "-m", "not integration",
 ]
-markers = ["env", "svc", "cfg", "shpd", "compl", "docker"]
+markers = ["env", "svc", "cfg", "shpd", "compl", "docker", "integration"]

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -26,7 +26,7 @@ extend_skip_glob = ["resources/*"]
 typeCheckingMode = "strict"
 venvPath = ".."
 venv = ".venv"
-exclude = ["../examples"]
+exclude = ["../examples", "tests"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from shepctl import cli
+
+
+def read_fixture(*parts: str) -> str:
+    here = Path(__file__).resolve().parent
+    return (here / "fixtures" / Path(*parts)).read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def shpd_env(tmp_path: Path):
+    """
+    Set up a temporary shepherd home with the basic nginx env config.
+    Tears down running containers after the test (best-effort).
+    """
+    temp_home = tmp_path / "home"
+    temp_home.mkdir()
+
+    config_file = temp_home / ".shpd.conf"
+    values = read_fixture("basic", "values.conf")
+    config_file.write_text(values.replace("${test_path}", str(temp_home)))
+
+    shpd_yaml = temp_home / ".shpd.yaml"
+    shpd_yaml.write_text(read_fixture("basic", "shpd.yaml"))
+
+    os.environ["SHPD_CONF"] = str(config_file)
+
+    yield temp_home
+
+    CliRunner().invoke(cli, ["env", "halt"])
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -37,18 +37,23 @@ def shpd_env(tmp_path: Path):
     shpd_yaml = temp_home / ".shpd.yaml"
     shpd_yaml.write_text(read_fixture("basic", "shpd.yaml"))
 
+    prev = os.environ.get("SHPD_CONF")
     os.environ["SHPD_CONF"] = str(config_file)
 
     yield temp_home
 
     CliRunner().invoke(cli, ["env", "halt"])
+    if prev is None:
+        os.environ.pop("SHPD_CONF", None)
+    else:
+        os.environ["SHPD_CONF"] = prev
 
 
 @pytest.fixture
 def shpd_gated_env(tmp_path: Path):
     """
     Set up a temporary shepherd home with the probe-gated env config
-    (web ungated + cache gated on the 'ready' probe).
+    (web ungated + api gated on the trivially-passing 'warmup' probe).
     Tears down running containers after the test (best-effort).
     """
     temp_home = tmp_path / "home"
@@ -61,11 +66,16 @@ def shpd_gated_env(tmp_path: Path):
     shpd_yaml = temp_home / ".shpd.yaml"
     shpd_yaml.write_text(read_fixture("gated", "shpd.yaml"))
 
+    prev = os.environ.get("SHPD_CONF")
     os.environ["SHPD_CONF"] = str(config_file)
 
     yield temp_home
 
     CliRunner().invoke(cli, ["env", "halt"])
+    if prev is None:
+        os.environ.pop("SHPD_CONF", None)
+    else:
+        os.environ["SHPD_CONF"] = prev
 
 
 @pytest.fixture
@@ -86,11 +96,16 @@ def shpd_redis_gated_env(tmp_path: Path):
     shpd_yaml = temp_home / ".shpd.yaml"
     shpd_yaml.write_text(read_fixture("gated_redis", "shpd.yaml"))
 
+    prev = os.environ.get("SHPD_CONF")
     os.environ["SHPD_CONF"] = str(config_file)
 
     yield temp_home
 
     CliRunner().invoke(cli, ["env", "halt"])
+    if prev is None:
+        os.environ.pop("SHPD_CONF", None)
+    else:
+        os.environ["SHPD_CONF"] = prev
 
 
 @pytest.fixture

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -45,5 +45,54 @@ def shpd_env(tmp_path: Path):
 
 
 @pytest.fixture
+def shpd_gated_env(tmp_path: Path):
+    """
+    Set up a temporary shepherd home with the probe-gated env config
+    (web ungated + cache gated on the 'ready' probe).
+    Tears down running containers after the test (best-effort).
+    """
+    temp_home = tmp_path / "home"
+    temp_home.mkdir()
+
+    config_file = temp_home / ".shpd.conf"
+    values = read_fixture("gated", "values.conf")
+    config_file.write_text(values.replace("${test_path}", str(temp_home)))
+
+    shpd_yaml = temp_home / ".shpd.yaml"
+    shpd_yaml.write_text(read_fixture("gated", "shpd.yaml"))
+
+    os.environ["SHPD_CONF"] = str(config_file)
+
+    yield temp_home
+
+    CliRunner().invoke(cli, ["env", "halt"])
+
+
+@pytest.fixture
+def shpd_redis_gated_env(tmp_path: Path):
+    """
+    Two-level probe-gated env: cache (redis) starts ungated, frontend
+    (nginx) starts only after the cache-ready probe connects to the live
+    redis. This exercises a real health-check gate rather than a trivial
+    always-passing probe.
+    """
+    temp_home = tmp_path / "home"
+    temp_home.mkdir()
+
+    config_file = temp_home / ".shpd.conf"
+    values = read_fixture("gated_redis", "values.conf")
+    config_file.write_text(values.replace("${test_path}", str(temp_home)))
+
+    shpd_yaml = temp_home / ".shpd.yaml"
+    shpd_yaml.write_text(read_fixture("gated_redis", "shpd.yaml"))
+
+    os.environ["SHPD_CONF"] = str(config_file)
+
+    yield temp_home
+
+    CliRunner().invoke(cli, ["env", "halt"])
+
+
+@pytest.fixture
 def runner() -> CliRunner:
     return CliRunner()

--- a/src/tests/integration/fixtures/basic/shpd.yaml
+++ b/src/tests/integration/fixtures/basic/shpd.yaml
@@ -1,0 +1,54 @@
+templates_path: ${templates_path}
+envs_path: ${envs_path}
+volumes_path: ${volumes_path}
+staging_area:
+  volumes_path: ${staging_area_volumes_path}
+  images_path: ${staging_area_images_path}
+env_templates: []
+service_templates: []
+envs:
+  - template: default
+    factory: docker-compose
+    tag: integ-basic
+    services:
+      - tag: web
+        factory: docker
+        template: default
+        service_class: null
+        labels: []
+        properties: {}
+        upstreams: []
+        containers:
+          - tag: nginx
+            image: nginx:1.27-alpine
+            hostname: web
+            container_name: null
+            workdir: null
+            volumes: []
+            environment: []
+            ports: []
+            networks:
+              - default
+            extra_hosts: []
+            build: null
+            inits: null
+        start: null
+        status:
+          active: true
+          rendered_config: null
+    probes: []
+    networks:
+      - tag: default
+        name: null
+        external: false
+        driver: bridge
+        attachable: true
+        enable_ipv6: false
+        driver_opts: null
+        ipam: null
+    volumes: []
+    ready:
+      when_probes: []
+    status:
+      active: true
+      rendered_config: null

--- a/src/tests/integration/fixtures/basic/values.conf
+++ b/src/tests/integration/fixtures/basic/values.conf
@@ -1,0 +1,10 @@
+shpd_path=${test_path}
+templates_path=${shpd_path}/templates
+envs_path=${shpd_path}/envs
+volumes_path=${shpd_path}/volumes
+staging_area_volumes_path=${shpd_path}/sa_volumes
+staging_area_images_path=${shpd_path}/sa_images
+log_file=${shpd_path}/logs/shepctl.log
+log_level=WARNING
+log_stdout=false
+log_format=%(asctime)s - %(levelname)s - %(message)s

--- a/src/tests/integration/fixtures/gated/shpd.yaml
+++ b/src/tests/integration/fixtures/gated/shpd.yaml
@@ -1,0 +1,99 @@
+templates_path: ${templates_path}
+envs_path: ${envs_path}
+volumes_path: ${volumes_path}
+staging_area:
+  volumes_path: ${staging_area_volumes_path}
+  images_path: ${staging_area_images_path}
+env_templates: []
+service_templates: []
+envs:
+  - template: default
+    factory: docker-compose
+    tag: integ-gated
+    services:
+      - tag: web
+        factory: docker
+        template: default
+        service_class: null
+        labels: []
+        properties: {}
+        upstreams: []
+        containers:
+          - tag: nginx
+            image: nginx:1.27-alpine
+            hostname: web
+            container_name: null
+            workdir: null
+            volumes: []
+            environment: []
+            ports: []
+            networks:
+              - default
+            extra_hosts: []
+            build: null
+            inits: null
+        start: null
+        status:
+          active: true
+          rendered_config: null
+      - tag: api
+        factory: docker
+        template: default
+        service_class: null
+        labels: []
+        properties: {}
+        upstreams: []
+        containers:
+          - tag: nginx
+            image: nginx:1.27-alpine
+            hostname: api
+            container_name: null
+            workdir: null
+            volumes: []
+            environment: []
+            ports: []
+            networks:
+              - default
+            extra_hosts: []
+            build: null
+            inits: null
+        start:
+          when_probes:
+            - warmup
+        status:
+          active: true
+          rendered_config: null
+    probes:
+      - tag: warmup
+        container:
+          tag: warmup
+          image: nginx:1.27-alpine
+          hostname: null
+          container_name: null
+          workdir: null
+          volumes: []
+          environment: []
+          ports: []
+          networks:
+            - default
+          extra_hosts: []
+          build: null
+          inits: null
+        script: "sh -lc 'true'"
+        script_path: null
+    networks:
+      - tag: default
+        name: null
+        external: false
+        driver: bridge
+        attachable: true
+        enable_ipv6: false
+        driver_opts: null
+        ipam: null
+    volumes: []
+    ready:
+      when_probes:
+        - warmup
+    status:
+      active: true
+      rendered_config: null

--- a/src/tests/integration/fixtures/gated/values.conf
+++ b/src/tests/integration/fixtures/gated/values.conf
@@ -1,0 +1,10 @@
+shpd_path=${test_path}
+templates_path=${shpd_path}/templates
+envs_path=${shpd_path}/envs
+volumes_path=${shpd_path}/volumes
+staging_area_volumes_path=${shpd_path}/sa_volumes
+staging_area_images_path=${shpd_path}/sa_images
+log_file=${shpd_path}/logs/shepctl.log
+log_level=WARNING
+log_stdout=false
+log_format=%(asctime)s - %(levelname)s - %(message)s

--- a/src/tests/integration/fixtures/gated_redis/shpd.yaml
+++ b/src/tests/integration/fixtures/gated_redis/shpd.yaml
@@ -1,0 +1,99 @@
+templates_path: ${templates_path}
+envs_path: ${envs_path}
+volumes_path: ${volumes_path}
+staging_area:
+  volumes_path: ${staging_area_volumes_path}
+  images_path: ${staging_area_images_path}
+env_templates: []
+service_templates: []
+envs:
+  - template: default
+    factory: docker-compose
+    tag: integ-redis-gated
+    services:
+      - tag: cache
+        factory: docker
+        template: default
+        service_class: null
+        labels: []
+        properties: {}
+        upstreams: []
+        containers:
+          - tag: redis
+            image: redis:7-alpine
+            hostname: cache
+            container_name: null
+            workdir: null
+            volumes: []
+            environment: []
+            ports: []
+            networks:
+              - default
+            extra_hosts: []
+            build: null
+            inits: null
+        start: null
+        status:
+          active: true
+          rendered_config: null
+      - tag: frontend
+        factory: docker
+        template: default
+        service_class: null
+        labels: []
+        properties: {}
+        upstreams: []
+        containers:
+          - tag: nginx
+            image: nginx:1.27-alpine
+            hostname: frontend
+            container_name: null
+            workdir: null
+            volumes: []
+            environment: []
+            ports: []
+            networks:
+              - default
+            extra_hosts: []
+            build: null
+            inits: null
+        start:
+          when_probes:
+            - cache-ready
+        status:
+          active: true
+          rendered_config: null
+    probes:
+      - tag: cache-ready
+        container:
+          tag: cache-ready
+          image: redis:7-alpine
+          hostname: null
+          container_name: null
+          workdir: null
+          volumes: []
+          environment: []
+          ports: []
+          networks:
+            - default
+          extra_hosts: []
+          build: null
+          inits: null
+        script: "sh -lc 'redis-cli -h cache ping | grep -q PONG'"
+        script_path: null
+    networks:
+      - tag: default
+        name: null
+        external: false
+        driver: bridge
+        attachable: true
+        enable_ipv6: false
+        driver_opts: null
+        ipam: null
+    volumes: []
+    ready:
+      when_probes:
+        - cache-ready
+    status:
+      active: true
+      rendered_config: null

--- a/src/tests/integration/fixtures/gated_redis/values.conf
+++ b/src/tests/integration/fixtures/gated_redis/values.conf
@@ -1,0 +1,10 @@
+shpd_path=${test_path}
+templates_path=${shpd_path}/templates
+envs_path=${shpd_path}/envs
+volumes_path=${shpd_path}/volumes
+staging_area_volumes_path=${shpd_path}/sa_volumes
+staging_area_images_path=${shpd_path}/sa_images
+log_file=${shpd_path}/logs/shepctl.log
+log_level=WARNING
+log_stdout=false
+log_format=%(asctime)s - %(levelname)s - %(message)s

--- a/src/tests/integration/test_env_lifecycle.py
+++ b/src/tests/integration/test_env_lifecycle.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from shepctl import cli
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=5
+        ).returncode
+        != 0,
+        reason="Docker daemon not available",
+    ),
+]
+
+
+def test_basic_env_up_down(shpd_env: Path, runner: CliRunner):
+    result = runner.invoke(cli, ["env", "up"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(cli, ["env", "status"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(cli, ["env", "halt"])
+    assert result.exit_code == 0, result.output
+
+
+def test_env_up_is_idempotent(shpd_env: Path, runner: CliRunner):
+    result = runner.invoke(cli, ["env", "up"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(cli, ["env", "up"])
+    assert result.exit_code == 0, result.output
+
+
+def test_env_halt_on_stopped_env_is_safe(shpd_env: Path, runner: CliRunner):
+    # halt without a prior up should not crash
+    result = runner.invoke(cli, ["env", "halt"])
+    assert result.exit_code == 0, result.output

--- a/src/tests/integration/test_env_probes.py
+++ b/src/tests/integration/test_env_probes.py
@@ -31,8 +31,8 @@ def test_gated_service_starts_after_probe_passes(
     shpd_gated_env: Path, runner: CliRunner
 ):
     # env up runs the full gate/probe loop: web starts immediately,
-    # then the 'ready' probe fires against the live cache container,
-    # and cache starts once the probe passes.
+    # the 'warmup' probe fires (trivially passing), and api starts
+    # once the probe passes.
     result = runner.invoke(cli, ["env", "up"])
     assert result.exit_code == 0, result.output
 

--- a/src/tests/integration/test_env_probes.py
+++ b/src/tests/integration/test_env_probes.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from shepctl import cli
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=5
+        ).returncode
+        != 0,
+        reason="Docker daemon not available",
+    ),
+]
+
+
+def test_gated_service_starts_after_probe_passes(
+    shpd_gated_env: Path, runner: CliRunner
+):
+    # env up runs the full gate/probe loop: web starts immediately,
+    # then the 'ready' probe fires against the live cache container,
+    # and cache starts once the probe passes.
+    result = runner.invoke(cli, ["env", "up"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(cli, ["env", "status"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(cli, ["env", "halt"])
+    assert result.exit_code == 0, result.output
+
+
+def test_env_reload_is_safe(shpd_gated_env: Path, runner: CliRunner):
+    result = runner.invoke(cli, ["env", "up"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(cli, ["env", "reload"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(cli, ["env", "halt"])
+    assert result.exit_code == 0, result.output
+
+
+def test_real_healthcheck_gate_opens_after_redis_is_ready(
+    shpd_redis_gated_env: Path, runner: CliRunner
+):
+    # cache (redis) starts ungated; frontend (nginx) is gated on the
+    # cache-ready probe which runs `redis-cli -h cache ping`.  The gate
+    # opens as soon as redis is accepting connections (~1 s), then
+    # frontend starts.  This exercises a real service health-check rather
+    # than a trivially-passing probe.
+    result = runner.invoke(cli, ["env", "up"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(cli, ["env", "status"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(cli, ["env", "halt"])
+    assert result.exit_code == 0, result.output

--- a/src/tests/integration/test_plugin.py
+++ b/src/tests/integration/test_plugin.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+from __future__ import annotations
+
+import shutil
+import tarfile
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from shepctl import cli
+
+pytestmark = pytest.mark.integration
+
+# hello-plugin lives at examples/plugins/hello-plugin/ relative to repo root.
+# From src/tests/integration/ we go up three levels to reach the repo root.
+_HELLO_PLUGIN_SRC = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "examples"
+    / "plugins"
+    / "hello-plugin"
+)
+
+
+def _make_hello_plugin_archive(tmp_path: Path) -> Path:
+    plugin_copy = tmp_path / "hello-plugin"
+    shutil.copytree(_HELLO_PLUGIN_SRC, plugin_copy)
+    archive = tmp_path / "hello-plugin.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(plugin_copy, arcname="hello-plugin")
+    return archive
+
+
+def test_plugin_install_and_list(
+    shpd_env: Path, runner: CliRunner, tmp_path: Path
+):
+    archive = _make_hello_plugin_archive(tmp_path)
+
+    result = runner.invoke(cli, ["plugin", "install", str(archive)])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(cli, ["plugin", "list"])
+    assert result.exit_code == 0, result.output
+    assert "hello-plugin" in result.output
+
+
+def test_plugin_command_available_after_install(
+    shpd_env: Path, runner: CliRunner, tmp_path: Path
+):
+    archive = _make_hello_plugin_archive(tmp_path)
+    runner.invoke(cli, ["plugin", "install", str(archive)])
+
+    result = runner.invoke(cli, ["hello", "greet"])
+    assert result.exit_code == 0, result.output
+    assert "Hello, world!" in result.output
+
+    result = runner.invoke(cli, ["hello", "greet", "Alice"])
+    assert result.exit_code == 0, result.output
+    assert "Hello, Alice!" in result.output
+
+
+def test_plugin_remove(shpd_env: Path, runner: CliRunner, tmp_path: Path):
+    archive = _make_hello_plugin_archive(tmp_path)
+    runner.invoke(cli, ["plugin", "install", str(archive)])
+
+    result = runner.invoke(cli, ["plugin", "remove", "hello-plugin"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(cli, ["plugin", "list"])
+    assert result.exit_code == 0, result.output
+    assert "hello-plugin" not in result.output

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -5,15 +5,13 @@
 # Open-source: see LICENSE (AGPL-3.0-only).
 # Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
-# flake8: noqa E501
-
 from __future__ import annotations
 
 import os
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
 import pytest
 import yaml
@@ -46,7 +44,7 @@ def normalize_expected_bind_paths(content: str) -> str:
 
 def mock_subprocess_with_running_ps(mocker: MockerFixture):
     def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
-        cmd = cast(list[str], args[0]) if args else []
+        cmd = args[0] if args else []
         if "ps" in cmd:
             return subprocess.CompletedProcess(
                 args=cmd,
@@ -665,7 +663,7 @@ def test_start_impl_starts_only_available_gates(mocker: MockerFixture):
             }
         ),
     )
-    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), cast(Any, env_cfg))
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
 
     run_compose_mock = mocker.patch(
         "docker.docker_compose_env.run_compose",
@@ -714,7 +712,7 @@ def test_start_impl_logs_compose_command_with_category(mocker: MockerFixture):
     env = DockerComposeEnv(
         mocker.Mock(),
         mocker.Mock(),
-        cast(Any, env_cfg),
+        env_cfg,
         cli_flags={"show_commands": True, "show_commands_limit": 5},
     )
 
@@ -751,7 +749,7 @@ def test_start_impl_records_compose_failure_output(mocker: MockerFixture):
     env = DockerComposeEnv(
         mocker.Mock(),
         mocker.Mock(),
-        cast(Any, env_cfg),
+        env_cfg,
         cli_flags={"show_commands": True, "show_commands_limit": 5},
     )
 
@@ -784,7 +782,7 @@ def test_start_rolls_back_with_stop_on_non_recoverable_gate_failure(
         volumes=[],
         status=SimpleNamespace(rendered_config=None),
     )
-    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), cast(Any, env_cfg))
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
     rendered_map = {
         "ungated": "name: rollback-env\nservices:\n  app: {}\n",
     }
@@ -828,32 +826,29 @@ def test_start_runs_init_when_probe_turns_true(mocker: MockerFixture):
         volumes=[],
         status=SimpleNamespace(rendered_config=None),
     )
-    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), cast(Any, env_cfg))
-    env.services = cast(
-        list[Any],
-        [
-            SimpleNamespace(
-                svcCfg=SimpleNamespace(
-                    tag="db",
-                    start=None,
-                    containers=[
-                        SimpleNamespace(
-                            tag="pg",
-                            run_container_name="db-init-env",
-                            inits=[
-                                SimpleNamespace(
-                                    tag="create-user",
-                                    script="echo init ok",
-                                    script_path=None,
-                                    when_probes=["ready"],
-                                )
-                            ],
-                        )
-                    ],
-                )
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    env.services = [
+        SimpleNamespace(
+            svcCfg=SimpleNamespace(
+                tag="db",
+                start=None,
+                containers=[
+                    SimpleNamespace(
+                        tag="pg",
+                        run_container_name="db-init-env",
+                        inits=[
+                            SimpleNamespace(
+                                tag="create-user",
+                                script="echo init ok",
+                                script_path=None,
+                                when_probes=["ready"],
+                            )
+                        ],
+                    )
+                ],
             )
-        ],
-    )
+        )
+    ]
     rendered_map = {
         "ungated": "name: init-env\nservices:\n  db-init-env: {}\n",
         "ready": "name: init-env\nservices:\n  ready-svc: {}\n",
@@ -912,44 +907,41 @@ def test_start_runs_init_in_enclosing_container(mocker: MockerFixture):
         volumes=[],
         status=SimpleNamespace(rendered_config=None),
     )
-    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), cast(Any, env_cfg))
-    env.services = cast(
-        list[Any],
-        [
-            SimpleNamespace(
-                svcCfg=SimpleNamespace(
-                    tag="svc",
-                    start=None,
-                    containers=[
-                        SimpleNamespace(
-                            tag="api",
-                            run_container_name="api-enclosing-env",
-                            inits=[
-                                SimpleNamespace(
-                                    tag="init-api",
-                                    script="echo api",
-                                    script_path=None,
-                                    when_probes=[],
-                                )
-                            ],
-                        ),
-                        SimpleNamespace(
-                            tag="worker",
-                            run_container_name="worker-enclosing-env",
-                            inits=[
-                                SimpleNamespace(
-                                    tag="init-worker",
-                                    script="echo worker",
-                                    script_path=None,
-                                    when_probes=[],
-                                )
-                            ],
-                        ),
-                    ],
-                )
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    env.services = [
+        SimpleNamespace(
+            svcCfg=SimpleNamespace(
+                tag="svc",
+                start=None,
+                containers=[
+                    SimpleNamespace(
+                        tag="api",
+                        run_container_name="api-enclosing-env",
+                        inits=[
+                            SimpleNamespace(
+                                tag="init-api",
+                                script="echo api",
+                                script_path=None,
+                                when_probes=[],
+                            )
+                        ],
+                    ),
+                    SimpleNamespace(
+                        tag="worker",
+                        run_container_name="worker-enclosing-env",
+                        inits=[
+                            SimpleNamespace(
+                                tag="init-worker",
+                                script="echo worker",
+                                script_path=None,
+                                when_probes=[],
+                            )
+                        ],
+                    ),
+                ],
             )
-        ],
-    )
+        )
+    ]
     rendered_map = {
         "ungated": (
             "name: enclosing-env\n"
@@ -1010,34 +1002,31 @@ def test_start_records_init_compose_failure_output(mocker: MockerFixture):
     env = DockerComposeEnv(
         mocker.Mock(),
         mocker.Mock(),
-        cast(Any, env_cfg),
+        env_cfg,
         cli_flags={"show_commands": True, "show_commands_limit": 5},
     )
-    env.services = cast(
-        list[Any],
-        [
-            SimpleNamespace(
-                svcCfg=SimpleNamespace(
-                    tag="svc",
-                    start=None,
-                    containers=[
-                        SimpleNamespace(
-                            tag="api",
-                            run_container_name="api-init-fail-env",
-                            inits=[
-                                SimpleNamespace(
-                                    tag="seed",
-                                    script="echo seed",
-                                    script_path=None,
-                                    when_probes=[],
-                                )
-                            ],
-                        )
-                    ],
-                )
+    env.services = [
+        SimpleNamespace(
+            svcCfg=SimpleNamespace(
+                tag="svc",
+                start=None,
+                containers=[
+                    SimpleNamespace(
+                        tag="api",
+                        run_container_name="api-init-fail-env",
+                        inits=[
+                            SimpleNamespace(
+                                tag="seed",
+                                script="echo seed",
+                                script_path=None,
+                                when_probes=[],
+                            )
+                        ],
+                    )
+                ],
             )
-        ],
-    )
+        )
+    ]
     rendered_map = {
         "ungated": "name: init-fail-env\nservices:\n  api-init-fail-env: {}\n",
     }
@@ -1098,32 +1087,29 @@ def test_start_does_not_rerun_init_across_probe_poll_cycles(
         volumes=[],
         status=SimpleNamespace(rendered_config=None),
     )
-    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), cast(Any, env_cfg))
-    env.services = cast(
-        list[Any],
-        [
-            SimpleNamespace(
-                svcCfg=SimpleNamespace(
-                    tag="svc",
-                    start=SimpleNamespace(when_probes=["ready"]),
-                    containers=[
-                        SimpleNamespace(
-                            tag="api",
-                            run_container_name="api-init-dedup-env",
-                            inits=[
-                                SimpleNamespace(
-                                    tag="seed",
-                                    script="echo seed once",
-                                    script_path=None,
-                                    when_probes=["ready"],
-                                )
-                            ],
-                        )
-                    ],
-                )
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    env.services = [
+        SimpleNamespace(
+            svcCfg=SimpleNamespace(
+                tag="svc",
+                start=SimpleNamespace(when_probes=["ready"]),
+                containers=[
+                    SimpleNamespace(
+                        tag="api",
+                        run_container_name="api-init-dedup-env",
+                        inits=[
+                            SimpleNamespace(
+                                tag="seed",
+                                script="echo seed once",
+                                script_path=None,
+                                when_probes=["ready"],
+                            )
+                        ],
+                    )
+                ],
             )
-        ],
-    )
+        )
+    ]
     rendered_map = {
         "ungated": "name: init-dedup-env\nservices:\n  base: {}\n",
         "ready": "name: init-dedup-env\nservices:\n  api-init-dedup-env: {}\n",
@@ -1195,7 +1181,7 @@ def test_render_target_merged_includes_gated_services(mocker: MockerFixture):
         volumes=[],
         status=SimpleNamespace(rendered_config=None),
     )
-    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), cast(Any, env_cfg))
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
 
     rendered_map = {
         "ungated": "name: merge-env\nservices: {base: {}}\n",
@@ -1218,7 +1204,7 @@ def test_render_target_grouped_uses_literal_blocks(mocker: MockerFixture):
         volumes=[],
         status=SimpleNamespace(rendered_config=None),
     )
-    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), cast(Any, env_cfg))
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
 
     rendered_map = {
         "ungated": "name: group-env\nservices: {base: {}}\n",
@@ -1240,7 +1226,7 @@ def test_start_loops_and_unblocks_gated_compose(mocker: MockerFixture):
         status=SimpleNamespace(rendered_config=None),
     )
     config_mng = mocker.Mock()
-    env = DockerComposeEnv(config_mng, mocker.Mock(), cast(Any, env_cfg))
+    env = DockerComposeEnv(config_mng, mocker.Mock(), env_cfg)
 
     rendered_map = {
         "ungated": "name: loop-env\nservices: {}\n",
@@ -1289,7 +1275,7 @@ def test_start_retries_gates_until_probe_turns_true(mocker: MockerFixture):
         volumes=[],
         status=SimpleNamespace(rendered_config=None),
     )
-    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), cast(Any, env_cfg))
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
 
     rendered_map = {
         "ungated": "name: retry-env\nservices: {}\n",

--- a/src/tests/test_environment_mng.py
+++ b/src/tests/test_environment_mng.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import time
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
 import pytest
 from pytest_mock import MockerFixture
@@ -210,7 +210,7 @@ def test_stop_env_no_wait_skips_wait_for_down(mocker: MockerFixture):
     wait_mock = mocker.patch.object(mng, "wait_for_env_down")
     mocker.patch.object(mng, "get_environment_from_cfg", return_value=env)
 
-    mng.stop_env(cast(Any, env_cfg), wait=False)
+    mng.stop_env(env_cfg, wait=False)
 
     wait_mock.assert_not_called()
     env.stop.assert_called_once_with()
@@ -395,7 +395,7 @@ def test_status_env_watch_delegates_to_waiter(mocker: MockerFixture):
     mocker.patch.object(mng, "get_environment_from_cfg", return_value=env)
     wait_mock = mocker.patch.object(mng, "wait_for_env_up")
 
-    mng.status_env(cast(Any, env_cfg), watch=True)
+    mng.status_env(env_cfg, watch=True)
 
     wait_mock.assert_called_once_with(
         env,
@@ -432,12 +432,12 @@ def test_status_env_renders_tree(mocker: MockerFixture):
     fake_console = mocker.Mock()
     mocker.patch.object(Util, "console", fake_console)
 
-    mng.status_env(cast(Any, env_cfg), watch=False)
+    mng.status_env(env_cfg, watch=False)
 
     collect_mock.assert_called_once_with(env, include_gates=False)
-    printed_group = cast(Group, fake_console.print.call_args.args[0])
-    printed_tree = cast(Tree, printed_group.renderables[0])
-    summary = cast(Text, printed_group.renderables[1])
+    printed_group = fake_console.print.call_args.args[0]
+    printed_tree = printed_group.renderables[0]
+    summary = printed_group.renderables[1]
     assert str(printed_tree.label) == "[bold white]env-1[/bold white]"
     service_node = printed_tree.children[0]
     assert str(service_node.label) == "[bold cyan]svc-1[/bold cyan]"
@@ -447,24 +447,17 @@ def test_status_env_renders_tree(mocker: MockerFixture):
 
 def test_format_service_gate_glyphs_states(mocker: MockerFixture):
     mng = _new_environment_mng(mocker)
-    mng_any = cast(Any, mng)
 
     gated = SimpleNamespace(
         svcCfg=SimpleNamespace(start=SimpleNamespace(when_probes=["p2", "p1"]))
     )
     ungated = SimpleNamespace(svcCfg=SimpleNamespace(start=None))
 
-    assert (
-        mng_any._format_service_gate_glyphs(cast(Any, ungated))
-        == "[dim]-[/dim]"
-    )
-    assert (
-        mng_any._format_service_gate_glyphs(cast(Any, gated))
-        == "[dim]·[/dim][dim]·[/dim]"
-    )
+    assert mng._format_service_gate_glyphs(ungated) == "[dim]-[/dim]"
+    assert mng._format_service_gate_glyphs(gated) == "[dim]·[/dim][dim]·[/dim]"
 
-    glyphs = mng_any._format_service_gate_glyphs(
-        cast(Any, gated),
+    glyphs = mng._format_service_gate_glyphs(
+        gated,
         gate_status={"p1": True, "p2": False},
     )
     assert "[bold red]✗[/bold red]" in glyphs
@@ -473,7 +466,6 @@ def test_format_service_gate_glyphs_states(mocker: MockerFixture):
 
 def test_format_service_gate_details_sorted_and_colored(mocker: MockerFixture):
     mng = _new_environment_mng(mocker)
-    mng_any = cast(Any, mng)
 
     gated = SimpleNamespace(
         svcCfg=SimpleNamespace(
@@ -482,13 +474,10 @@ def test_format_service_gate_details_sorted_and_colored(mocker: MockerFixture):
     )
     ungated = SimpleNamespace(svcCfg=SimpleNamespace(start=None))
 
-    assert (
-        mng_any._format_service_gate_details(cast(Any, ungated))
-        == "[dim]-[/dim]"
-    )
+    assert mng._format_service_gate_details(ungated) == "[dim]-[/dim]"
 
-    details = mng_any._format_service_gate_details(
-        cast(Any, gated),
+    details = mng._format_service_gate_details(
+        gated,
         gate_status={"alpha": True, "beta": False, "zeta": None},
     )
     assert details.find("alpha") < details.find("beta") < details.find("zeta")
@@ -499,7 +488,7 @@ def test_format_service_gate_details_sorted_and_colored(mocker: MockerFixture):
 
 def test_evaluate_gate_status_success_and_exception(mocker: MockerFixture):
     mng = _new_environment_mng(mocker)
-    mng_any = cast(Any, mng)
+
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
 
@@ -509,14 +498,14 @@ def test_evaluate_gate_status_success_and_exception(mocker: MockerFixture):
         ProbeRunResult(tag="c", exit_code=0, timed_out=True),
     ]
 
-    status = mng_any._evaluate_gate_status(env, {"a", "b", "c", "d"})
+    status = mng._evaluate_gate_status(env, {"a", "b", "c", "d"})
     assert status["a"] is True
     assert status["b"] is False
     assert status["c"] is False
     assert status["d"] is None
 
     env.check_probes.side_effect = RuntimeError("probe error")
-    status_err = mng_any._evaluate_gate_status(env, {"a", "b"})
+    status_err = mng._evaluate_gate_status(env, {"a", "b"})
     assert status_err == {"a": None, "b": None}
 
 
@@ -531,8 +520,8 @@ def test_build_probe_status_tree_returns_colored_probe_nodes():
         title="[white]env-1[/white] probes",
     )
     assert isinstance(renderable, Group)
-    tree = cast(Tree, renderable.renderables[0])
-    summary = cast(Text, renderable.renderables[1])
+    tree = renderable.renderables[0]
+    summary = renderable.renderables[1]
     assert str(tree.label) == "[white]env-1[/white] probes"
     child_labels = [str(child.label) for child in tree.children]
     assert "[green]ok-probe[/green]" in child_labels
@@ -559,7 +548,7 @@ def test_check_probes_renders_probe_status_tree(mocker: MockerFixture):
     fake_console = mocker.Mock()
     mocker.patch.object(Util, "console", fake_console)
 
-    exit_code = mng.check_probes(cast(Any, env_cfg), probe_tag=None)
+    exit_code = mng.check_probes(env_cfg, probe_tag=None)
 
     assert exit_code == 0
     build_tree.assert_called_once()
@@ -568,7 +557,7 @@ def test_check_probes_renders_probe_status_tree(mocker: MockerFixture):
 
 def test_build_env_status_tree_with_command_log_panel(mocker: MockerFixture):
     mng = _new_environment_mng(mocker)
-    mng_any = cast(Any, mng)
+
     grouped = {
         "svc-1": [
             [
@@ -580,7 +569,7 @@ def test_build_env_status_tree_with_command_log_panel(mocker: MockerFixture):
         ]
     }
 
-    renderable = mng_any._build_env_status_tree(
+    renderable = mng._build_env_status_tree(
         "env-1",
         grouped,
         command_log=["[green]ok[/green]", "[red]fail[/red]"],
@@ -600,7 +589,7 @@ def test_build_env_status_tree_with_command_log_panel(mocker: MockerFixture):
 
 def test_build_env_status_tree_with_error_panel(mocker: MockerFixture):
     mng = _new_environment_mng(mocker)
-    mng_any = cast(Any, mng)
+
     grouped = {
         "svc-1": [
             [
@@ -612,7 +601,7 @@ def test_build_env_status_tree_with_error_panel(mocker: MockerFixture):
         ]
     }
 
-    renderable = mng_any._build_env_status_tree(
+    renderable = mng._build_env_status_tree(
         "env-1",
         grouped,
         command_log=["[green]ok[/green]"],
@@ -653,8 +642,8 @@ def test_build_env_status_tree_returns_tree_with_service_metadata():
     )
 
     assert isinstance(renderable, Group)
-    tree = cast(Tree, renderable.renderables[0])
-    summary = cast(Text, renderable.renderables[1])
+    tree = renderable.renderables[0]
+    summary = renderable.renderables[1]
     assert str(tree.label) == "[bold white]env-1[/bold white]"
     service_node = tree.children[0]
     assert str(service_node.label) == "[bold cyan]svc-1[/bold cyan]"
@@ -678,7 +667,7 @@ def test_build_env_status_tree_manager_method_returns_tree(
     mocker: MockerFixture,
 ):
     mng = _new_environment_mng(mocker)
-    mng_any = cast(Any, mng)
+
     grouped = {
         "svc-1": [
             [
@@ -690,7 +679,7 @@ def test_build_env_status_tree_manager_method_returns_tree(
         ]
     }
 
-    renderable = mng_any._build_env_status_tree("env-1", grouped)
+    renderable = mng._build_env_status_tree("env-1", grouped)
 
     assert isinstance(renderable, Group)
     assert isinstance(renderable.renderables[0], Tree)
@@ -715,7 +704,7 @@ def test_build_env_status_tree_omits_gates_node_without_probes():
     )
 
     assert isinstance(renderable, Group)
-    tree = cast(Tree, renderable.renderables[0])
+    tree = renderable.renderables[0]
     service_node = tree.children[0]
     child_labels = [str(child.label) for child in service_node.children]
     assert "[cyan]gates[/cyan]" not in child_labels
@@ -744,7 +733,7 @@ def test_build_env_status_tree_applies_flash_to_changed_nodes():
         flashing_probes={("svc-1", "probe-a")},
     )
 
-    tree = cast(Tree, cast(Group, renderable).renderables[0])
+    tree = renderable.renderables[0]
     service_node = tree.children[0]
     gates_node = service_node.children[0]
     gate_labels = [str(child.label) for child in gates_node.children]
@@ -776,7 +765,7 @@ def test_build_env_status_tree_applies_flash_to_changed_summary_values():
         flashing_summary_keys={"RUNNING", "GATES OK"},
     )
 
-    summary = cast(Text, cast(Group, renderable).renderables[1])
+    summary = renderable.renderables[1]
     assert "RUNNING: 1" in summary.plain
     assert "GATES OK: 1" in summary.plain
     assert len(summary.spans) >= 2
@@ -791,7 +780,6 @@ def test_collect_env_status_includes_probe_details_for_tree_view(
     mocker: MockerFixture,
 ):
     mng = _new_environment_mng(mocker)
-    mng_any = cast(Any, mng)
 
     container = SimpleNamespace(tag="cnt-a", run_container_name="svc-a-cnt")
     svc = SimpleNamespace(
@@ -805,7 +793,7 @@ def test_collect_env_status_includes_probe_details_for_tree_view(
     env.status.return_value = [{"Service": "svc-a-cnt", "State": "running"}]
     env.get_services.return_value = [svc]
 
-    grouped, _, _, _ = mng_any._collect_env_status(
+    grouped, _, _, _ = mng._collect_env_status(
         env,
         gate_status={"p1": True, "p2": None},
     )
@@ -815,7 +803,6 @@ def test_collect_env_status_includes_probe_details_for_tree_view(
 
 def test_collect_env_status_details_row_shape(mocker: MockerFixture):
     mng = _new_environment_mng(mocker, cli_flags={"details": True})
-    mng_any = cast(Any, mng)
 
     container = SimpleNamespace(tag="cnt-a", run_container_name="svc-a-cnt")
     svc = SimpleNamespace(
@@ -829,11 +816,9 @@ def test_collect_env_status_details_row_shape(mocker: MockerFixture):
     env.status.return_value = [{"Service": "svc-a-cnt", "State": "running"}]
     env.get_services.return_value = [svc]
 
-    grouped, all_running, any_running, has_containers = (
-        mng_any._collect_env_status(
-            env,
-            gate_status={"p1": True, "p2": None},
-        )
+    grouped, all_running, any_running, has_containers = mng._collect_env_status(
+        env,
+        gate_status={"p1": True, "p2": None},
     )
     assert all_running is True
     assert any_running is True
@@ -845,7 +830,6 @@ def test_collect_env_status_details_row_shape(mocker: MockerFixture):
 
 def test_collect_env_status_can_omit_gate_details(mocker: MockerFixture):
     mng = _new_environment_mng(mocker)
-    mng_any = cast(Any, mng)
 
     container = SimpleNamespace(tag="cnt-a", run_container_name="svc-a-cnt")
     svc = SimpleNamespace(
@@ -859,12 +843,10 @@ def test_collect_env_status_can_omit_gate_details(mocker: MockerFixture):
     env.status.return_value = [{"Service": "svc-a-cnt", "State": "running"}]
     env.get_services.return_value = [svc]
 
-    grouped, all_running, any_running, has_containers = (
-        mng_any._collect_env_status(
-            env,
-            gate_status={"p1": True, "p2": None},
-            include_gates=False,
-        )
+    grouped, all_running, any_running, has_containers = mng._collect_env_status(
+        env,
+        gate_status={"p1": True, "p2": None},
+        include_gates=False,
     )
 
     assert all_running is True

--- a/src/tests/test_install_utils.py
+++ b/src/tests/test_install_utils.py
@@ -7,7 +7,6 @@
 
 import subprocess
 from pathlib import Path
-from typing import List
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -67,9 +66,9 @@ class TestInstallUtils:
             mock_result.stdout = "test output"
             mock_run.return_value = mock_result
 
-            result_capture: subprocess.CompletedProcess[str] = Util.run_command(
+            result_capture = Util.run_command(
                 ["echo", "test"], capture_output=True
-            )  # type: ignore[assignment]
+            )
             assert result_capture.stdout == "test output"
 
         # Test command failure
@@ -84,11 +83,7 @@ class TestInstallUtils:
         with patch("subprocess.run") as mock_run:
             error = subprocess.CalledProcessError(1, ["echo", "test"])
             mock_run.side_effect = error
-            result_noexit: (
-                subprocess.CompletedProcess[str] | subprocess.CalledProcessError
-            ) = Util.run_command(
-                ["echo", "test"], check=False
-            )  # type: ignore[type-arg]
+            result_noexit = Util.run_command(["echo", "test"], check=False)
             assert isinstance(result_noexit, subprocess.CalledProcessError)
 
     def test_get_current_user(self):
@@ -171,7 +166,7 @@ class TestInstallUtils:
 
         # Define a simplified version of the function for testing
         def simplified_install_packages(distro: str) -> None:
-            missing_pkgs: List[str] = ["pkg1"]  # Simulate a missing package
+            missing_pkgs = ["pkg1"]  # Simulate a missing package
             print("Simulated missing packages:", missing_pkgs)  # Debug print
             # Call install_missing_packages directly
             RepositoryManager.install_missing_packages(distro, missing_pkgs)
@@ -202,12 +197,8 @@ class TestInstallUtils:
         """Test that install_packages correctly identifies missing packages."""
 
         # Create a simplified version of the function for testing
-        def simplified_check_and_install(
-            distro: str,
-            pkgs: List[str],
-            check_results: List[bool],
-        ) -> None:
-            missing: List[str] = []
+        def simplified_check_and_install(distro, pkgs, check_results):
+            missing = []
             for i, pkg in enumerate(pkgs):
                 # Use the provided check results
                 # instead of calling check_package_installed
@@ -220,9 +211,9 @@ class TestInstallUtils:
                 RepositoryManager.install_missing_packages(distro, missing)
 
         # Set up our test packages and check results
-        test_pkgs: List[str] = ["pkg1", "pkg2", "pkg3"]
+        test_pkgs = ["pkg1", "pkg2", "pkg3"]
         # pkg1 and pkg3 are installed, pkg2 is missing
-        check_results: List[bool] = [True, False, True]
+        check_results = [True, False, True]
 
         with (
             patch(

--- a/src/tests/test_plugin_runtime.py
+++ b/src/tests/test_plugin_runtime.py
@@ -552,9 +552,7 @@ def test_attach_managers_populates_plugin_contexts(
     )
 
     shepherd = ShepherdMng()
-    runtime_mng: PluginRuntimeMng = (
-        shepherd.pluginRuntimeMng  # type: ignore[assignment]
-    )
+    runtime_mng: PluginRuntimeMng = shepherd.pluginRuntimeMng
 
     # Pre-bootstrap: build a fresh runtime with no managers passed in.
     runtime_no_managers = PluginRuntimeMng(shepherd.configMng)

--- a/src/tests/test_svc_docker_compose.py
+++ b/src/tests/test_svc_docker_compose.py
@@ -5,14 +5,11 @@
 # Open-source: see LICENSE (AGPL-3.0-only).
 # Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
-# flake8: noqa E501
-
 from __future__ import annotations
 
 import os
 import subprocess
 from pathlib import Path
-from typing import cast
 
 import pytest
 import yaml
@@ -44,11 +41,7 @@ def mock_subprocess_with_running_ps(mocker: MockerFixture):
     def fake_run(
         *args: object, **kwargs: object
     ) -> subprocess.CompletedProcess[str]:
-        cmd = (
-            cast(list[str], args[0])
-            if args and isinstance(args[0], list)
-            else []
-        )
+        cmd = args[0] if args and isinstance(args[0], list) else []
         if "ps" in cmd:
             return subprocess.CompletedProcess(
                 args=cmd,


### PR DESCRIPTION
## Summary

- Remove pyright/flake8 enforcement from `src/tests/` and clean up forced patterns (`cast`, `type: ignore`, `mng_any` indirection for private method calls)
- Add integration tests with real Docker: basic env lifecycle, probe-gated environments, two-level redis health-check gate, plugin lifecycle
- Add GitHub Actions workflow for integration tests (`pytest -m integration`)
- Add GitHub Actions workflow for installation/uninstallation testing (`scripts/install.sh` source method end-to-end)

## Test plan

- [x] Unit tests still pass: `cd src && pytest`
- [x] Integration tests pass locally (requires Docker): `cd src && pytest -m integration -v`
- [x] CI: `Unit Tests`, `Integration Tests`, and `Installation Test` workflows all green on this PR

Fixes: #198