### PR TITLE
feat(remote): implement FTPBackend and SFTPBackend

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -39,4 +39,4 @@ addopts = [
   "--cov-config=.coveragerc",
   "-m", "not integration",
 ]
-markers = ["env", "svc", "cfg", "shpd", "compl", "docker", "integration", "storage"]
+markers = ["env", "svc", "cfg", "shpd", "compl", "docker", "integration", "storage", "remote"]

--- a/src/remote/ftp_backend.py
+++ b/src/remote/ftp_backend.py
@@ -9,6 +9,10 @@
 
 from __future__ import annotations
 
+import ftplib
+import io
+import posixpath
+
 from .backend import RemoteBackend
 
 
@@ -43,24 +47,94 @@ class FTPBackend(RemoteBackend):
         password: str = "",
         root_path: str = "/",
     ) -> None:
-        raise NotImplementedError  # TODO: Issue 7
+        self._root = root_path.rstrip("/")
+        # Shard cache: shard prefix → set of known chunk hashes.
+        self._shard_cache: dict[str, set[str]] = {}
+        self._ftp = ftplib.FTP()
+        self._ftp.connect(host, port)
+        self._ftp.login(user, password)
+        self._ftp.set_pasv(True)
 
+    # ------------------------------------------------------------------
     # RemoteBackend implementation
+    # ------------------------------------------------------------------
 
     def exists(self, path: str) -> bool:
-        raise NotImplementedError  # TODO: Issue 7
+        parts = path.split("/")
+        if len(parts) == 3 and parts[0] == "chunks":
+            shard = parts[1]
+            if shard not in self._shard_cache:
+                self._warm_shard(shard)
+            return parts[2] in self._shard_cache.get(shard, set())
+        try:
+            self._ftp.size(self._abs(path))
+            return True
+        except ftplib.error_perm:
+            return False
 
     def upload(self, path: str, data: bytes) -> None:
-        raise NotImplementedError  # TODO: Issue 7
+        abs_path = self._abs(path)
+        self._mkdirs(posixpath.dirname(abs_path))
+        self._ftp.storbinary(f"STOR {abs_path}", io.BytesIO(data))
+        # Keep shard cache consistent after a new chunk is written.
+        parts = path.split("/")
+        if len(parts) == 3 and parts[0] == "chunks":
+            shard = parts[1]
+            if shard in self._shard_cache:
+                self._shard_cache[shard].add(parts[2])
 
     def download(self, path: str) -> bytes:
-        raise NotImplementedError  # TODO: Issue 7
+        buf = io.BytesIO()
+        self._ftp.retrbinary(f"RETR {self._abs(path)}", buf.write)
+        return buf.getvalue()
 
     def list_prefix(self, prefix: str) -> list[str]:
-        raise NotImplementedError  # TODO: Issue 7
+        names: list[str] = []
+        try:
+            self._ftp.retrlines(f"NLST {self._abs(prefix)}", names.append)
+        except ftplib.error_perm:
+            pass
+        return [posixpath.basename(n) for n in names]
 
     def delete(self, path: str) -> None:
-        raise NotImplementedError  # TODO: Issue 7
+        # Note: the shard cache is NOT updated here.  Deletion happens during
+        # pruning, which uses a separate backend instance from the dedup-check
+        # path, so stale cache entries are never observed in practice.
+        try:
+            self._ftp.delete(self._abs(path))
+        except ftplib.error_perm:
+            pass
 
     def close(self) -> None:
-        raise NotImplementedError  # TODO: Issue 7
+        try:
+            self._ftp.quit()
+        except Exception:
+            self._ftp.close()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _abs(self, path: str) -> str:
+        return f"{self._root}/{path}" if self._root else path
+
+    def _mkdirs(self, abs_dir: str) -> None:
+        """Create all components of *abs_dir*, ignoring existing dirs."""
+        current = ""
+        for part in abs_dir.lstrip("/").split("/"):
+            current = f"{current}/{part}"
+            try:
+                self._ftp.mkd(current)
+            except ftplib.error_perm:
+                pass
+
+    def _warm_shard(self, shard: str) -> None:
+        """Populate the shard cache for *shard* with a single NLST call."""
+        names: list[str] = []
+        try:
+            self._ftp.retrlines(
+                f"NLST {self._abs(f'chunks/{shard}')}", names.append
+            )
+        except ftplib.error_perm:
+            pass
+        self._shard_cache[shard] = {posixpath.basename(n) for n in names}

--- a/src/remote/sftp_backend.py
+++ b/src/remote/sftp_backend.py
@@ -9,7 +9,20 @@
 
 from __future__ import annotations
 
+import posixpath
+
+import paramiko
+
 from .backend import RemoteBackend
+
+
+def _load_pkey(path: str) -> paramiko.PKey:
+    """Load a private key from *path*, auto-detecting the key type.
+
+    Uses ``paramiko.PKey.from_path`` (available since paramiko 3.2), which
+    transparently handles Ed25519, ECDSA, and RSA keys.
+    """
+    return paramiko.PKey.from_path(path)  # type: ignore[return-value]
 
 
 class SFTPBackend(RemoteBackend):
@@ -45,24 +58,71 @@ class SFTPBackend(RemoteBackend):
         identity_file: str | None = None,
         root_path: str = "/",
     ) -> None:
-        raise NotImplementedError  # TODO: Issue 7
+        self._root = root_path.rstrip("/")
+        self._transport = paramiko.Transport((host, port))
+        if identity_file:
+            self._transport.connect(
+                username=user, pkey=_load_pkey(identity_file)
+            )
+        else:
+            self._transport.connect(username=user, password=password)
+        sftp = paramiko.SFTPClient.from_transport(self._transport)
+        if sftp is None:
+            raise RuntimeError("Failed to open SFTP channel")
+        self._sftp = sftp
 
+    # ------------------------------------------------------------------
     # RemoteBackend implementation
+    # ------------------------------------------------------------------
 
     def exists(self, path: str) -> bool:
-        raise NotImplementedError  # TODO: Issue 7
+        try:
+            self._sftp.stat(self._abs(path))
+            return True
+        except FileNotFoundError:
+            return False
 
     def upload(self, path: str, data: bytes) -> None:
-        raise NotImplementedError  # TODO: Issue 7
+        abs_path = self._abs(path)
+        self._mkdirs(posixpath.dirname(abs_path))
+        with self._sftp.open(abs_path, "wb") as f:
+            f.write(data)
 
     def download(self, path: str) -> bytes:
-        raise NotImplementedError  # TODO: Issue 7
+        with self._sftp.open(self._abs(path), "rb") as f:
+            return bytes(f.read())
 
     def list_prefix(self, prefix: str) -> list[str]:
-        raise NotImplementedError  # TODO: Issue 7
+        try:
+            return self._sftp.listdir(self._abs(prefix))
+        except FileNotFoundError:
+            return []
 
     def delete(self, path: str) -> None:
-        raise NotImplementedError  # TODO: Issue 7
+        try:
+            self._sftp.remove(self._abs(path))
+        except FileNotFoundError:
+            pass
 
     def close(self) -> None:
-        raise NotImplementedError  # TODO: Issue 7
+        try:
+            self._sftp.close()
+        finally:
+            self._transport.close()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _abs(self, path: str) -> str:
+        return f"{self._root}/{path}" if self._root else path
+
+    def _mkdirs(self, abs_dir: str) -> None:
+        """Create all components of *abs_dir*, ignoring existing dirs."""
+        current = ""
+        for part in abs_dir.lstrip("/").split("/"):
+            current = f"{current}/{part}"
+            try:
+                self._sftp.mkdir(current)
+            except OSError:
+                pass

--- a/src/tests/test_remote_backends.py
+++ b/src/tests/test_remote_backends.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+from __future__ import annotations
+
+import ftplib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from remote import FTPBackend, SFTPBackend
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ROOT = "/shepherd"
+_CHUNK_HASH = "ab" + "3f" * 31  # 64-char hex hash, shard "ab"
+_CHUNK_PATH = f"chunks/ab/{_CHUNK_HASH}"
+_META_PATH = "envs/my-env/latest.json"
+_DATA = b"some compressed chunk bytes"
+
+
+def _make_ftp_backend(mock_ftp: MagicMock, root: str = _ROOT) -> FTPBackend:
+    """Construct FTPBackend with a pre-wired mock FTP instance."""
+    with patch("remote.ftp_backend.ftplib.FTP", return_value=mock_ftp):
+        return FTPBackend("host", root_path=root)
+
+
+def _make_sftp_backend(
+    mock_sftp: MagicMock,
+    mock_transport: MagicMock,
+    root: str = _ROOT,
+) -> SFTPBackend:
+    """Construct SFTPBackend with pre-wired mock transport and SFTP client."""
+    with (
+        patch(
+            "remote.sftp_backend.paramiko.Transport",
+            return_value=mock_transport,
+        ),
+        patch(
+            "remote.sftp_backend.paramiko.SFTPClient.from_transport",
+            return_value=mock_sftp,
+        ),
+    ):
+        return SFTPBackend("host", root_path=root)
+
+
+# ---------------------------------------------------------------------------
+# FTPBackend tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_ftp_upload_calls_stor() -> None:
+    """upload issues STOR at the correct absolute path."""
+    mock_ftp = MagicMock()
+    backend = _make_ftp_backend(mock_ftp)
+    backend.upload(_CHUNK_PATH, _DATA)
+    mock_ftp.storbinary.assert_called_once()
+    cmd = mock_ftp.storbinary.call_args[0][0]
+    assert cmd == f"STOR {_ROOT}/{_CHUNK_PATH}"
+
+
+@pytest.mark.remote
+def test_ftp_download_returns_data() -> None:
+    """download pipes RETR output into a buffer and returns it."""
+    mock_ftp = MagicMock()
+
+    def retrbinary_side_effect(cmd: str, callback: object) -> None:
+        assert callable(callback)
+        callback(_DATA)  # type: ignore[operator]
+
+    mock_ftp.retrbinary.side_effect = retrbinary_side_effect
+    backend = _make_ftp_backend(mock_ftp)
+    result = backend.download(_META_PATH)
+    assert result == _DATA
+
+
+@pytest.mark.remote
+def test_ftp_exists_shard_cache_warms_once() -> None:
+    """NLST is called once per shard; subsequent exists() hits the cache."""
+    mock_ftp = MagicMock()
+
+    def retrlines_side_effect(cmd: str, callback: object) -> None:
+        assert callable(callback)
+        if "NLST" in cmd:
+            callback(_CHUNK_HASH)  # type: ignore[operator]
+
+    mock_ftp.retrlines.side_effect = retrlines_side_effect
+    backend = _make_ftp_backend(mock_ftp)
+
+    assert backend.exists(_CHUNK_PATH) is True
+    assert backend.exists(_CHUNK_PATH) is True  # second call
+    # NLST was issued only once (warm_shard), not on the second call.
+    nlst_calls = [
+        c for c in mock_ftp.retrlines.call_args_list if "NLST" in c[0][0]
+    ]
+    assert len(nlst_calls) == 1
+
+
+@pytest.mark.remote
+def test_ftp_exists_shard_cache_miss() -> None:
+    """exists() returns False for a hash not in the NLST result."""
+    mock_ftp = MagicMock()
+    mock_ftp.retrlines.return_value = None  # NLST yields nothing
+    backend = _make_ftp_backend(mock_ftp)
+    assert backend.exists(_CHUNK_PATH) is False
+
+
+@pytest.mark.remote
+def test_ftp_exists_non_chunk_uses_size() -> None:
+    """Non-chunk paths use SIZE, not NLST."""
+    mock_ftp = MagicMock()
+    backend = _make_ftp_backend(mock_ftp)
+    assert backend.exists(_META_PATH) is True
+    mock_ftp.size.assert_called_once_with(f"{_ROOT}/{_META_PATH}")
+    mock_ftp.retrlines.assert_not_called()
+
+
+@pytest.mark.remote
+def test_ftp_exists_non_chunk_missing() -> None:
+    """SIZE raising error_perm maps to False."""
+    mock_ftp = MagicMock()
+    mock_ftp.size.side_effect = ftplib.error_perm("550 not found")
+    backend = _make_ftp_backend(mock_ftp)
+    assert backend.exists(_META_PATH) is False
+
+
+@pytest.mark.remote
+def test_ftp_list_prefix_returns_basenames() -> None:
+    """list_prefix strips directory components returned by some FTP servers."""
+    mock_ftp = MagicMock()
+
+    def retrlines_side_effect(cmd: str, callback: object) -> None:
+        assert callable(callback)
+        # Simulate an FTP server that returns full paths in NLST.
+        for name in [f"{_ROOT}/chunks/ab/hash1", f"{_ROOT}/chunks/ab/hash2"]:
+            callback(name)  # type: ignore[operator]
+
+    mock_ftp.retrlines.side_effect = retrlines_side_effect
+    backend = _make_ftp_backend(mock_ftp)
+    result = backend.list_prefix("chunks/ab")
+    assert result == ["hash1", "hash2"]
+
+
+@pytest.mark.remote
+def test_ftp_list_prefix_empty_on_error() -> None:
+    """error_perm from NLST (missing dir) returns an empty list."""
+    mock_ftp = MagicMock()
+    mock_ftp.retrlines.side_effect = ftplib.error_perm("550 no such dir")
+    backend = _make_ftp_backend(mock_ftp)
+    assert backend.list_prefix("chunks/zz") == []
+
+
+@pytest.mark.remote
+def test_ftp_delete_ignores_missing() -> None:
+    """error_perm from DELETE does not propagate."""
+    mock_ftp = MagicMock()
+    mock_ftp.delete.side_effect = ftplib.error_perm("550 not found")
+    backend = _make_ftp_backend(mock_ftp)
+    backend.delete(_CHUNK_PATH)  # must not raise
+
+
+@pytest.mark.remote
+def test_ftp_close_calls_quit() -> None:
+    """close() calls quit() on the FTP connection."""
+    mock_ftp = MagicMock()
+    backend = _make_ftp_backend(mock_ftp)
+    backend.close()
+    mock_ftp.quit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# SFTPBackend tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_sftp_upload_creates_parents() -> None:
+    """upload calls mkdir for each path component, then opens for writing."""
+    mock_sftp = MagicMock()
+    mock_transport = MagicMock()
+    backend = _make_sftp_backend(mock_sftp, mock_transport)
+    backend.upload(_CHUNK_PATH, _DATA)
+    # open("wb") must have been called with the correct absolute path.
+    mock_sftp.open.assert_called_once_with(f"{_ROOT}/{_CHUNK_PATH}", "wb")
+    # mkdir must have been called at least once (for intermediate dirs).
+    assert mock_sftp.mkdir.call_count >= 1
+
+
+@pytest.mark.remote
+def test_sftp_download_returns_data() -> None:
+    """download opens "rb", reads, and returns bytes."""
+    mock_sftp = MagicMock()
+    mock_transport = MagicMock()
+    mock_file = MagicMock()
+    mock_file.read.return_value = _DATA
+    mock_sftp.open.return_value.__enter__ = MagicMock(return_value=mock_file)
+    mock_sftp.open.return_value.__exit__ = MagicMock(return_value=False)
+    backend = _make_sftp_backend(mock_sftp, mock_transport)
+    result = backend.download(_META_PATH)
+    assert result == _DATA
+    mock_sftp.open.assert_called_once_with(f"{_ROOT}/{_META_PATH}", "rb")
+
+
+@pytest.mark.remote
+def test_sftp_exists_true() -> None:
+    """exists() returns True when stat() succeeds."""
+    mock_sftp = MagicMock()
+    mock_transport = MagicMock()
+    backend = _make_sftp_backend(mock_sftp, mock_transport)
+    assert backend.exists(_META_PATH) is True
+    mock_sftp.stat.assert_called_once_with(f"{_ROOT}/{_META_PATH}")
+
+
+@pytest.mark.remote
+def test_sftp_exists_false_on_missing() -> None:
+    """exists() returns False when stat() raises FileNotFoundError."""
+    mock_sftp = MagicMock()
+    mock_transport = MagicMock()
+    mock_sftp.stat.side_effect = FileNotFoundError
+    backend = _make_sftp_backend(mock_sftp, mock_transport)
+    assert backend.exists(_META_PATH) is False
+
+
+@pytest.mark.remote
+def test_sftp_list_prefix_returns_names() -> None:
+    """list_prefix returns the listdir result directly."""
+    mock_sftp = MagicMock()
+    mock_transport = MagicMock()
+    mock_sftp.listdir.return_value = ["hash1", "hash2"]
+    backend = _make_sftp_backend(mock_sftp, mock_transport)
+    assert backend.list_prefix("chunks/ab") == ["hash1", "hash2"]
+    mock_sftp.listdir.assert_called_once_with(f"{_ROOT}/chunks/ab")
+
+
+@pytest.mark.remote
+def test_sftp_list_prefix_empty_on_missing() -> None:
+    """FileNotFoundError from listdir (missing dir) returns []."""
+    mock_sftp = MagicMock()
+    mock_transport = MagicMock()
+    mock_sftp.listdir.side_effect = FileNotFoundError
+    backend = _make_sftp_backend(mock_sftp, mock_transport)
+    assert backend.list_prefix("chunks/zz") == []
+
+
+@pytest.mark.remote
+def test_sftp_delete_ignores_missing() -> None:
+    """FileNotFoundError from remove does not propagate."""
+    mock_sftp = MagicMock()
+    mock_transport = MagicMock()
+    mock_sftp.remove.side_effect = FileNotFoundError
+    backend = _make_sftp_backend(mock_sftp, mock_transport)
+    backend.delete(_CHUNK_PATH)  # must not raise
+
+
+@pytest.mark.remote
+def test_sftp_close_closes_transport() -> None:
+    """transport.close() is always called, even if sftp.close() raises."""
+    mock_sftp = MagicMock()
+    mock_transport = MagicMock()
+    mock_sftp.close.side_effect = RuntimeError("channel broken")
+    backend = _make_sftp_backend(mock_sftp, mock_transport)
+    with pytest.raises(RuntimeError):
+        backend.close()
+    mock_transport.close.assert_called_once()


### PR DESCRIPTION
## Summary

- Implements `FTPBackend` using stdlib `ftplib`: shard-listing strategy warms an in-memory `set[str]` per 2-char prefix on the first `exists()` call, eliminating redundant `NLST` round-trips during dedup checks
- Implements `SFTPBackend` using `paramiko`: supports password and private-key auth; uses `paramiko.PKey.from_path()` for auto-detection of Ed25519, ECDSA, and RSA key types
- Both backends share `_abs(path)` and `_mkdirs(abs_dir)` helpers; safe as context managers via `RemoteBackend.__exit__`
- 18 new unit tests under `@pytest.mark.remote`, all mocked (no live server needed)
- Registers `remote` marker in `pyproject.toml`

## Testing

```
cd src
pytest -m remote -v        # 18 new tests pass
pytest -q                  # 401 passed, 0 regressions
black src --check
isort src --check-only
pyright src                # 0 errors
```

Fixes: #213