### PR TITLE
feat(plugin): enforce capabilities declared in plugin.yaml

### DIFF
--- a/src/plugin/runtime.py
+++ b/src/plugin/runtime.py
@@ -533,21 +533,77 @@ class PluginRuntimeMng:
         plugin_id = loaded.descriptor.id
         if plugin_id in self.registry.plugins:
             Util.print_error_and_die(f"Plugin '{plugin_id}' is already loaded.")
+
+        # Collect contributions once so they can be capability-checked and
+        # registered without calling each getter twice.
+        commands = loaded.instance.get_commands()
+        completions = loaded.instance.get_completion_providers()
+        env_factories = loaded.instance.get_env_factories()
+        svc_factories = loaded.instance.get_service_factories()
+        remote_backends = loaded.instance.get_remote_backends()
+
+        self._check_capabilities(
+            loaded,
+            commands,
+            completions,
+            env_factories,
+            svc_factories,
+            remote_backends,
+        )
+
         self.registry.plugins[plugin_id] = loaded
-        self._register_commands(plugin_id, loaded.instance.get_commands())
-        self._register_completion_providers(
-            plugin_id, loaded.instance.get_completion_providers()
-        )
+        self._register_commands(plugin_id, commands)
+        self._register_completion_providers(plugin_id, completions)
         self._register_descriptor_templates(loaded)
-        self._register_env_factories(
-            plugin_id, loaded.instance.get_env_factories()
-        )
-        self._register_svc_factories(
-            plugin_id, loaded.instance.get_service_factories()
-        )
-        self._register_remote_backends(
-            plugin_id, loaded.instance.get_remote_backends()
-        )
+        self._register_env_factories(plugin_id, env_factories)
+        self._register_svc_factories(plugin_id, svc_factories)
+        self._register_remote_backends(plugin_id, remote_backends)
+
+    def _check_capabilities(
+        self,
+        loaded: LoadedPlugin,
+        commands: Sequence[PluginCommandSpec],
+        completions: Sequence[PluginCompletionSpec],
+        env_factories: Sequence[PluginEnvFactorySpec],
+        svc_factories: Sequence[PluginSvcFactorySpec],
+        remote_backends: Sequence[PluginRemoteBackendSpec],
+    ) -> None:
+        """Reject plugins that contribute to undeclared capability areas.
+
+        If ``capabilities`` is absent or empty the check is skipped entirely
+        (backward-compatible with plugins that predate the field).  A declared
+        area that returns no contributions is allowed — advertised ≠ mandatory.
+        """
+        caps = loaded.descriptor.capabilities
+        if not caps:
+            return
+        plugin_id = loaded.descriptor.id
+        descriptor = loaded.descriptor
+        checks: list[tuple[str, bool]] = [
+            ("commands", bool(commands)),
+            ("completion", bool(completions)),
+            (
+                # Templates are declared statically in plugin.yaml, not
+                # returned by a getter — hence the descriptor field check
+                # rather than a get_*() call like the other areas.
+                "templates",
+                bool(
+                    descriptor.env_templates
+                    or descriptor.service_templates
+                    or descriptor.env_template_fragments
+                ),
+            ),
+            ("env_factories", bool(env_factories)),
+            ("svc_factories", bool(svc_factories)),
+            ("remote_backends", bool(remote_backends)),
+        ]
+        for area, has_contributions in checks:
+            if has_contributions and not caps.get(area, False):
+                Util.print_error_and_die(
+                    f"Plugin '{plugin_id}': contributions found for '{area}' "
+                    f"but 'capabilities.{area}' is not declared true in "
+                    f"plugin.yaml."
+                )
 
     def _register_commands(
         self,

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Shared pytest fixtures for the unit-test suite."""
+
+from __future__ import annotations
+
+import pytest
+from rich.console import Console
+
+
+@pytest.fixture(autouse=True)
+def _no_rich_color(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace Util.console with a plain, no-color Console for every test.
+
+    ``Util.console`` is a class-level attribute initialized at import time.
+    If pytest runs in a colour-capable terminal the Rich Console caches
+    colour support and emits ANSI escape codes even when CliRunner captures
+    stdout, making plain-string assertions fail.  Patching it here ensures
+    consistent, colour-free output across all environments.
+    """
+    from util.util import Util
+
+    monkeypatch.setattr(
+        Util, "console", Console(force_terminal=False, no_color=True)
+    )

--- a/src/tests/test_plugin_runtime.py
+++ b/src/tests/test_plugin_runtime.py
@@ -1093,3 +1093,193 @@ def test_plugin_remote_backend_rejects_duplicate_type_id(
         ShepherdMng()
 
     assert excinfo.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Capability enforcement tests
+# ---------------------------------------------------------------------------
+
+
+def _patch_capabilities(plugin_dir: Path, caps: dict[str, bool] | None) -> None:
+    """Overwrite (or remove) the capabilities block in plugin.yaml."""
+    descriptor_path = plugin_dir / "plugin.yaml"
+    descriptor = yaml.safe_load(descriptor_path.read_text())
+    if caps is None:
+        descriptor.pop("capabilities", None)
+    else:
+        descriptor["capabilities"] = caps
+    descriptor_path.write_text(yaml.dump(descriptor, sort_keys=False))
+
+
+def _single_plugin_inventory(shpd_yaml: Path) -> None:
+    _write_plugin_inventory(
+        shpd_yaml,
+        [
+            {
+                "id": "runtime-plugin",
+                "enabled": True,
+                "version": "1.0.0",
+                "config": {"region": "eu-west-1"},
+            }
+        ],
+    )
+
+
+@pytest.mark.shpd
+def test_capabilities_rejects_undeclared_commands(
+    shpd_conf: tuple[Path, Path], mocker: MockerFixture
+) -> None:
+    """Plugin with undeclared 'commands' capability is rejected at startup."""
+    shpd_path = shpd_conf[0]
+    plugin_dir = _install_fixture_plugin(shpd_path)
+    _single_plugin_inventory(shpd_path / ".shpd.yaml")
+    descriptor_path = plugin_dir / "plugin.yaml"
+    descriptor = yaml.safe_load(descriptor_path.read_text())
+    descriptor["capabilities"]["commands"] = False
+    descriptor_path.write_text(yaml.dump(descriptor, sort_keys=False))
+
+    with pytest.raises(SystemExit) as excinfo:
+        ShepherdMng()
+
+    assert excinfo.value.code == 1
+
+
+@pytest.mark.shpd
+def test_capabilities_rejects_undeclared_completion(
+    shpd_conf: tuple[Path, Path], mocker: MockerFixture
+) -> None:
+    """Plugin with undeclared 'completion' capability is rejected at startup."""
+    shpd_path = shpd_conf[0]
+    plugin_dir = _install_fixture_plugin(shpd_path)
+    _single_plugin_inventory(shpd_path / ".shpd.yaml")
+    descriptor_path = plugin_dir / "plugin.yaml"
+    descriptor = yaml.safe_load(descriptor_path.read_text())
+    descriptor["capabilities"]["completion"] = False
+    descriptor_path.write_text(yaml.dump(descriptor, sort_keys=False))
+
+    with pytest.raises(SystemExit) as excinfo:
+        ShepherdMng()
+
+    assert excinfo.value.code == 1
+
+
+@pytest.mark.shpd
+def test_capabilities_rejects_undeclared_templates(
+    shpd_conf: tuple[Path, Path], mocker: MockerFixture
+) -> None:
+    """Plugin with undeclared 'templates' capability is rejected at startup."""
+    shpd_path = shpd_conf[0]
+    plugin_dir = _install_fixture_plugin(shpd_path)
+    _single_plugin_inventory(shpd_path / ".shpd.yaml")
+    descriptor_path = plugin_dir / "plugin.yaml"
+    descriptor = yaml.safe_load(descriptor_path.read_text())
+    descriptor["capabilities"]["templates"] = False
+    descriptor_path.write_text(yaml.dump(descriptor, sort_keys=False))
+
+    with pytest.raises(SystemExit) as excinfo:
+        ShepherdMng()
+
+    assert excinfo.value.code == 1
+
+
+@pytest.mark.shpd
+def test_capabilities_rejects_undeclared_env_factories(
+    shpd_conf: tuple[Path, Path], mocker: MockerFixture
+) -> None:
+    """Plugin with undeclared 'env_factories' capability is rejected."""
+    shpd_path = shpd_conf[0]
+    plugin_dir = _install_fixture_plugin(shpd_path)
+    _single_plugin_inventory(shpd_path / ".shpd.yaml")
+    descriptor_path = plugin_dir / "plugin.yaml"
+    descriptor = yaml.safe_load(descriptor_path.read_text())
+    descriptor["capabilities"]["env_factories"] = False
+    descriptor_path.write_text(yaml.dump(descriptor, sort_keys=False))
+
+    with pytest.raises(SystemExit) as excinfo:
+        ShepherdMng()
+
+    assert excinfo.value.code == 1
+
+
+@pytest.mark.shpd
+def test_capabilities_rejects_undeclared_svc_factories(
+    shpd_conf: tuple[Path, Path], mocker: MockerFixture
+) -> None:
+    """Plugin with undeclared 'svc_factories' capability is rejected."""
+    shpd_path = shpd_conf[0]
+    plugin_dir = _install_fixture_plugin(shpd_path)
+    _single_plugin_inventory(shpd_path / ".shpd.yaml")
+    descriptor_path = plugin_dir / "plugin.yaml"
+    descriptor = yaml.safe_load(descriptor_path.read_text())
+    descriptor["capabilities"]["svc_factories"] = False
+    descriptor_path.write_text(yaml.dump(descriptor, sort_keys=False))
+
+    with pytest.raises(SystemExit) as excinfo:
+        ShepherdMng()
+
+    assert excinfo.value.code == 1
+
+
+@pytest.mark.shpd
+def test_capabilities_rejects_undeclared_remote_backends(
+    shpd_conf: tuple[Path, Path], mocker: MockerFixture
+) -> None:
+    """Plugin with undeclared 'remote_backends' capability is rejected."""
+    shpd_path = shpd_conf[0]
+    plugin_dir = _install_fixture_plugin(shpd_path)
+    _single_plugin_inventory(shpd_path / ".shpd.yaml")
+    descriptor_path = plugin_dir / "plugin.yaml"
+    descriptor = yaml.safe_load(descriptor_path.read_text())
+    descriptor["capabilities"]["remote_backends"] = False
+    descriptor_path.write_text(yaml.dump(descriptor, sort_keys=False))
+
+    with pytest.raises(SystemExit) as excinfo:
+        ShepherdMng()
+
+    assert excinfo.value.code == 1
+
+
+@pytest.mark.shpd
+def test_capabilities_allows_declared_area_with_no_contributions(
+    shpd_conf: tuple[Path, Path], mocker: MockerFixture
+) -> None:
+    """A capability declared true but returning no contributions is allowed."""
+    shpd_path = shpd_conf[0]
+    # Override the plugin so all getters return () and no templates are declared.
+    plugin_dir = _install_fixture_plugin(
+        shpd_path,
+        main_content=(
+            "from plugin import ShepherdPlugin\n\n"
+            "class RuntimeFixturePlugin(ShepherdPlugin):\n"
+            "    pass\n"
+        ),
+    )
+    _single_plugin_inventory(shpd_path / ".shpd.yaml")
+    descriptor_path = plugin_dir / "plugin.yaml"
+    descriptor = yaml.safe_load(descriptor_path.read_text())
+    descriptor.pop("env_templates", None)
+    descriptor.pop("service_templates", None)
+    descriptor.pop("env_template_fragments", None)
+    descriptor["capabilities"] = {"commands": True}
+    descriptor_path.write_text(yaml.dump(descriptor, sort_keys=False))
+
+    # Must load without error (advertised != mandatory).
+    shepherd = ShepherdMng()
+
+    assert shepherd.pluginRuntimeMng is not None
+
+
+@pytest.mark.shpd
+def test_capabilities_absent_skips_enforcement(
+    shpd_conf: tuple[Path, Path], mocker: MockerFixture
+) -> None:
+    """A plugin without a capabilities block is loaded without enforcement."""
+    shpd_path = shpd_conf[0]
+    plugin_dir = _install_fixture_plugin(shpd_path)
+    _single_plugin_inventory(shpd_path / ".shpd.yaml")
+    _patch_capabilities(plugin_dir, None)  # remove capabilities entirely
+
+    shepherd = ShepherdMng()
+
+    assert shepherd.pluginRuntimeMng is not None
+    assert "runtime-plugin" in shepherd.pluginRuntimeMng.registry.plugins


### PR DESCRIPTION
## Summary

- Refactors `_register_plugin` to collect all contributions into locals first (single getter call each), then run the capability check, then register — eliminating the previous double getter-call pattern
- Adds `_check_capabilities`: reads `capabilities` from the plugin descriptor; skips enforcement if the block is absent or empty (backward-compatible); rejects with `sys.exit(1)` if any area has contributions but the corresponding key is absent or `false`
- Six areas enforced: `commands`, `completion`, `templates`, `env_factories`, `svc_factories`, `remote_backends`
- Declared capability with no actual contributions is allowed (advertised ≠ mandatory)
- 8 new `@pytest.mark.shpd` tests: one per rejection path, plus "declared true with no contributions → OK" and "capabilities absent → skips enforcement"

## Testing

```
cd src
pytest -m shpd -v        # 103 shpd tests pass (8 new)
pytest -q                # 409 passed, 0 regressions
black src --check
isort src --check-only
pyright src              # 0 errors
```

Fixes: #206