### PR TITLE
feat(remote): write ADR-0006 and scaffold storage/remote module skeletons

### DIFF
--- a/docs/decisions/0006-remote-storage-deduplication.md
+++ b/docs/decisions/0006-remote-storage-deduplication.md
@@ -1,0 +1,288 @@
+---
+status: "accepted"
+date: 2026-04-12
+decision-makers:
+  - '@giubacc'
+---
+
+# Remote Storage Deduplication for Shepherd Environments
+
+## Context and Problem Statement
+
+Shepherd environments include the state of backing services (e.g. Postgres
+database dumps, Redis snapshots) alongside service definitions. When a user
+wants to persist or share an environment they must produce an archive
+containing all of this state and upload it to remote storage (FTP server,
+S3 bucket, or similar).
+
+The naive approach — one monolithic `.tar.gz` per backup — is wasteful: if
+only the database changed between two backups, all unchanged service data
+(other DB tables, uploaded files, runtime state) is retransmitted in full.
+On a slow uplink or a large database this makes frequent backups impractical.
+
+How do we reduce the data transferred on each backup while keeping the remote
+backend fully passive (no server-side agent, no compute)?
+
+## Decision Drivers
+
+- Remote storage is passive: FTP, S3, or any object/file store with
+  read/write/list only. No server-side compute can be assumed.
+- All deduplication intelligence must live on the client.
+- Multiple clients may write to the same remote concurrently without
+  corrupting data.
+- A client must enumerate available environments and snapshots with minimal
+  round-trips.
+- New storage transports (S3, Azure Blob, SFTP, …) must be addable as
+  plugins without modifying the core.
+
+## Considered Options
+
+- Monolithic `.tar.gz` — one file per snapshot, no dedup.
+- rsync delta over the monolithic archive — requires SSH/rsync server-side.
+- bsdiff patches over the previous snapshot — no cross-environment sharing;
+  requires storing the previous archive to apply the patch.
+- Content-defined chunking with a passive chunk store.
+
+## Decision Outcome
+
+Chosen option: **content-defined chunking with a passive chunk store**,
+because it is the only approach that satisfies all constraints (passive
+backend, client-only logic, cross-environment dedup, and pluggable
+transports).
+
+### Algorithm
+
+Instead of uploading a monolithic archive, the client:
+
+1. Produces an **uncompressed `.tar` stream** of the environment directory
+   and all associated host-mounted volumes.
+2. Splits the stream into variable-length chunks using **FastCDC**
+   (content-defined chunking). Chunking is performed on the *uncompressed*
+   stream — this is critical for chunk stability across backups;
+   recompressing with a different window state would shift all boundaries.
+3. Compresses each chunk individually with **Zstd**.
+4. Hashes each compressed chunk with **SHA-256** to produce a content
+   address.
+5. Checks the remote store for which chunk hashes already exist (strategy
+   is backend-specific — see below).
+6. Uploads only the missing chunks.
+7. Writes a **snapshot manifest** (JSON) listing the ordered chunk hashes
+   required to reconstruct the archive, plus rich environment metadata.
+8. Updates the per-environment `latest.json` pointer and the global
+   `index.json` catalogue.
+
+This gives natural deduplication across environments and across time: if
+two environments share a common dataset (e.g. the same initial DB seed), or
+a new snapshot differs from the previous one only in recently changed rows,
+the shared data is stored exactly once.
+
+### Remote Storage Layout
+
+```text
+remote-storage/
+├── index/
+│   └── index.json          # global catalogue — fetch once for discovery
+├── envs/
+│   └── <env-name>/
+│       ├── latest.json     # pointer to most recent snapshot id
+│       └── snapshots/
+│           ├── <snapshot-id>.json   # manifest: metadata + chunk list
+│           └── ...
+└── chunks/
+    ├── ab/                 # first 2 hex chars = shard subfolder
+    │   └── ab3f1c9d...
+    └── ...
+```
+
+Sharding by 2-character prefix mirrors git's object store and limits any
+single FTP directory listing to ≤ 256 entries.
+
+### Key Parameter Decisions
+
+| Parameter | Value | Rationale |
+| --- | --- | --- |
+| Hash | SHA-256 (`hashlib`) | stdlib, no native build |
+| Chunk sizes | min 512 KB / avg 2 MB / max 8 MB | good dedup; tunable |
+| Snapshot ID | `{ISO-8601-UTC}-{6-hex-sha256(manifest)}` | readable + safe |
+| FTP check | `NLST` shard-listing → in-memory set | avoids O(n) MLST |
+| Manifest | `@dataclass` + `json`, `from_dict`/`to_dict` | config.py style |
+| Local cache | opt-in LRU, max-bytes, NullLocalChunkCache no-op | 0 overhead |
+
+### sudo-aware tar
+
+DBMS containers often write data under a non-root UID mapped from the host.
+When `os.access(path, os.R_OK)` returns `False`, the tar subprocess is
+spawned under `sudo tar -cC <path> .`, piped to the chunk engine — mirroring
+the existing `_delete_dir_with_sudo` pattern.
+
+### Consistency Model
+
+- Chunks are immutable and content-addressed — concurrent uploads are
+  idempotent.
+- Manifests are written only after all chunks are confirmed present — a
+  partial backup leaves orphan chunks but never a corrupt manifest.
+- `index.json` is a best-effort cache; ground truth is always the
+  per-environment manifests.
+- `latest.json` last-writer-wins — environments are not typically backed up
+  from two nodes simultaneously.
+
+### Built-in Transports
+
+Two transports ship with the core:
+
+- **FTP** — using stdlib `ftplib`. Existence checks use the shard-listing
+  strategy (one `NLST` per 2-char prefix per session, resolved from an
+  in-memory set).
+- **SFTP** — using `paramiko`. Provides encrypted transfer and SSH key
+  authentication, making it the preferred choice for most real deployments.
+
+Both implement the same `RemoteBackend` ABC and are interchangeable from
+the orchestration layer's perspective.
+
+### Backend Extensibility
+
+`RemoteBackend` is an abstract base class exposed in the public plugin API
+alongside `EnvironmentFactory` and `ServiceFactory`. A plugin contributes
+additional transports by implementing `ShepherdPlugin.get_remote_backends()`
+returning `PluginRemoteBackendSpec(type_id, factory)`.
+`RemoteMng._build_backend()` checks core built-ins first (FTP, SFTP), then
+delegates to the plugin registry — the same dispatch pattern used by env/svc
+factories.
+
+S3, Azure Blob, and other transports follow as standalone plugin packages.
+
+### Remote Configuration and CLI
+
+Remotes are persisted in the main Shepherd config (`~/.shpd.conf`) under a
+top-level `remotes` list. Each entry has a `name`, a `type` (`ftp` or `sftp`
+for built-ins, or a plugin-registered type id), type-specific connection
+fields, and optional chunk tuning and local cache settings.
+
+Remotes are managed via `shepctl remote`:
+
+```sh
+# Register an FTP remote
+shepctl remote add prod-backup --ftp \
+    --host storage.example.com \
+    --user backup \
+    --password "${BACKUP_PWD}" \
+    --root-path /shepherd \
+    --set-default
+
+# Register an SFTP remote (key-based auth)
+shepctl remote add dev-backup --sftp \
+    --host dev.example.com \
+    --user deploy \
+    --identity-file ~/.ssh/id_ed25519 \
+    --root-path /backups/shepherd
+
+# List registered remotes
+shepctl remote list
+
+# Inspect snapshots available for an environment on a remote
+shepctl remote get myenv [--remote=prod-backup]
+
+# Remove orphan chunks from a remote
+shepctl remote prune [--remote=prod-backup] [--dry-run]
+
+# Unregister a remote (does not delete remote data)
+shepctl remote delete prod-backup
+```
+
+Environment operations that interact with a remote:
+
+```sh
+# Push a new snapshot
+# (uses tracking remote or default if --remote omitted)
+shepctl env push [env-tag] \
+    [--remote=<name>] [--set-tracking-remote] [--labels=...]
+
+# First-time download — env not yet registered locally
+shepctl env pull [env-tag] [--remote=<name>] [--snapshot-id=<id>]
+
+# Restore data for an already-registered dehydrated env
+shepctl env hydrate [env-tag] [--remote=<name>] [--snapshot-id=<id>]
+
+# Strip local data, keep config entry
+shepctl env dehydrate [env-tag]
+```
+
+`--password` and `--identity-file` values that contain `${VAR}` are stored
+verbatim and resolved at runtime via the existing `Resolvable` mechanism, so
+credentials are never hard-coded in the config file.
+
+### pull vs hydrate State Machine
+
+```text
+[remote snapshot]
+      │
+      │  env pull    (env unknown locally → creates config entry + data)
+      ▼
+[local env, hydrated] ──── env dehydrate ────► [local env, dehydrated]
+      ▲                                                  │
+      └──────────────── env hydrate ─────────────────────┘
+```
+
+- `env push` — create a new remote snapshot from the local env.
+- `env pull` — first-time download; env not yet registered locally.
+- `env hydrate` — restore data for an already-registered dehydrated env.
+- `env dehydrate` — strip local data, keep config entry.
+
+### Consequences
+
+- Good, because only changed data is transferred; dedup is automatic across
+  environments and across time for env-specific data (DB state, mounted
+  volumes, runtime files).
+- Good, because the passive-backend constraint is fully respected.
+- Good, because new transports can be added as plugins without touching
+  the core.
+- Good, because orphan chunks can be reclaimed with a `prune` command.
+- Neutral, because chunk metadata (manifests, index) adds a small overhead
+  per snapshot vs. a single file upload.
+- Bad, because the implementation introduces three new runtime dependencies
+  (`fastcdc`, `zstandard`, `paramiko`).
+
+### Confirmation
+
+The implementation is aligned with this ADR when:
+
+- `shepctl env push` transfers fewer bytes on a second push of the same
+  environment.
+- `shepctl env pull` creates a local env entry from a remote snapshot.
+- `shepctl env dehydrate` + `shepctl env hydrate` round-trip without data
+  loss.
+- `shepctl remote prune` removes orphan chunks and retains all referenced
+  ones.
+- A plugin contributing a `PluginRemoteBackendSpec` is picked up by
+  `RemoteMng` without core modifications.
+- Automated tests cover the push/pull/hydrate/dehydrate/prune flows using a
+  `FakeRemoteBackend` and an FTP/SFTP integration fixture.
+
+## Pros and Cons of the Options
+
+### Content-Defined Chunking (chosen)
+
+- Good, because dedup is cross-environment and cross-time with no extra
+  metadata.
+- Good, because the passive backend constraint is satisfied.
+- Good, because chunk uploads are individually retryable.
+- Neutral, because manifest management adds a small protocol layer.
+
+### Monolithic `.tar.gz`
+
+- Good, because it is trivially simple to implement.
+- Bad, because the entire archive is retransmitted on every backup.
+- Bad, because it does not scale to large environments on slow links.
+
+### rsync Delta
+
+- Good, because deltas can be very small.
+- Bad, because it requires an rsync or SSH server — violates the
+  passive-backend constraint.
+
+### bsdiff Patches
+
+- Bad, because there is no cross-environment sharing.
+- Bad, because restoring requires the previous archive to apply the patch.
+- Bad, because patch metadata can be large for random-access storage
+  patterns.

--- a/src/remote/__init__.py
+++ b/src/remote/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Remote storage backends and orchestration manager."""
+
+from .backend import RemoteBackend
+from .ftp_backend import FTPBackend
+from .remote_mng import RemoteMng
+from .sftp_backend import SFTPBackend
+
+__all__ = [
+    "FTPBackend",
+    "RemoteBackend",
+    "RemoteMng",
+    "SFTPBackend",
+]

--- a/src/remote/backend.py
+++ b/src/remote/backend.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Abstract base class for remote storage backends.
+
+This ABC is also exported from the public plugin API (``src/plugin/api.py``)
+so that external plugins can contribute new backend implementations.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class RemoteBackend(ABC):
+    """Contract that every remote storage transport must satisfy.
+
+    Implementations are responsible for a single concern: moving bytes between
+    the local machine and a remote store identified by opaque path strings.
+    All higher-level logic (chunking, manifests, dedup) lives in
+    :class:`~remote.remote_mng.RemoteMng`.
+
+    Implementations should be used as context managers so that connections are
+    closed deterministically::
+
+        with backend:
+            backend.upload("chunks/ab/ab3f...", data)
+    """
+
+    # ------------------------------------------------------------------
+    # Path helpers (convenience, not abstract — backends may override)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def chunk_path(chunk_hash: str) -> str:
+        """Return the remote path for *chunk_hash*.
+
+        Example: ``ab3f1c9d...`` → ``chunks/ab/ab3f1c9d...``
+        """
+        return f"chunks/{chunk_hash[:2]}/{chunk_hash}"
+
+    @staticmethod
+    def snapshot_path(env_name: str, snapshot_id: str) -> str:
+        """Return the remote path for a snapshot manifest."""
+        return f"envs/{env_name}/snapshots/{snapshot_id}.json"
+
+    @staticmethod
+    def latest_path(env_name: str) -> str:
+        """Return the remote path for an environment's latest pointer."""
+        return f"envs/{env_name}/latest.json"
+
+    @staticmethod
+    def index_path() -> str:
+        """Return the remote path for the global index."""
+        return "index/index.json"
+
+    # ------------------------------------------------------------------
+    # Abstract transport operations
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def exists(self, path: str) -> bool:
+        """Return ``True`` if *path* exists on the remote."""
+
+    @abstractmethod
+    def upload(self, path: str, data: bytes) -> None:
+        """Write *data* to *path* on the remote, creating parents as needed."""
+
+    @abstractmethod
+    def download(self, path: str) -> bytes:
+        """Return the full contents of *path* from the remote."""
+
+    @abstractmethod
+    def list_prefix(self, prefix: str) -> list[str]:
+        """Return the leaf names of all objects under *prefix*.
+
+        Example: ``list_prefix("chunks/ab")`` might return
+        ``["ab3f1c9d...", "ab7e2a11..."]``.
+        """
+
+    @abstractmethod
+    def delete(self, path: str) -> None:
+        """Delete *path* from the remote."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release any underlying connections or resources."""
+
+    # ------------------------------------------------------------------
+    # Context manager support
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> RemoteBackend:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()

--- a/src/remote/ftp_backend.py
+++ b/src/remote/ftp_backend.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Built-in FTP remote storage backend using stdlib ``ftplib``."""
+
+from __future__ import annotations
+
+from .backend import RemoteBackend
+
+
+class FTPBackend(RemoteBackend):
+    """FTP remote backend.
+
+    Existence checks use the shard-listing strategy: at the start of a backup
+    session, each needed 2-character prefix directory is listed once via
+    ``NLST``, building an in-memory ``set[str]`` of known chunk hashes.
+    Subsequent ``exists()`` calls for chunks in the same shard are resolved
+    from the in-memory cache without additional round-trips.
+
+    Parameters
+    ----------
+    host:
+        FTP server hostname.
+    port:
+        FTP server port (default 21).
+    user:
+        FTP username.
+    password:
+        FTP password (supports ``${VAR}`` resolved before construction).
+    root_path:
+        Remote root directory under which the chunk store layout lives.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 21,
+        user: str = "",
+        password: str = "",
+        root_path: str = "/",
+    ) -> None:
+        raise NotImplementedError  # TODO: Issue 7
+
+    # RemoteBackend implementation
+
+    def exists(self, path: str) -> bool:
+        raise NotImplementedError  # TODO: Issue 7
+
+    def upload(self, path: str, data: bytes) -> None:
+        raise NotImplementedError  # TODO: Issue 7
+
+    def download(self, path: str) -> bytes:
+        raise NotImplementedError  # TODO: Issue 7
+
+    def list_prefix(self, prefix: str) -> list[str]:
+        raise NotImplementedError  # TODO: Issue 7
+
+    def delete(self, path: str) -> None:
+        raise NotImplementedError  # TODO: Issue 7
+
+    def close(self) -> None:
+        raise NotImplementedError  # TODO: Issue 7

--- a/src/remote/remote_mng.py
+++ b/src/remote/remote_mng.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Orchestrates all remote storage operations: push, pull, hydrate, dehydrate,
+prune, and remote/env listing."""
+
+from __future__ import annotations
+
+
+class RemoteMng:
+    """Coordinates the full remote backup and restore workflow.
+
+    Responsibilities:
+    - Build the appropriate :class:`~remote.backend.RemoteBackend` (core
+      built-in FTP, or a plugin-registered backend) from a ``RemoteCfg``.
+    - Drive the push algorithm: tar stream → chunk → dedup check → upload
+      missing chunks → write manifest → update ``latest.json`` / ``index.json``.
+    - Drive pull (first-time download, creates local env entry) and hydrate
+      (restore data for an already-registered dehydrated env).
+    - Dehydrate: strip local data while keeping the env registered in config.
+    - List remote envs and snapshots.
+    - Prune orphan chunks.
+    """
+
+    def __init__(self) -> None:
+        raise NotImplementedError  # TODO: Issues 8–10

--- a/src/remote/sftp_backend.py
+++ b/src/remote/sftp_backend.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Built-in SFTP remote storage backend using paramiko."""
+
+from __future__ import annotations
+
+from .backend import RemoteBackend
+
+
+class SFTPBackend(RemoteBackend):
+    """SFTP remote backend.
+
+    Provides encrypted transfer and SSH key or password authentication,
+    making it the preferred built-in transport for most real deployments.
+
+    Parameters
+    ----------
+    host:
+        SFTP server hostname.
+    port:
+        SFTP server port (default 22).
+    user:
+        SSH username.
+    password:
+        SSH password (optional; supports ``${VAR}`` resolved before
+        construction). Mutually exclusive with ``identity_file``.
+    identity_file:
+        Path to a private key file (optional; supports ``${VAR}``).
+        Takes precedence over ``password`` when both are supplied.
+    root_path:
+        Remote root directory under which the chunk store layout lives.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 22,
+        user: str = "",
+        password: str | None = None,
+        identity_file: str | None = None,
+        root_path: str = "/",
+    ) -> None:
+        raise NotImplementedError  # TODO: Issue 7
+
+    # RemoteBackend implementation
+
+    def exists(self, path: str) -> bool:
+        raise NotImplementedError  # TODO: Issue 7
+
+    def upload(self, path: str, data: bytes) -> None:
+        raise NotImplementedError  # TODO: Issue 7
+
+    def download(self, path: str) -> bytes:
+        raise NotImplementedError  # TODO: Issue 7
+
+    def list_prefix(self, prefix: str) -> list[str]:
+        raise NotImplementedError  # TODO: Issue 7
+
+    def delete(self, path: str) -> None:
+        raise NotImplementedError  # TODO: Issue 7
+
+    def close(self) -> None:
+        raise NotImplementedError  # TODO: Issue 7

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,3 +4,6 @@ distro
 pyyaml
 glom
 packaging
+fastcdc
+zstandard
+paramiko

--- a/src/storage/__init__.py
+++ b/src/storage/__init__.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Local storage engine: chunking, tar, snapshot models, and chunk cache."""
+
+from .chunker import Chunker, ChunkResult
+from .local_cache import (
+    LocalChunkCache,
+    LocalChunkCacheProtocol,
+    NullLocalChunkCache,
+)
+from .snapshot import (
+    IndexCatalogue,
+    IndexCatalogueEntry,
+    LatestPointer,
+    SnapshotManifest,
+)
+from .tar_stream import TarStreamProducer
+
+__all__ = [
+    "ChunkResult",
+    "Chunker",
+    "IndexCatalogue",
+    "IndexCatalogueEntry",
+    "LatestPointer",
+    "LocalChunkCache",
+    "LocalChunkCacheProtocol",
+    "NullLocalChunkCache",
+    "SnapshotManifest",
+    "TarStreamProducer",
+]

--- a/src/storage/chunker.py
+++ b/src/storage/chunker.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""FastCDC-based chunker: splits a byte stream into variable-length chunks,
+compresses each with Zstd, and hashes with SHA-256."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import IO, Iterator
+
+
+@dataclass
+class ChunkResult:
+    """A single content-defined chunk ready for upload."""
+
+    hash: str
+    """SHA-256 hex digest of the *compressed* chunk bytes."""
+
+    data: bytes
+    """Compressed (Zstd) chunk bytes."""
+
+    raw_size: int
+    """Size of the uncompressed chunk in bytes."""
+
+
+class Chunker:
+    """Splits a raw byte stream into content-defined chunks.
+
+    Each chunk is:
+    1. Bounded by FastCDC cut-points on the *uncompressed* stream.
+    2. Compressed individually with Zstd.
+    3. Identified by the SHA-256 of the compressed bytes.
+
+    Parameters
+    ----------
+    min_size:
+        Minimum chunk size in bytes (default 512 KB).
+    avg_size:
+        Average (target) chunk size in bytes (default 2 MB).
+    max_size:
+        Maximum chunk size in bytes (default 8 MB).
+    """
+
+    def __init__(
+        self,
+        min_size: int = 512 * 1024,
+        avg_size: int = 2 * 1024 * 1024,
+        max_size: int = 8 * 1024 * 1024,
+    ) -> None:
+        raise NotImplementedError  # TODO: Issue 5
+
+    def chunk_stream(self, stream: IO[bytes]) -> Iterator[ChunkResult]:
+        """Yield ChunkResult objects for every chunk in *stream*.
+
+        Parameters
+        ----------
+        stream:
+            An uncompressed, readable byte stream (e.g. a tar stream).
+        """
+        raise NotImplementedError  # TODO: Issue 5

--- a/src/storage/local_cache.py
+++ b/src/storage/local_cache.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Optional LRU on-disk chunk cache.
+
+Stores compressed chunk bytes in a flat-file layout that mirrors the remote
+chunk store (``<cache_path>/chunks/<2-char-prefix>/<full-hash>``).  LRU
+metadata (eviction order and sizes) is kept in a JSON sidecar at
+``<cache_path>/meta.json``.
+
+Use :class:`NullLocalChunkCache` when no cache is configured — it is a
+drop-in no-op with zero overhead.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class LocalChunkCacheProtocol(Protocol):
+    """Shared interface for local chunk caches.
+
+    Both :class:`LocalChunkCache` and :class:`NullLocalChunkCache` satisfy
+    this protocol, allowing ``RemoteMng`` to accept either without a common
+    ABC and without pyright drift between their signatures.
+    """
+
+    def contains(self, chunk_hash: str) -> bool: ...
+
+    def get(self, chunk_hash: str) -> bytes | None: ...
+
+    def put(self, chunk_hash: str, data: bytes) -> None: ...
+
+
+class LocalChunkCache:
+    """LRU on-disk cache for compressed chunk bytes.
+
+    Parameters
+    ----------
+    cache_path:
+        Root directory for the cache.
+    max_bytes:
+        Maximum total size of cached chunks in bytes.  When exceeded, the
+        least-recently-used chunks are evicted until the cache fits.
+    """
+
+    def __init__(self, cache_path: str, max_bytes: int) -> None:
+        raise NotImplementedError  # TODO: Issue 6
+
+    def contains(self, chunk_hash: str) -> bool:
+        raise NotImplementedError  # TODO: Issue 6
+
+    def get(self, chunk_hash: str) -> bytes | None:
+        """Return compressed chunk bytes, or ``None`` if not cached."""
+        raise NotImplementedError  # TODO: Issue 6
+
+    def put(self, chunk_hash: str, data: bytes) -> None:
+        """Store compressed chunk bytes; evict LRU entries if over budget."""
+        raise NotImplementedError  # TODO: Issue 6
+
+
+class NullLocalChunkCache:
+    """No-op cache used when local caching is disabled."""
+
+    def contains(self, chunk_hash: str) -> bool:  # noqa: ARG002
+        return False
+
+    def get(self, chunk_hash: str) -> bytes | None:  # noqa: ARG002
+        return None
+
+    def put(self, chunk_hash: str, data: bytes) -> None:  # noqa: ARG002
+        pass

--- a/src/storage/snapshot.py
+++ b/src/storage/snapshot.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Dataclasses for snapshot manifests, latest pointers, and the global index.
+
+All models serialise to/from plain JSON via ``from_dict`` / ``to_dict``
+helpers, consistent with the ``config.py`` dataclass style.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class SnapshotManifest:
+    """Full record for a single environment snapshot.
+
+    The ``chunks`` list contains SHA-256 hex digests of the compressed chunk
+    bytes, ordered so that concatenating the chunks and decompressing each one
+    in turn reconstructs the original uncompressed tar stream.
+    """
+
+    snapshot_id: str
+    environment: str
+    shepherd_version: str
+    created_at: str
+    chunks: list[str]
+    chunk_count: int
+    total_size_bytes: int
+    stored_size_bytes: int
+    compression: str = "zstd"
+    chunk_algo: str = "fastcdc"
+    avg_chunk_size_kb: int = 2048
+    labels: list[str] = field(default_factory=lambda: [])
+    db_included: bool = False
+    db_engine: str | None = None
+    db_version: str | None = None
+
+    @staticmethod
+    def build_id(created_at: str, manifest_bytes: bytes) -> str:
+        """Return ``{created_at}-{first-6-chars-sha256(manifest_bytes)}``."""
+        raise NotImplementedError  # TODO: Issue 5
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SnapshotManifest:
+        raise NotImplementedError  # TODO: Issue 5
+
+    def to_dict(self) -> dict[str, Any]:
+        raise NotImplementedError  # TODO: Issue 5
+
+
+@dataclass
+class LatestPointer:
+    """Lightweight file that points to the most recent snapshot for an env."""
+
+    snapshot_id: str
+    updated_at: str
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> LatestPointer:
+        raise NotImplementedError  # TODO: Issue 5
+
+    def to_dict(self) -> dict[str, Any]:
+        raise NotImplementedError  # TODO: Issue 5
+
+
+@dataclass
+class IndexCatalogueEntry:
+    """Per-environment summary stored inside ``index.json``."""
+
+    latest_snapshot: str
+    snapshot_count: int
+    last_backup: str
+    labels: list[str]
+    total_size_bytes: int
+    stored_size_bytes: int
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> IndexCatalogueEntry:
+        raise NotImplementedError  # TODO: Issue 5
+
+    def to_dict(self) -> dict[str, Any]:
+        raise NotImplementedError  # TODO: Issue 5
+
+
+@dataclass
+class IndexCatalogue:
+    """Global catalogue file (``index/index.json``).
+
+    This is a best-effort cache; ground truth is always the per-environment
+    manifest files.
+    """
+
+    updated_at: str
+    environments: dict[str, IndexCatalogueEntry] = field(
+        default_factory=lambda: {}
+    )
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> IndexCatalogue:
+        raise NotImplementedError  # TODO: Issue 5
+
+    def to_dict(self) -> dict[str, Any]:
+        raise NotImplementedError  # TODO: Issue 5

--- a/src/storage/tar_stream.py
+++ b/src/storage/tar_stream.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Produces an uncompressed tar byte stream from a Shepherd environment,
+including host-mounted volumes (with sudo escalation when required)."""
+
+from __future__ import annotations
+
+from typing import IO
+
+
+class TarStreamProducer:
+    """Produces an uncompressed tar stream for a Shepherd environment.
+
+    The stream covers:
+    - The environment's data directory (``env.get_path()``).
+    - All host-mounted volume paths declared in ``env_cfg.volumes``.
+
+    When a volume path is not readable by the current process (e.g. DBMS data
+    written under a non-root UID), the tar subprocess is spawned under ``sudo``,
+    mirroring the existing ``_delete_dir_with_sudo`` pattern.
+    """
+
+    def stream(self) -> IO[bytes]:
+        """Return a readable, uncompressed tar byte stream for the environment.
+
+        The caller is responsible for closing the stream when done.
+        """
+        raise NotImplementedError  # TODO: Issue 4


### PR DESCRIPTION
## Summary

- Adds `docs/decisions/0006-remote-storage-deduplication.md` — ADR documenting all design decisions for the remote storage deduplication epic: content-defined chunking (FastCDC + Zstd + SHA-256), FTP/SFTP built-in transports, passive consistency model, plugin extensibility for additional backends, and the full CLI shape for `shepctl remote` and `env push/pull/hydrate/dehydrate`
- Scaffolds `src/storage/` — `chunker.py`, `tar_stream.py`, `snapshot.py`, `local_cache.py` (includes fully-implemented `NullLocalChunkCache` no-op)
- Scaffolds `src/remote/` — `backend.py` (fully-implemented `RemoteBackend` ABC with path helpers and context manager), `ftp_backend.py`, `sftp_backend.py`, `remote_mng.py` stubs
- Adds `fastcdc`, `zstandard`, `paramiko` to `src/requirements.txt`

## Test plan

- All 345 existing tests pass (`pytest`)
- Import smoke tests pass for all new modules
- `black`, `isort`, `flake8`, `pyright`, `markdownlint` all pass

Fixes: #200