### PR TITLE
feat(storage): TarStreamProducer with volume identity

### DIFF
--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import subprocess
 import time
-from typing import Any, Optional, cast, override
+from typing import IO, Any, Optional, cast, override
 
 import yaml
 
@@ -57,6 +59,71 @@ class DockerComposeEnv(Environment):
                         Util.ensure_dir(
                             Util.translate_host_path(device_path), vol.tag
                         )
+
+    @override
+    def get_volume_tar_streams(self) -> list[tuple[str, IO[bytes]]]:
+        """Return one ``(volume_tag, tar_stream)`` pair per volume.
+
+        Bind-mounts are streamed directly from the host path (sudo when the
+        path is not readable by the current process).  Named and external
+        volumes are streamed via a temporary ``docker run`` container so no
+        knowledge of Docker's internal volume storage layout is required.
+        """
+        if not self.envCfg.volumes:
+            return []
+        result: list[tuple[str, IO[bytes]]] = []
+        for vol in self.envCfg.volumes:
+            if (
+                vol.driver == "local"
+                and vol.driver_opts
+                and vol.driver_opts.get("type") == "none"
+                and vol.driver_opts.get("o") == "bind"
+            ):
+                device = vol.driver_opts.get("device", "")
+                result.append((vol.tag, self._path_tar_stream(device)))
+            else:
+                vol_name = (
+                    vol.name if vol.is_external() and vol.name else vol.tag
+                )
+                result.append(
+                    (vol.tag, self._docker_volume_tar_stream(vol_name))
+                )
+        return result
+
+    def _is_readable(self, path: str) -> bool:
+        return os.access(path, os.R_OK)
+
+    def _path_tar_stream(self, path: str) -> IO[bytes]:
+        cmd = (
+            ["tar", "-cC", path, "."]
+            if self._is_readable(path)
+            else ["sudo", "tar", "-cC", path, "."]
+        )
+        proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        assert proc.stdout is not None
+        return proc.stdout
+
+    def _docker_volume_tar_stream(self, vol_name: str) -> IO[bytes]:
+        proc = subprocess.Popen(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "-v",
+                f"{vol_name}:/mnt",
+                "busybox:stable-glibc",
+                "tar",
+                "-cC",
+                "/mnt",
+                ".",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert proc.stdout is not None
+        return proc.stdout
 
     @override
     def clone_impl(self, dst_env_tag: str) -> DockerComposeEnv:

--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -27,6 +27,43 @@ from util.util import Util
 from .docker_compose_util import render_container, run_compose
 
 
+class _ProcStream:
+    """Wraps subprocess stdout; calls ``proc.wait()`` on close.
+
+    Using ``proc.stdout`` directly would leave the child process as a zombie
+    until it is garbage-collected.  This wrapper ensures the process is reaped
+    as soon as the caller is done reading.
+    """
+
+    def __init__(self, proc: subprocess.Popen[bytes]) -> None:
+        assert proc.stdout is not None
+        self._proc = proc
+        self._inner: IO[bytes] = proc.stdout
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def read(self, n: int = -1) -> bytes:
+        return self._inner.read(n)
+
+    def flush(self) -> None:
+        self._inner.flush()
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            self._inner.close()
+            self._proc.wait()
+
+    def __enter__(self) -> _ProcStream:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+
 class DockerComposeEnv(Environment):
     _command_category_width = 16
 
@@ -102,8 +139,7 @@ class DockerComposeEnv(Environment):
         proc = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
-        assert proc.stdout is not None
-        return proc.stdout
+        return cast(IO[bytes], _ProcStream(proc))
 
     def _docker_volume_tar_stream(self, vol_name: str) -> IO[bytes]:
         proc = subprocess.Popen(
@@ -122,8 +158,7 @@ class DockerComposeEnv(Environment):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        assert proc.stdout is not None
-        return proc.stdout
+        return cast(IO[bytes], _ProcStream(proc))
 
     @override
     def clone_impl(self, dst_env_tag: str) -> DockerComposeEnv:

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -18,7 +18,7 @@ import time
 from abc import ABC, abstractmethod
 from collections import deque
 from dataclasses import dataclass
-from typing import Any, Callable, Optional
+from typing import IO, Any, Callable, Optional
 
 import yaml
 
@@ -342,6 +342,16 @@ class Environment(ABC):
     def get_path_for_tag(self, env_tag: str) -> str:
         """Return the directory for the environment with a given tag."""
         return os.path.join(self.configMng.config.envs_path, env_tag)
+
+    def get_volume_tar_streams(self) -> list[tuple[str, IO[bytes]]]:
+        """Return one ``(volume_tag, tar_stream)`` pair per environment volume.
+
+        Each stream is uncompressed, rooted at ``.`` (entries like
+        ``./subdir/file``).  The tag binds the stream to the volume for
+        identity-preserving restore.  The default returns an empty list;
+        backends override this.
+        """
+        return []
 
     def ensure_resources(self):
         """Ensure the environment resources are available."""

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -38,4 +38,4 @@ addopts = [
   "--cov-config=.coveragerc",
   "-m", "not integration",
 ]
-markers = ["env", "svc", "cfg", "shpd", "compl", "docker", "integration"]
+markers = ["env", "svc", "cfg", "shpd", "compl", "docker", "integration", "storage"]

--- a/src/storage/tar_stream.py
+++ b/src/storage/tar_stream.py
@@ -10,6 +10,9 @@ including host-mounted volumes (with sudo escalation when required)."""
 
 from __future__ import annotations
 
+import os
+import tarfile
+import threading
 from typing import IO
 
 
@@ -17,17 +20,71 @@ class TarStreamProducer:
     """Produces an uncompressed tar stream for a Shepherd environment.
 
     The stream covers:
-    - The environment's data directory (``env.get_path()``).
-    - All host-mounted volume paths declared in ``env_cfg.volumes``.
+    - The environment's data directory under the ``env/`` arcname prefix.
+    - Each volume supplied as a ``(volume_tag, stream)`` pair, re-injected
+      under ``volumes/<tag>/``.
 
-    When a volume path is not readable by the current process (e.g. DBMS data
-    written under a non-root UID), the tar subprocess is spawned under ``sudo``,
-    mirroring the existing ``_delete_dir_with_sudo`` pattern.
+    Volume streams carry the ``volume_tag`` so that the resulting archive is
+    self-describing: a restore pass can match each ``volumes/<tag>/`` subtree
+    back to the correct ``VolumeCfg`` regardless of order or future additions.
+    Callers are responsible for producing the per-volume streams (e.g. via
+    ``Environment.get_volume_tar_streams()``).
+
+    Parameters
+    ----------
+    env_path:
+        Absolute path to the environment directory.  This path must be
+        readable by the current process.
+    volume_streams:
+        Ordered list of ``(volume_tag, uncompressed_tar_stream)`` pairs.
+        Each stream must be in tar streaming format (``r|``-readable, entries
+        rooted at ``.``).
     """
 
-    def stream(self) -> IO[bytes]:
-        """Return a readable, uncompressed tar byte stream for the environment.
+    def __init__(
+        self,
+        env_path: str,
+        volume_streams: list[tuple[str, IO[bytes]]],
+    ) -> None:
+        self._env_path = env_path
+        self._volume_streams = volume_streams
 
-        The caller is responsible for closing the stream when done.
+    def stream(self) -> IO[bytes]:
+        """Return a readable, uncompressed tar byte stream.
+
+        The stream is produced on a daemon background thread.  The caller is
+        responsible for closing the returned file object when done.
         """
-        raise NotImplementedError  # TODO: Issue 4
+        r_fd, w_fd = os.pipe()
+
+        def _produce() -> None:
+            try:
+                with os.fdopen(w_fd, "wb") as out_file:
+                    with tarfile.open(mode="w|", fileobj=out_file) as out_tar:
+                        out_tar.add(
+                            self._env_path, arcname="env", recursive=True
+                        )
+                        for tag, vol_stream in self._volume_streams:
+                            self._reinject(out_tar, tag, vol_stream)
+            except BrokenPipeError:
+                pass  # caller closed the read end early
+
+        t = threading.Thread(target=_produce, daemon=True)
+        t.start()
+        return os.fdopen(r_fd, "rb")
+
+    def _reinject(
+        self,
+        out_tar: tarfile.TarFile,
+        tag: str,
+        vol_stream: IO[bytes],
+    ) -> None:
+        """Copy entries from *vol_stream* into *out_tar* prefixed by tag."""
+        with tarfile.open(mode="r|", fileobj=vol_stream) as src_tar:
+            for member in src_tar:
+                rel = member.name.lstrip("./")
+                member.name = (
+                    f"volumes/{tag}/{rel}" if rel else f"volumes/{tag}"
+                )
+                fobj = src_tar.extractfile(member) if member.isreg() else None
+                out_tar.addfile(member, fobj)

--- a/src/storage/tar_stream.py
+++ b/src/storage/tar_stream.py
@@ -13,7 +13,53 @@ from __future__ import annotations
 import os
 import tarfile
 import threading
-from typing import IO
+from typing import IO, cast
+
+
+class _CheckedStream:
+    """Readable stream that re-raises background-thread errors on close.
+
+    Wraps the read end of the producer pipe.  When the caller closes the
+    stream, it joins the background thread and re-raises any exception the
+    producer stored — giving a clear root cause instead of a silent EOF.
+    ``BrokenPipeError`` (caller closed early) is never stored and therefore
+    never re-raised.
+    """
+
+    def __init__(
+        self,
+        r: IO[bytes],
+        thread: threading.Thread,
+        exc_holder: list[BaseException],
+    ) -> None:
+        self._r = r
+        self._thread = thread
+        self._exc_holder = exc_holder
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def read(self, n: int = -1) -> bytes:
+        return self._r.read(n)
+
+    def flush(self) -> None:
+        pass
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            self._r.close()
+            self._thread.join()
+            if self._exc_holder:
+                raise self._exc_holder[0]
+
+    def __enter__(self) -> _CheckedStream:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
 
 
 class TarStreamProducer:
@@ -52,10 +98,12 @@ class TarStreamProducer:
     def stream(self) -> IO[bytes]:
         """Return a readable, uncompressed tar byte stream.
 
-        The stream is produced on a daemon background thread.  The caller is
-        responsible for closing the returned file object when done.
+        The stream is produced on a daemon background thread.  Closing the
+        returned stream joins the thread; any exception raised by the producer
+        (other than ``BrokenPipeError``) is re-raised at that point.
         """
         r_fd, w_fd = os.pipe()
+        exc_holder: list[BaseException] = []
 
         def _produce() -> None:
             try:
@@ -68,10 +116,15 @@ class TarStreamProducer:
                             self._reinject(out_tar, tag, vol_stream)
             except BrokenPipeError:
                 pass  # caller closed the read end early
+            except BaseException as exc:
+                exc_holder.append(exc)
 
         t = threading.Thread(target=_produce, daemon=True)
         t.start()
-        return os.fdopen(r_fd, "rb")
+        return cast(
+            IO[bytes],
+            _CheckedStream(os.fdopen(r_fd, "rb"), t, exc_holder),
+        )
 
     def _reinject(
         self,
@@ -88,3 +141,4 @@ class TarStreamProducer:
                 )
                 fobj = src_tar.extractfile(member) if member.isreg() else None
                 out_tar.addfile(member, fobj)
+        vol_stream.close()

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -1783,3 +1783,143 @@ def test_check_probe_timeout(
 
     assert result.exit_code != 0
     mock_subproc.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# get_volume_tar_streams
+# ---------------------------------------------------------------------------
+
+
+def _make_env_cfg_with_volumes(volumes: list[object]) -> object:
+    return SimpleNamespace(
+        tag="test-env",
+        services=[],
+        volumes=volumes,
+        status=SimpleNamespace(rendered_config=None),
+    )
+
+
+def _bind_vol(tag: str, device: str) -> object:
+    return SimpleNamespace(
+        tag=tag,
+        driver="local",
+        driver_opts={"type": "none", "o": "bind", "device": device},
+        name=None,
+        external="false",
+        is_external=lambda: False,
+    )
+
+
+def _named_vol(tag: str) -> object:
+    return SimpleNamespace(
+        tag=tag,
+        driver=None,
+        driver_opts=None,
+        name=None,
+        external="false",
+        is_external=lambda: False,
+    )
+
+
+def _external_vol(tag: str, name: str) -> object:
+    return SimpleNamespace(
+        tag=tag,
+        driver=None,
+        driver_opts=None,
+        name=name,
+        external="true",
+        is_external=lambda: True,
+    )
+
+
+@pytest.mark.env
+def test_volume_streams_empty(mocker: MockerFixture) -> None:
+    """No volumes → empty list returned."""
+    env_cfg = _make_env_cfg_with_volumes([])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    assert env.get_volume_tar_streams() == []
+
+
+@pytest.mark.env
+def test_volume_streams_bind_mount_readable(mocker: MockerFixture) -> None:
+    """Bind-mount whose path is readable → ``tar -cC`` (no sudo)."""
+    env_cfg = _make_env_cfg_with_volumes([_bind_vol("db_data", "/data/db")])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+
+    mocker.patch.object(env, "_is_readable", return_value=True)
+    mock_popen = mocker.patch(
+        "docker.docker_compose_env.subprocess.Popen",
+        return_value=mocker.Mock(stdout=mocker.Mock()),
+    )
+
+    streams = env.get_volume_tar_streams()
+
+    assert len(streams) == 1
+    tag, _ = streams[0]
+    assert tag == "db_data"
+    cmd = mock_popen.call_args[0][0]
+    assert cmd == ["tar", "-cC", "/data/db", "."]
+
+
+@pytest.mark.env
+def test_volume_streams_bind_mount_sudo(mocker: MockerFixture) -> None:
+    """Bind-mount whose path is not readable → ``sudo tar -cC``."""
+    env_cfg = _make_env_cfg_with_volumes([_bind_vol("db_data", "/data/db")])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+
+    mocker.patch.object(env, "_is_readable", return_value=False)
+    mock_popen = mocker.patch(
+        "docker.docker_compose_env.subprocess.Popen",
+        return_value=mocker.Mock(stdout=mocker.Mock()),
+    )
+
+    streams = env.get_volume_tar_streams()
+
+    assert len(streams) == 1
+    tag, _ = streams[0]
+    assert tag == "db_data"
+    cmd = mock_popen.call_args[0][0]
+    assert cmd == ["sudo", "tar", "-cC", "/data/db", "."]
+
+
+@pytest.mark.env
+def test_volume_streams_named_volume(mocker: MockerFixture) -> None:
+    """Named volume → ``docker run --rm -v <tag>:/mnt``."""
+    env_cfg = _make_env_cfg_with_volumes([_named_vol("uploads")])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+
+    mock_popen = mocker.patch(
+        "docker.docker_compose_env.subprocess.Popen",
+        return_value=mocker.Mock(stdout=mocker.Mock()),
+    )
+
+    streams = env.get_volume_tar_streams()
+
+    assert len(streams) == 1
+    tag, _ = streams[0]
+    assert tag == "uploads"
+    cmd = mock_popen.call_args[0][0]
+    assert "docker" in cmd
+    assert "uploads:/mnt" in cmd
+
+
+@pytest.mark.env
+def test_volume_streams_external_volume(mocker: MockerFixture) -> None:
+    """External volume uses ``vol.name`` (not tag) for the docker run volume arg."""
+    env_cfg = _make_env_cfg_with_volumes(
+        [_external_vol("ext_vol", "prod_db_backup")]
+    )
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+
+    mock_popen = mocker.patch(
+        "docker.docker_compose_env.subprocess.Popen",
+        return_value=mocker.Mock(stdout=mocker.Mock()),
+    )
+
+    streams = env.get_volume_tar_streams()
+
+    assert len(streams) == 1
+    tag, _ = streams[0]
+    assert tag == "ext_vol"
+    cmd = mock_popen.call_args[0][0]
+    assert "prod_db_backup:/mnt" in cmd

--- a/src/tests/test_storage_tar_stream.py
+++ b/src/tests/test_storage_tar_stream.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+from typing import IO
+
+import pytest
+
+from storage import TarStreamProducer
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tar_stream(files: dict[str, bytes]) -> IO[bytes]:
+    """Build an in-memory tar stream with the given ``{name: content}`` map."""
+    buf = io.BytesIO()
+    with tarfile.open(mode="w|", fileobj=buf) as t:
+        for name, content in files.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(content)
+            t.addfile(info, io.BytesIO(content))
+    buf.seek(0)
+    return buf
+
+
+def _list_tar_names(stream: IO[bytes]) -> list[str]:
+    with tarfile.open(mode="r|", fileobj=stream) as t:
+        return [m.name for m in t]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.storage
+def test_stream_env_only(tmp_path: Path) -> None:
+    """Output tar contains env/ entries when no volumes are provided."""
+    env_dir = tmp_path / "myenv"
+    env_dir.mkdir()
+    (env_dir / "docker-compose.yml").write_text("version: '3'")
+
+    producer = TarStreamProducer(str(env_dir), [])
+    names = _list_tar_names(producer.stream())
+
+    assert any(n.startswith("env") for n in names)
+    assert not any(n.startswith("volumes/") for n in names)
+
+
+@pytest.mark.storage
+def test_stream_with_volumes(tmp_path: Path) -> None:
+    """Volume streams are re-injected under volumes/<tag>/."""
+    env_dir = tmp_path / "env"
+    env_dir.mkdir()
+    (env_dir / "meta.yml").write_text("tag: test")
+
+    vol_a = _make_tar_stream({"./data.bin": b"aaa"})
+    vol_b = _make_tar_stream({"./rows.csv": b"1,2,3"})
+
+    producer = TarStreamProducer(
+        str(env_dir),
+        [("db_data", vol_a), ("uploads", vol_b)],
+    )
+    names = _list_tar_names(producer.stream())
+
+    assert any(n.startswith("env") for n in names)
+    assert any(n.startswith("volumes/db_data") for n in names)
+    assert any(n.startswith("volumes/uploads") for n in names)
+
+
+@pytest.mark.storage
+def test_stream_env_and_volume_arcnames(tmp_path: Path) -> None:
+    """Arcname prefixes are exactly env/ and volumes/<tag>/ — not index-based."""
+    env_dir = tmp_path / "env"
+    env_dir.mkdir()
+    (env_dir / "cfg.yml").write_text("x: 1")
+
+    vol = _make_tar_stream({"./file.txt": b"hello"})
+    producer = TarStreamProducer(str(env_dir), [("my_vol", vol)])
+    names = _list_tar_names(producer.stream())
+
+    # Exact prefix check
+    assert all(
+        n.startswith("env") or n.startswith("volumes/my_vol") for n in names
+    )
+    # No numeric index in any name
+    assert not any(n.startswith("volumes/0") for n in names)


### PR DESCRIPTION
## Summary

- Add `Environment.get_volume_tar_streams() -> list[tuple[str, IO[bytes]]]` to the ABC (non-abstract, default `[]`)
- Implement in `DockerComposeEnv`: bind-mounts use path-based `tar`/`sudo tar`; named and external volumes use `docker run --rm -v <name>:/mnt busybox tar`
- Implement `TarStreamProducer` (was `NotImplementedError` stub): accepts `(volume_tag, stream)` pairs; re-injects each under `volumes/<tag>/` so the archive is self-describing
- Add `"storage"` pytest marker
- Add 3 `@pytest.mark.storage` tests for `TarStreamProducer` and 5 `@pytest.mark.env` tests for `DockerComposeEnv.get_volume_tar_streams()`

## Design notes

- Volume identity is preserved via the tag: `volumes/<tag>/` arcnames allow restoration to match each subtree back to its `VolumeCfg` regardless of ordering or future additions
- All backend knowledge (sudo, docker run) stays inside `DockerComposeEnv`; `TarStreamProducer` is a pure stream stitcher
- `_is_readable` is a separate method to allow targeted mocking in tests

## Test plan

- [x] `pytest -m storage -v` — 3 new tests pass
- [x] `pytest -m env -v -k volume_stream` — 5 new tests pass
- [x] `pytest -q` — 362 passed, 0 failures
- [x] `black --check` passes
- [x] `isort --check-only` passes
- [x] `pyright` — 55 pre-existing errors, 0 new

Fixes: #207