### PR TITLE
feat(plugin): expose RemoteBackend ABC in plugin API

### DIFF
--- a/src/plugin/__init__.py
+++ b/src/plugin/__init__.py
@@ -14,7 +14,9 @@ from .api import (
     PluginCommandSpec,
     PluginCompletionSpec,
     PluginEnvFactorySpec,
+    PluginRemoteBackendSpec,
     PluginSvcFactorySpec,
+    RemoteBackendProvider,
     ShepherdPlugin,
     SvcFactoryProvider,
 )
@@ -44,9 +46,11 @@ __all__ = [
     "PluginEnvironmentView",
     "PluginMng",
     "PluginRegistry",
+    "PluginRemoteBackendSpec",
     "PluginRuntimeMng",
     "PluginServiceView",
     "PluginSvcFactorySpec",
+    "RemoteBackendProvider",
     "ShepherdPlugin",
     "SvcFactoryProvider",
 ]

--- a/src/plugin/api.py
+++ b/src/plugin/api.py
@@ -23,6 +23,7 @@ import click
 from config import ConfigMng
 from environment import EnvironmentFactory
 from plugin.context import PluginContext
+from remote import RemoteBackend
 from service import ServiceFactory
 
 
@@ -82,6 +83,15 @@ Pass the **class** of your ``EnvironmentFactory`` subclass — the runtime
 calls it with ``(configMng, svc_factory, cli_flags)`` to produce the
 instance.  A pre-built instance or a builder callable with the same
 signature are also accepted.
+"""
+
+RemoteBackendProvider: TypeAlias = RemoteBackend | Callable[[], RemoteBackend]
+"""
+Accepted value for :attr:`PluginRemoteBackendSpec.provider`.
+
+Pass the **class** of your ``RemoteBackend`` subclass — the runtime calls
+it with no arguments to produce the instance.  A pre-built instance is
+also accepted.
 """
 
 
@@ -145,6 +155,24 @@ class PluginSvcFactorySpec:
     provider: SvcFactoryProvider
 
 
+@dataclass(frozen=True)
+class PluginRemoteBackendSpec:
+    """One remote storage backend transport contributed by a plugin.
+
+    ``type_id`` is the value placed in ``RemoteCfg.type`` to select this
+    transport (e.g. ``"s3"`` or ``"azure-blob"``).  It must not collide
+    with the core built-ins ``"ftp"`` and ``"sftp"``.
+
+    ``provider`` must satisfy :data:`RemoteBackendProvider` — either a
+    pre-built ``RemoteBackend`` instance or the **class** (zero-argument
+    factory callable) of your ``RemoteBackend`` subclass.  The runtime
+    calls it with no arguments to produce the instance on demand.
+    """
+
+    type_id: str
+    provider: RemoteBackendProvider
+
+
 class ShepherdPlugin(ABC):
     """
     Root runtime interface implemented by external plugins.
@@ -182,4 +210,8 @@ class ShepherdPlugin(ABC):
 
     def get_service_factories(self) -> Sequence[PluginSvcFactorySpec]:
         """Return service factories owned by the plugin."""
+        return ()
+
+    def get_remote_backends(self) -> Sequence[PluginRemoteBackendSpec]:
+        """Return remote storage backend transport contributions."""
         return ()

--- a/src/plugin/runtime.py
+++ b/src/plugin/runtime.py
@@ -37,6 +37,7 @@ from plugin.api import (
     PluginCommandSpec,
     PluginCompletionSpec,
     PluginEnvFactorySpec,
+    PluginRemoteBackendSpec,
     PluginSvcFactorySpec,
     ShepherdPlugin,
 )
@@ -45,6 +46,7 @@ from plugin.context import (
     PluginEnvironmentView,
     PluginServiceView,
 )
+from remote import RemoteBackend
 from service import ServiceFactory, ServiceMng
 from util import Constants, Util
 
@@ -83,6 +85,11 @@ def _env_factory_registry() -> dict[str, "PluginEnvFactorySpec"]:
 
 def _svc_factory_registry() -> dict[str, "PluginSvcFactorySpec"]:
     """Create a typed default for canonical service factory registrations."""
+    return {}
+
+
+def _remote_backend_registry() -> dict[str, "PluginRemoteBackendSpec"]:
+    """Create a typed default for remote backend registrations."""
     return {}
 
 
@@ -134,6 +141,9 @@ class PluginRegistry:
     )
     service_factories: dict[str, PluginSvcFactorySpec] = field(
         default_factory=_svc_factory_registry
+    )
+    remote_backends: dict[str, PluginRemoteBackendSpec] = field(
+        default_factory=_remote_backend_registry
     )
 
 
@@ -535,6 +545,9 @@ class PluginRuntimeMng:
         self._register_svc_factories(
             plugin_id, loaded.instance.get_service_factories()
         )
+        self._register_remote_backends(
+            plugin_id, loaded.instance.get_remote_backends()
+        )
 
     def _register_commands(
         self,
@@ -906,6 +919,51 @@ class PluginRuntimeMng:
         # (ServiceFactory | Callable[...]) via isinstance alone.
         """Return whether the svc factory provider can be materialized."""
         return isinstance(provider, ServiceFactory) or callable(provider)
+
+    _CORE_BACKEND_TYPE_IDS: frozenset[str] = frozenset({"ftp", "sftp"})
+
+    def _register_remote_backends(
+        self,
+        plugin_id: str,
+        backends: Sequence[PluginRemoteBackendSpec],
+    ) -> None:
+        """Register plugin-contributed remote backend transports."""
+        for backend in backends:
+            if backend.type_id in self._CORE_BACKEND_TYPE_IDS:
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' remote backend type_id "
+                    f"'{backend.type_id}' collides with a core built-in."
+                )
+            if backend.type_id in self.registry.remote_backends:
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' declares duplicate remote "
+                    f"backend type_id '{backend.type_id}'."
+                )
+            if not self._is_remote_backend_provider(backend.provider):
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}' remote backend "
+                    f"'{backend.type_id}' must provide a RemoteBackend "
+                    "instance or a zero-argument factory callable."
+                )
+            self.registry.remote_backends[backend.type_id] = backend
+
+    def _is_remote_backend_provider(self, provider: Any) -> bool:
+        """Return whether the remote backend provider can be materialized."""
+        return isinstance(provider, RemoteBackend) or callable(provider)
+
+    def build_remote_backend(self, type_id: str) -> RemoteBackend | None:
+        """Return a plugin-owned RemoteBackend for *type_id*, or None."""
+        spec = self.registry.remote_backends.get(type_id)
+        if spec is None:
+            return None
+        provider = spec.provider
+        if isinstance(provider, RemoteBackend):
+            return provider
+        if callable(provider):
+            return provider()
+        raise ValueError(
+            f"Plugin remote backend '{type_id}' provider is invalid."
+        )
 
     def get_environment_template(
         self, template_id: str

--- a/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py
+++ b/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py
@@ -13,10 +13,34 @@ from plugin import (
     PluginCommandSpec,
     PluginCompletionSpec,
     PluginEnvFactorySpec,
+    PluginRemoteBackendSpec,
     PluginSvcFactorySpec,
     ShepherdPlugin,
 )
+from remote import RemoteBackend
 from service import Service, ServiceFactory
+
+
+class FakeRemoteBackend(RemoteBackend):
+    """Minimal no-op backend for plugin registry tests."""
+
+    def exists(self, path: str) -> bool:
+        return False
+
+    def upload(self, path: str, data: bytes) -> None:
+        pass
+
+    def download(self, path: str) -> bytes:
+        return b""
+
+    def list_prefix(self, prefix: str) -> list[str]:
+        return []
+
+    def delete(self, path: str) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
 
 
 class FixturePluginServiceFactory(ServiceFactory):
@@ -108,5 +132,13 @@ class RuntimeFixturePlugin(ShepherdPlugin):
             PluginSvcFactorySpec(
                 id="api-factory",
                 provider=FixturePluginServiceFactory,
+            )
+        ]
+
+    def get_remote_backends(self):
+        return [
+            PluginRemoteBackendSpec(
+                type_id="fake-store",
+                provider=FakeRemoteBackend,
             )
         ]

--- a/src/tests/fixtures/plugins/runtime_plugin/plugin.yaml
+++ b/src/tests/fixtures/plugins/runtime_plugin/plugin.yaml
@@ -12,6 +12,7 @@ capabilities:
   templates: true
   env_factories: true
   svc_factories: true
+  remote_backends: true
 default_config:
   region: eu-west-1
 env_templates:

--- a/src/tests/test_plugin_runtime.py
+++ b/src/tests/test_plugin_runtime.py
@@ -141,6 +141,7 @@ def test_shepherd_loads_enabled_plugin_runtime_registry(
     assert "runtime-plugin/api" in registry.service_templates
     assert "runtime-plugin/baseline-factory" in registry.env_factories
     assert "runtime-plugin/api-factory" in registry.service_factories
+    assert "fake-store" in registry.remote_backends
     assert callable(registry.completion_providers["observability"][0].provider)
     env_template = shepherd.configMng.get_environment_template(
         "runtime-plugin/baseline"
@@ -1001,3 +1002,94 @@ def test_plugins_loaded_in_dependency_order(
     assert "plugin-b" in loaded_order
     # plugin-a must appear before plugin-b in the insertion-ordered dict
     assert loaded_order.index("plugin-a") < loaded_order.index("plugin-b")
+
+
+# ---------------------------------------------------------------------------
+# RemoteBackend plugin registration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.shpd
+def test_plugin_remote_backend_lands_in_registry(
+    shpd_conf: tuple[Path, Path], mocker: MockerFixture
+):
+    """PluginRemoteBackendSpec is registered and build_remote_backend works."""
+    from remote import RemoteBackend
+
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _install_fixture_plugin(shpd_path)
+    _write_plugin_inventory(
+        shpd_yaml,
+        [{"id": "runtime-plugin", "enabled": True, "version": "1.0.0"}],
+    )
+
+    shepherd = ShepherdMng()
+
+    assert shepherd.pluginRuntimeMng is not None
+    registry = shepherd.pluginRuntimeMng.registry
+    assert "fake-store" in registry.remote_backends
+
+    backend = shepherd.pluginRuntimeMng.build_remote_backend("fake-store")
+    assert isinstance(backend, RemoteBackend)
+
+    assert shepherd.pluginRuntimeMng.build_remote_backend("unknown") is None
+
+
+@pytest.mark.shpd
+def test_plugin_remote_backend_rejects_core_type_id(
+    shpd_conf: tuple[Path, Path], mocker: MockerFixture
+):
+    """A plugin using a core type_id ('ftp' or 'sftp') is rejected."""
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _install_fixture_plugin(
+        shpd_path,
+        main_content=(
+            "from remote import RemoteBackend\n"
+            "from plugin import PluginRemoteBackendSpec, ShepherdPlugin\n\n"
+            "class FakeBackend(RemoteBackend):\n"
+            "    def exists(self, p): return False\n"
+            "    def upload(self, p, d): pass\n"
+            "    def download(self, p): return b''\n"
+            "    def list_prefix(self, p): return []\n"
+            "    def delete(self, p): pass\n"
+            "    def close(self): pass\n\n"
+            "class RuntimeFixturePlugin(ShepherdPlugin):\n"
+            "    def get_remote_backends(self):\n"
+            "        return [PluginRemoteBackendSpec("
+            "type_id='ftp', provider=FakeBackend)]\n"
+        ),
+    )
+    _write_plugin_inventory(
+        shpd_yaml,
+        [{"id": "runtime-plugin", "enabled": True, "version": "1.0.0"}],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        ShepherdMng()
+
+    assert excinfo.value.code == 1
+
+
+@pytest.mark.shpd
+def test_plugin_remote_backend_rejects_duplicate_type_id(
+    shpd_conf: tuple[Path, Path], mocker: MockerFixture
+):
+    """Two plugins registering the same type_id cause a hard failure."""
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _install_fixture_plugin(shpd_path, plugin_id="runtime-plugin")
+    _install_fixture_plugin(shpd_path, plugin_id="collision-plugin")
+    _write_plugin_inventory(
+        shpd_yaml,
+        [
+            {"id": "runtime-plugin", "enabled": True, "version": "1.0.0"},
+            {"id": "collision-plugin", "enabled": True, "version": "1.0.0"},
+        ],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        ShepherdMng()
+
+    assert excinfo.value.code == 1


### PR DESCRIPTION
## Summary

- Add `PluginRemoteBackendSpec` and `RemoteBackendProvider` to the public
  plugin API, following the `PluginSvcFactorySpec` / `SvcFactoryProvider`
  pattern
- Add `ShepherdPlugin.get_remote_backends()` hook (default: empty, non-breaking)
- `PluginRegistry` gains `remote_backends` dict; `_register_plugin` wires in
  `_register_remote_backends` with guards for core type_id collision
  (`"ftp"` / `"sftp"`) and duplicates
- `build_remote_backend(type_id)` materializes a provider on demand
- Fixture plugin extended with `FakeRemoteBackend`

Part of the Remote Storage Deduplication epic (ADR-0006).

## Test plan

- [ ] `cd src && pytest -m shpd -v` — 95 shpd tests pass
- [ ] `cd src && pytest -q` — 354 tests pass, 0 failures
- [ ] `black src/plugin/ --check` — clean
- [ ] `pyright src` — 50 pre-existing errors, 0 new

Fixes: #204