### PR TITLE
feat(storage): implement LRU on-disk local chunk cache

### DIFF
--- a/src/storage/local_cache.py
+++ b/src/storage/local_cache.py
@@ -18,6 +18,9 @@ drop-in no-op with zero overhead.
 
 from __future__ import annotations
 
+import json
+import pathlib
+import threading
 from typing import Protocol, runtime_checkable
 
 
@@ -50,18 +53,91 @@ class LocalChunkCache:
     """
 
     def __init__(self, cache_path: str, max_bytes: int) -> None:
-        raise NotImplementedError  # TODO: Issue 6
+        self._max_bytes = max_bytes
+        self._lock = threading.Lock()
+        self._root = pathlib.Path(cache_path)
+        self._meta_path = self._root / "meta.json"
+        self._chunks_dir = self._root / "chunks"
+        self._chunks_dir.mkdir(parents=True, exist_ok=True)
+        # _order: front = LRU, back = MRU
+        self._order: list[str] = []
+        self._sizes: dict[str, int] = {}
+        self._total: int = 0
+        self._load_meta()
+
+    # ------------------------------------------------------------------
+    # Protocol implementation
+    # ------------------------------------------------------------------
 
     def contains(self, chunk_hash: str) -> bool:
-        raise NotImplementedError  # TODO: Issue 6
+        with self._lock:
+            return chunk_hash in self._sizes
 
     def get(self, chunk_hash: str) -> bytes | None:
         """Return compressed chunk bytes, or ``None`` if not cached."""
-        raise NotImplementedError  # TODO: Issue 6
+        with self._lock:
+            if chunk_hash not in self._sizes:
+                return None
+            data = self._chunk_path(chunk_hash).read_bytes()
+            # Promote to MRU.
+            self._order.remove(chunk_hash)
+            self._order.append(chunk_hash)
+            self._save_meta()
+            return data
 
     def put(self, chunk_hash: str, data: bytes) -> None:
         """Store compressed chunk bytes; evict LRU entries if over budget."""
-        raise NotImplementedError  # TODO: Issue 6
+        with self._lock:
+            if chunk_hash in self._sizes:
+                # Refresh: remove old accounting before re-writing.
+                self._total -= self._sizes.pop(chunk_hash)
+                self._order.remove(chunk_hash)
+            path = self._chunk_path(chunk_hash)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(data)
+            size = len(data)
+            self._sizes[chunk_hash] = size
+            self._total += size
+            self._order.append(chunk_hash)
+            self._evict()
+            self._save_meta()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _chunk_path(self, chunk_hash: str) -> pathlib.Path:
+        return self._chunks_dir / chunk_hash[:2] / chunk_hash
+
+    def _evict(self) -> None:
+        """Remove LRU entries until total_bytes ≤ max_bytes."""
+        while self._total > self._max_bytes and self._order:
+            lru = self._order.pop(0)
+            evicted = self._sizes.pop(lru, 0)
+            self._total -= evicted
+            self._chunk_path(lru).unlink(missing_ok=True)
+
+    def _load_meta(self) -> None:
+        if not self._meta_path.exists():
+            return
+        with self._meta_path.open() as fh:
+            d: dict[str, object] = json.load(fh)
+        self._order = list(d.get("order", []))  # type: ignore[arg-type]
+        self._sizes = dict(d.get("sizes", {}))  # type: ignore[arg-type]
+        self._total = int(d.get("total_bytes", 0))  # type: ignore[arg-type]
+
+    def _save_meta(self) -> None:
+        tmp = self._meta_path.with_suffix(".tmp")
+        with tmp.open("w") as fh:
+            json.dump(
+                {
+                    "total_bytes": self._total,
+                    "order": self._order,
+                    "sizes": self._sizes,
+                },
+                fh,
+            )
+        tmp.replace(self._meta_path)
 
 
 class NullLocalChunkCache:

--- a/src/tests/test_storage_local_cache.py
+++ b/src/tests/test_storage_local_cache.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from storage import (
+    LocalChunkCache,
+    LocalChunkCacheProtocol,
+    NullLocalChunkCache,
+)
+
+_HASH_A = "a" * 64
+_HASH_B = "b" * 64
+_HASH_C = "c" * 64
+_DATA_A = b"chunk-a-data"
+_DATA_B = b"chunk-b-data"
+_DATA_C = b"chunk-c-data"
+
+
+@pytest.mark.storage
+def test_cache_put_and_get(tmp_path: pathlib.Path) -> None:
+    """put then get returns the same bytes."""
+    cache = LocalChunkCache(str(tmp_path), max_bytes=1024 * 1024)
+    cache.put(_HASH_A, _DATA_A)
+    assert cache.get(_HASH_A) == _DATA_A
+
+
+@pytest.mark.storage
+def test_cache_contains(tmp_path: pathlib.Path) -> None:
+    """contains returns True after put, False for absent hash."""
+    cache = LocalChunkCache(str(tmp_path), max_bytes=1024 * 1024)
+    assert not cache.contains(_HASH_A)
+    cache.put(_HASH_A, _DATA_A)
+    assert cache.contains(_HASH_A)
+    assert not cache.contains(_HASH_B)
+
+
+@pytest.mark.storage
+def test_cache_get_missing(tmp_path: pathlib.Path) -> None:
+    """get of an absent hash returns None."""
+    cache = LocalChunkCache(str(tmp_path), max_bytes=1024 * 1024)
+    assert cache.get(_HASH_A) is None
+
+
+@pytest.mark.storage
+def test_cache_evicts_lru(tmp_path: pathlib.Path) -> None:
+    """Inserting past the budget evicts the least-recently-used entry."""
+    # budget: fits exactly two 12-byte chunks
+    cache = LocalChunkCache(str(tmp_path), max_bytes=len(_DATA_A) * 2)
+    cache.put(_HASH_A, _DATA_A)
+    cache.put(_HASH_B, _DATA_B)
+    # Adding a third entry must evict the LRU (_HASH_A).
+    cache.put(_HASH_C, _DATA_C)
+    assert not cache.contains(_HASH_A)
+    assert cache.contains(_HASH_B)
+    assert cache.contains(_HASH_C)
+
+
+@pytest.mark.storage
+def test_cache_lru_order_updated_on_get(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A get call promotes the entry to MRU, changing eviction order."""
+    cache = LocalChunkCache(str(tmp_path), max_bytes=len(_DATA_A) * 2)
+    cache.put(_HASH_A, _DATA_A)
+    cache.put(_HASH_B, _DATA_B)
+    # Access _HASH_A so it becomes MRU; _HASH_B is now LRU.
+    cache.get(_HASH_A)
+    cache.put(_HASH_C, _DATA_C)
+    assert cache.contains(_HASH_A)
+    assert not cache.contains(_HASH_B)
+    assert cache.contains(_HASH_C)
+
+
+@pytest.mark.storage
+def test_cache_persists_across_instances(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Data and LRU metadata survive across separate LocalChunkCache instances."""
+    cache1 = LocalChunkCache(str(tmp_path), max_bytes=1024 * 1024)
+    cache1.put(_HASH_A, _DATA_A)
+    cache1.put(_HASH_B, _DATA_B)
+
+    cache2 = LocalChunkCache(str(tmp_path), max_bytes=1024 * 1024)
+    assert cache2.get(_HASH_A) == _DATA_A
+    assert cache2.get(_HASH_B) == _DATA_B
+
+
+@pytest.mark.storage
+def test_null_cache_always_misses() -> None:
+    """NullLocalChunkCache always returns False/None and accepts put silently."""
+    null = NullLocalChunkCache()
+    null.put(_HASH_A, _DATA_A)
+    assert not null.contains(_HASH_A)
+    assert null.get(_HASH_A) is None
+
+
+@pytest.mark.storage
+def test_protocol_satisfied(tmp_path: pathlib.Path) -> None:
+    """Both implementations satisfy LocalChunkCacheProtocol."""
+    assert isinstance(NullLocalChunkCache(), LocalChunkCacheProtocol)
+    assert isinstance(
+        LocalChunkCache(str(tmp_path), max_bytes=1024),
+        LocalChunkCacheProtocol,
+    )


### PR DESCRIPTION
## Summary

- Implements `LocalChunkCache` in `src/storage/local_cache.py`:
  - Flat-file layout: `chunks/<hash[:2]>/<hash>` under the configured root
  - LRU metadata persisted atomically in `meta.json` (`total_bytes`, `order`, `sizes`)
  - `put()` writes compressed bytes and evicts LRU entries until `total_bytes ≤ max_bytes`
  - `get()` promotes the accessed entry to MRU and persists the updated order
  - Thread-safe via a single `threading.Lock`
- `NullLocalChunkCache` already implemented (no-op drop-in, unchanged)
- Both classes satisfy `LocalChunkCacheProtocol` (verified by test)
- Adds 8 unit tests covering: put/get, contains, missing-get, LRU eviction, LRU order on get, cross-instance persistence, null cache, protocol conformance

## Testing

```
cd src
pytest -m storage -v        # 24 storage tests pass (8 new)
pytest -q                   # 383 passed, 0 regressions
black src --check
isort src --check-only
pyright src                 # 0 errors
```

Fixes: #212