### PR TITLE
feat(remote): implement remote discovery CLI and RemoteMng foundation

### DIFF
--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -13,11 +13,13 @@ from completion.completion_env import CompletionEnvMng
 from completion.completion_mng import AbstractCompletionMng
 from completion.completion_plugin import CompletionPluginMng
 from completion.completion_probe import CompletionProbeMng
+from completion.completion_remote import CompletionRemoteMng
 from completion.completion_svc import CompletionSvcMng
 from config import ConfigMng
 
 if TYPE_CHECKING:
     from plugin import PluginRegistry
+    from remote import RemoteMng
 
 
 class CompletionMng(AbstractCompletionMng):
@@ -52,6 +54,7 @@ class CompletionMng(AbstractCompletionMng):
         ],
         "svc": ["get", "add", "up", "halt", "reload", "build", "logs", "shell"],
         "probe": ["get", "check"],
+        "remote": ["add", "list", "delete", "envs", "get"],
     }
     SCOPE_VERBS = CORE_SCOPE_VERBS
 
@@ -123,6 +126,23 @@ class CompletionMng(AbstractCompletionMng):
             OptionSpec(tokens=("--show-commands-limit",), takes_value=True),
         ),
         ("plugin", "install"): (OptionSpec(tokens=("--force",)),),
+        ("remote", "add"): (
+            OptionSpec(tokens=("--ftp",)),
+            OptionSpec(tokens=("--sftp",)),
+            OptionSpec(tokens=("--host",), takes_value=True),
+            OptionSpec(tokens=("--user",), takes_value=True),
+            OptionSpec(tokens=("--port",), takes_value=True),
+            OptionSpec(tokens=("--password",), takes_value=True),
+            OptionSpec(tokens=("--root-path",), takes_value=True),
+            OptionSpec(tokens=("--identity-file",), takes_value=True),
+            OptionSpec(tokens=("--set-default",)),
+        ),
+        ("remote", "envs"): (
+            OptionSpec(tokens=("--remote",), takes_value=True),
+        ),
+        ("remote", "get"): (
+            OptionSpec(tokens=("--remote",), takes_value=True),
+        ),
     }
 
     def __init__(
@@ -130,6 +150,7 @@ class CompletionMng(AbstractCompletionMng):
         cli_flags: dict[str, Any],
         configMng: ConfigMng,
         plugin_registry: "PluginRegistry | None" = None,
+        remoteMng: "RemoteMng | None" = None,
     ):
         self.cli_flags = cli_flags
         self.configMng = configMng
@@ -138,6 +159,9 @@ class CompletionMng(AbstractCompletionMng):
         self.completionPluginMng = CompletionPluginMng(cli_flags, configMng)
         self.completionSvcMng = CompletionSvcMng(cli_flags, configMng)
         self.completionProbeMng = CompletionProbeMng(cli_flags, configMng)
+        self.completionRemoteMng = CompletionRemoteMng(
+            cli_flags, configMng, remoteMng
+        )
         self._option_by_token: dict[str, CompletionMng.OptionSpec] = {}
         for spec in self.GLOBAL_OPTIONS:
             for token in spec.tokens:
@@ -186,6 +210,8 @@ class CompletionMng(AbstractCompletionMng):
             return self.completionSvcMng
         if scope == "probe":
             return self.completionProbeMng
+        if scope == "remote":
+            return self.completionRemoteMng
         return None
 
     def _match_option(self, token: str) -> Optional[OptionSpec]:
@@ -326,13 +352,36 @@ class CompletionMng(AbstractCompletionMng):
 
         if expect_value_for is not None:
             if last_token in expect_value_for.tokens:
-                return list(expect_value_for.choices)
+                if expect_value_for.choices:
+                    return list(expect_value_for.choices)
+                # Dynamic option value — option token is the current word.
+                # Inject it into sanitized_args so the scope manager can see
+                # which option's value is being completed.
+                dynamic_args = sanitized_args + [last_token]
+                completion_manager = self.get_completion_manager(scope)
+                if completion_manager:
+                    return self._unique(
+                        completion_manager.get_completions(dynamic_args)
+                    )
+                return []
             if not last_token.startswith("-"):
-                return [
-                    choice
-                    for choice in expect_value_for.choices
-                    if not last_token or choice.startswith(last_token)
-                ]
+                if expect_value_for.choices:
+                    return [
+                        choice
+                        for choice in expect_value_for.choices
+                        if not last_token or choice.startswith(last_token)
+                    ]
+                # Dynamic option value with partial prefix: inject the option
+                # token (and the prefix) so the scope manager can filter.
+                dynamic_args = sanitized_args + [expect_value_for.tokens[0]]
+                if last_token:
+                    dynamic_args = dynamic_args + [last_token]
+                completion_manager = self.get_completion_manager(scope)
+                if completion_manager:
+                    return self._unique(
+                        completion_manager.get_completions(dynamic_args)
+                    )
+                return []
 
         if not scope:
             if option_prefix is not None:

--- a/src/completion/completion_remote.py
+++ b/src/completion/completion_remote.py
@@ -5,6 +5,7 @@
 # Open-source: see LICENSE (AGPL-3.0-only).
 # Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
+import logging
 from typing import TYPE_CHECKING, Any, Optional, override
 
 from completion.completion_mng import AbstractCompletionMng
@@ -46,6 +47,9 @@ class CompletionRemoteMng(AbstractCompletionMng):
             case "get":
                 return self._complete_get(args[2:])
             case _:
+                # "add" and "list" have no dynamic positional completions —
+                # their flags are served entirely by the static CONTEXT_OPTIONS
+                # table in CompletionMng.
                 return []
 
     # ------------------------------------------------------------------
@@ -128,5 +132,6 @@ class CompletionRemoteMng(AbstractCompletionMng):
             if prefix:
                 return [n for n in names if n.startswith(prefix)]
             return names
-        except Exception:
+        except Exception as exc:
+            logging.debug("remote completion: env-name lookup failed: %s", exc)
             return []

--- a/src/completion/completion_remote.py
+++ b/src/completion/completion_remote.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+from typing import TYPE_CHECKING, Any, Optional, override
+
+from completion.completion_mng import AbstractCompletionMng
+from config import ConfigMng
+
+if TYPE_CHECKING:
+    from remote import RemoteMng
+
+
+class CompletionRemoteMng(AbstractCompletionMng):
+    """Remote scope completer.
+
+    Handles argument and option-value completion for the ``remote`` command
+    group.  Where completion requires a live index (``remote get`` ENV_NAME),
+    the call is delegated to :class:`~remote.remote_mng.RemoteMng` against the
+    default remote; network failures are silently swallowed so that a
+    temporarily unavailable remote never breaks the shell prompt.
+    """
+
+    def __init__(
+        self,
+        cli_flags: dict[str, Any],
+        configMng: ConfigMng,
+        remoteMng: "Optional[RemoteMng]" = None,
+    ) -> None:
+        self.cli_flags = cli_flags
+        self.configMng = configMng
+        self.remoteMng = remoteMng
+
+    @override
+    def get_completions_impl(self, args: list[str]) -> list[str]:
+        if len(args) < 2:
+            return []
+        match args[1]:
+            case "delete":
+                return self._complete_remote_name(args[2:])
+            case "envs":
+                return self._complete_remote_option(args[2:])
+            case "get":
+                return self._complete_get(args[2:])
+            case _:
+                return []
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _remote_names(self, prefix: str = "") -> list[str]:
+        """Return registered remote names, optionally filtered by *prefix*."""
+        names = [r.name for r in self.configMng.get_remotes()]
+        if prefix:
+            return [n for n in names if n.startswith(prefix)]
+        return names
+
+    def _complete_remote_name(self, args: list[str]) -> list[str]:
+        """Complete a single positional remote-name argument."""
+        if not args:
+            return self._remote_names()
+        if len(args) == 1:
+            prefix = args[0]
+            # Return empty once an exact name has been chosen (mirrors the
+            # env-delete / plugin-id pattern).
+            if any(r.name == prefix for r in self.configMng.get_remotes()):
+                return []
+            return self._remote_names(prefix=prefix)
+        return []
+
+    def _complete_remote_option(self, args: list[str]) -> list[str]:
+        """Complete the value of ``--remote``.
+
+        Called directly for ``remote envs`` and as a sub-check inside
+        :meth:`_complete_get`.  The dynamic-option fallback in
+        :class:`~completion.completion.CompletionMng` injects the ``--remote``
+        token (and optional partial value) at the tail of *args* when the user
+        is in the middle of typing ``--remote <name>``.
+        """
+        if not args:
+            return []
+        if args[-1] == "--remote":
+            return self._remote_names()
+        if len(args) >= 2 and args[-2] == "--remote":
+            return self._remote_names(prefix=args[-1])
+        return []
+
+    def _complete_get(self, args: list[str]) -> list[str]:
+        """Complete arguments for ``remote get``.
+
+        Priority order:
+        1. If ``--remote`` value is expected (injected by dynamic-option
+           fallback) → return registered remote names.
+        2. Otherwise complete the ENV_NAME positional from the default
+           remote's index catalogue.
+        """
+        # --remote value completion
+        if args and (
+            args[-1] == "--remote"
+            or (len(args) >= 2 and args[-2] == "--remote")
+        ):
+            return self._complete_remote_option(args)
+
+        # ENV_NAME positional — --remote <val> pairs are already stripped from
+        # args by CompletionMng._parse_args; remaining "-" tokens are flags
+        positional = [a for a in args if not a.startswith("-")]
+        if not positional:
+            return self._env_names()
+        if len(positional) == 1:
+            return self._env_names(prefix=positional[0])
+        return []
+
+    def _env_names(self, prefix: str = "") -> list[str]:
+        """Return environment names from the default remote's index.
+
+        Falls back to ``[]`` on any error (no default remote, network
+        unavailable, etc.) so that completion never blocks the shell.
+        """
+        if self.remoteMng is None:
+            return []
+        try:
+            _, catalogue = self.remoteMng.list_envs(remote_name=None)
+            names = list(catalogue.environments.keys())
+            if prefix:
+                return [n for n in names if n.startswith(prefix)]
+            return names
+        except Exception:
+            return []

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1828,11 +1828,11 @@ class ConfigMng:
 
         :raises ValueError: If a remote with the same name already exists.
         """
-        if any(r.name == remote.name for r in self.get_remotes()):
+        remotes = list(self.config.remotes or [])
+        if any(r.name == remote.name for r in remotes):
             raise ValueError(f"Remote '{remote.name}' already exists.")
-        if self.config.remotes is None:
-            self.config.remotes = []
-        self.config.remotes.append(remote)
+        remotes.append(remote)
+        self.config.remotes = remotes
         self.store()
 
     def remove_remote(self, name: str) -> None:

--- a/src/plugin/context.py
+++ b/src/plugin/context.py
@@ -27,8 +27,10 @@ from config import (
     PluginCfg,
     ServiceTemplateCfg,
 )
+from config.config import RemoteCfg
 from environment import Environment
 from service import Service
+from storage.snapshot import IndexCatalogue, SnapshotManifest
 
 
 @runtime_checkable
@@ -206,6 +208,42 @@ class PluginServiceView(Protocol):
         ...
 
 
+@runtime_checkable
+class PluginRemoteView(Protocol):
+    """Remote storage operations exposed to plugins.
+
+    Provides access to the configured remotes and their environment/snapshot
+    indices.  Internal transport helpers (``_resolve_remote``,
+    ``_build_backend``) are intentionally excluded.
+    """
+
+    def list_envs(
+        self, remote_name: Optional[str] = None
+    ) -> tuple[RemoteCfg, IndexCatalogue]:
+        """Return the index catalogue from *remote_name* (or the default)."""
+        ...
+
+    def list_snapshots(
+        self, env_name: str, remote_name: Optional[str] = None
+    ) -> tuple[RemoteCfg, list[SnapshotManifest]]:
+        """Return all snapshot manifests for *env_name* from *remote_name*."""
+        ...
+
+    def display_registered(self) -> None:
+        """Render a table of registered remotes from the local config."""
+        ...
+
+    def display_envs(self, remote_name: Optional[str] = None) -> None:
+        """Render a table of environments available on *remote_name*."""
+        ...
+
+    def display_snapshots(
+        self, env_name: str, remote_name: Optional[str] = None
+    ) -> None:
+        """Render a table of snapshots for *env_name* on *remote_name*."""
+        ...
+
+
 @dataclass
 class PluginContext:
     """Core manager access injected into every plugin at startup.
@@ -216,13 +254,14 @@ class PluginContext:
 
     ``config`` is always populated.
 
-    ``environment`` and ``service`` are ``None`` during the Click command
-    resolution phase (tab completion) and are set to the live managers once
-    the full CLI bootstrap completes.  Plugin command handlers run after
-    the full bootstrap, so by the time any handler executes, both fields
+    ``environment``, ``service``, and ``remote`` are ``None`` during the Click
+    command resolution phase (tab completion) and are set to the live managers
+    once the full CLI bootstrap completes.  Plugin command handlers run after
+    the full bootstrap, so by the time any handler executes, all three fields
     are available.
     """
 
     config: PluginConfigView
     environment: Optional[PluginEnvironmentView] = None
     service: Optional[PluginServiceView] = None
+    remote: Optional[PluginRemoteView] = None

--- a/src/plugin/context.py
+++ b/src/plugin/context.py
@@ -210,11 +210,13 @@ class PluginServiceView(Protocol):
 
 @runtime_checkable
 class PluginRemoteView(Protocol):
-    """Remote storage operations exposed to plugins.
+    """Remote storage data access exposed to plugins.
 
-    Provides access to the configured remotes and their environment/snapshot
-    indices.  Internal transport helpers (``_resolve_remote``,
-    ``_build_backend``) are intentionally excluded.
+    Provides programmatic access to configured remotes and their
+    environment/snapshot indices.  Terminal-rendering helpers
+    (``display_*``) and internal transport helpers (``_resolve_remote``,
+    ``_build_backend``) are intentionally excluded — plugins that need to
+    present remote data should format the returned objects themselves.
     """
 
     def list_envs(
@@ -227,20 +229,6 @@ class PluginRemoteView(Protocol):
         self, env_name: str, remote_name: Optional[str] = None
     ) -> tuple[RemoteCfg, list[SnapshotManifest]]:
         """Return all snapshot manifests for *env_name* from *remote_name*."""
-        ...
-
-    def display_registered(self) -> None:
-        """Render a table of registered remotes from the local config."""
-        ...
-
-    def display_envs(self, remote_name: Optional[str] = None) -> None:
-        """Render a table of environments available on *remote_name*."""
-        ...
-
-    def display_snapshots(
-        self, env_name: str, remote_name: Optional[str] = None
-    ) -> None:
-        """Render a table of snapshots for *env_name* on *remote_name*."""
         ...
 
 

--- a/src/plugin/runtime.py
+++ b/src/plugin/runtime.py
@@ -44,9 +44,10 @@ from plugin.api import (
 from plugin.context import (
     PluginContext,
     PluginEnvironmentView,
+    PluginRemoteView,
     PluginServiceView,
 )
-from remote import RemoteBackend
+from remote import RemoteBackend, RemoteMng
 from service import ServiceFactory, ServiceMng
 from util import Constants, Util
 
@@ -175,10 +176,12 @@ class PluginRuntimeMng:
         configMng: ConfigMng,
         environmentMng: EnvironmentMng | None = None,
         serviceMng: ServiceMng | None = None,
+        remoteMng: RemoteMng | None = None,
     ):
         self.configMng = configMng
         self._environmentMng: PluginEnvironmentView | None = environmentMng
         self._serviceMng: PluginServiceView | None = serviceMng
+        self._remoteMng: PluginRemoteView | None = remoteMng
         self.registry = PluginRegistry()
         self.load_enabled_plugins()
 
@@ -186,6 +189,7 @@ class PluginRuntimeMng:
         self,
         environmentMng: EnvironmentMng,
         serviceMng: ServiceMng,
+        remoteMng: RemoteMng | None = None,
     ) -> None:
         """Inject managers into already-loaded plugin contexts.
 
@@ -195,9 +199,13 @@ class PluginRuntimeMng:
         """
         self._environmentMng = environmentMng
         self._serviceMng = serviceMng
+        if remoteMng is not None:
+            self._remoteMng = remoteMng
         for loaded in self.registry.plugins.values():
             loaded.instance.context.environment = environmentMng
             loaded.instance.context.service = serviceMng
+            if remoteMng is not None:
+                loaded.instance.context.remote = remoteMng
 
     def load_enabled_plugins(self) -> PluginRegistry:
         """
@@ -460,6 +468,7 @@ class PluginRuntimeMng:
             config=self.configMng,
             environment=self._environmentMng,
             service=self._serviceMng,
+            remote=self._remoteMng,
         )
         try:
             plugin = plugin_class(ctx)

--- a/src/remote/backend.py
+++ b/src/remote/backend.py
@@ -44,6 +44,14 @@ class RemoteBackend(ABC):
         return f"chunks/{chunk_hash[:2]}/{chunk_hash}"
 
     @staticmethod
+    def snapshots_prefix(env_name: str) -> str:
+        """Return the remote path prefix for all snapshots of *env_name*.
+
+        Example: ``"my-env"`` → ``"envs/my-env/snapshots"``
+        """
+        return f"envs/{env_name}/snapshots"
+
+    @staticmethod
     def snapshot_path(env_name: str, snapshot_id: str) -> str:
         """Return the remote path for a snapshot manifest."""
         return f"envs/{env_name}/snapshots/{snapshot_id}.json"

--- a/src/remote/remote_mng.py
+++ b/src/remote/remote_mng.py
@@ -27,18 +27,6 @@ from .ftp_backend import FTPBackend
 from .sftp_backend import SFTPBackend
 
 
-def _fmt_bytes(n: int) -> str:
-    """Return a human-readable byte count (e.g. ``1.2 MiB``)."""
-    for unit, threshold in (
-        ("GiB", 1 << 30),
-        ("MiB", 1 << 20),
-        ("KiB", 1 << 10),
-    ):
-        if n >= threshold:
-            return f"{n / threshold:.1f} {unit}"
-    return f"{n} B"
-
-
 class RemoteMng:
     """Coordinates the full remote backup and restore workflow.
 
@@ -225,8 +213,8 @@ class RemoteMng:
                 entry.latest_snapshot,
                 str(entry.snapshot_count),
                 entry.last_backup,
-                _fmt_bytes(entry.total_size_bytes),
-                _fmt_bytes(entry.stored_size_bytes),
+                Util.fmt_bytes(entry.total_size_bytes),
+                Util.fmt_bytes(entry.stored_size_bytes),
             ]
             for env_name, entry in sorted(catalogue.environments.items())
         ]
@@ -259,8 +247,8 @@ class RemoteMng:
                 m.snapshot_id,
                 m.created_at,
                 str(m.chunk_count),
-                _fmt_bytes(m.total_size_bytes),
-                _fmt_bytes(m.stored_size_bytes),
+                Util.fmt_bytes(m.total_size_bytes),
+                Util.fmt_bytes(m.stored_size_bytes),
                 ", ".join(m.labels) if m.labels else "",
             ]
             for m in manifests

--- a/src/remote/remote_mng.py
+++ b/src/remote/remote_mng.py
@@ -10,6 +10,34 @@ prune, and remote/env listing."""
 
 from __future__ import annotations
 
+import datetime
+import json
+from copy import deepcopy
+from typing import Optional
+
+import click
+
+from config import ConfigMng
+from config.config import RemoteCfg
+from storage.snapshot import IndexCatalogue, SnapshotManifest
+from util import Util
+
+from .backend import RemoteBackend
+from .ftp_backend import FTPBackend
+from .sftp_backend import SFTPBackend
+
+
+def _fmt_bytes(n: int) -> str:
+    """Return a human-readable byte count (e.g. ``1.2 MiB``)."""
+    for unit, threshold in (
+        ("GiB", 1 << 30),
+        ("MiB", 1 << 20),
+        ("KiB", 1 << 10),
+    ):
+        if n >= threshold:
+            return f"{n / threshold:.1f} {unit}"
+    return f"{n} B"
+
 
 class RemoteMng:
     """Coordinates the full remote backup and restore workflow.
@@ -26,5 +54,226 @@ class RemoteMng:
     - Prune orphan chunks.
     """
 
-    def __init__(self) -> None:
-        raise NotImplementedError  # TODO: Issues 8–10
+    def __init__(self, configMng: ConfigMng) -> None:
+        self.configMng = configMng
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_remote(self, name: Optional[str]) -> RemoteCfg:
+        """Return the named remote, the default, or raise
+        :exc:`click.UsageError`.
+
+        :param name: Remote name, or ``None`` to fall back to the default.
+        :raises click.UsageError: If the remote cannot be found or no default
+            is configured.
+        """
+        if name:
+            cfg = self.configMng.get_remote(name)
+            if cfg is None:
+                raise click.UsageError(f"Remote '{name}' is not configured.")
+            return cfg
+        cfg = self.configMng.get_default_remote()
+        if cfg is not None:
+            return cfg
+        remotes = self.configMng.get_remotes()
+        if not remotes:
+            raise click.UsageError(
+                "No remotes configured. Use 'shepctl remote add' first."
+            )
+        raise click.UsageError(
+            "No default remote set and --remote not specified. "
+            "Use --remote=<name> or mark one as default with --set-default."
+        )
+
+    def _build_backend(self, cfg: RemoteCfg) -> RemoteBackend:
+        """Instantiate the transport backend described by *cfg*.
+
+        Resolves ``${VAR}`` placeholders in connection fields before passing
+        them to the backend constructor.
+
+        :raises NotImplementedError: For plugin-registered backend types
+            (not yet supported in this release).
+        :raises click.UsageError: For unknown built-in type strings.
+        """
+        cfg = deepcopy(cfg)
+        cfg.set_resolved()
+        host: str = cfg.host or ""
+        port: Optional[int] = cfg.port
+        user: str = cfg.user or ""
+        root_path: str = cfg.root_path or "/"
+
+        if cfg.type == "ftp":
+            return FTPBackend(
+                host=host,
+                port=port if port is not None else 21,
+                user=user,
+                password=cfg.password or "",
+                root_path=root_path,
+            )
+
+        if cfg.type == "sftp":
+            return SFTPBackend(
+                host=host,
+                port=port if port is not None else 22,
+                user=user,
+                password=cfg.password if cfg.password else None,
+                identity_file=cfg.identity_file if cfg.identity_file else None,
+                root_path=root_path,
+            )
+
+        raise click.UsageError(
+            f"Unknown remote type '{cfg.type}'. "
+            "Built-in types are 'ftp' and 'sftp'. "
+            "Plugin-registered backends are not yet supported."
+        )
+
+    # ------------------------------------------------------------------
+    # Data-returning methods (used by display_* and tests)
+    # ------------------------------------------------------------------
+
+    def list_envs(
+        self, remote_name: Optional[str] = None
+    ) -> tuple[RemoteCfg, IndexCatalogue]:
+        """Fetch the global index from *remote_name* and return it.
+
+        Returns an empty :class:`~storage.snapshot.IndexCatalogue` when the
+        remote has no index yet (first use).
+
+        :param remote_name: Name of the remote to query, or ``None`` to use the
+            default.
+        :returns: A ``(RemoteCfg, IndexCatalogue)`` pair.
+        """
+        remote_cfg = self._resolve_remote(remote_name)
+        with self._build_backend(remote_cfg) as backend:
+            index_path = backend.index_path()
+            if not backend.exists(index_path):
+                now = (
+                    datetime.datetime.now(datetime.timezone.utc)
+                    .isoformat(timespec="seconds")
+                    .replace("+00:00", "Z")
+                )
+                return remote_cfg, IndexCatalogue(updated_at=now)
+            raw = backend.download(index_path)
+            catalogue = IndexCatalogue.from_dict(json.loads(raw))
+        return remote_cfg, catalogue
+
+    def list_snapshots(
+        self, env_name: str, remote_name: Optional[str] = None
+    ) -> tuple[RemoteCfg, list[SnapshotManifest]]:
+        """Fetch all snapshot manifests for *env_name* from *remote_name*.
+
+        :param env_name: Name of the environment to query.
+        :param remote_name: Name of the remote to query, or ``None`` to use the
+            default.
+        :returns: A ``(RemoteCfg, list[SnapshotManifest])`` pair sorted
+            newest-first by ``created_at``.
+        """
+        remote_cfg = self._resolve_remote(remote_name)
+        with self._build_backend(remote_cfg) as backend:
+            prefix = RemoteBackend.snapshots_prefix(env_name)
+            names = backend.list_prefix(prefix)
+            manifests: list[SnapshotManifest] = []
+            for name in names:
+                if not name.endswith(".json"):
+                    continue
+                raw = backend.download(f"{prefix}/{name}")
+                manifests.append(SnapshotManifest.from_dict(json.loads(raw)))
+        manifests.sort(key=lambda m: m.created_at, reverse=True)
+        return remote_cfg, manifests
+
+    # ------------------------------------------------------------------
+    # Display methods (called by CLI commands)
+    # ------------------------------------------------------------------
+
+    def display_registered(self) -> None:
+        """Render a table of registered remotes from the local config."""
+        remotes = self.configMng.get_remotes()
+        if not remotes:
+            Util.print("No remotes configured.")
+            return
+        rows = [
+            [
+                r.name,
+                r.type,
+                r.host or "",
+                "*" if r.is_default() else "",
+            ]
+            for r in remotes
+        ]
+        Util.render_table(
+            "Remotes",
+            [
+                {"header": "Name", "style": "cyan"},
+                {"header": "Type"},
+                {"header": "Host"},
+                {"header": "Default"},
+            ],
+            rows,
+        )
+
+    def display_envs(self, remote_name: Optional[str] = None) -> None:
+        """Render a table of environments available on *remote_name*."""
+        remote_cfg, catalogue = self.list_envs(remote_name)
+        if not catalogue.environments:
+            Util.print(f"No environments found on remote '{remote_cfg.name}'.")
+            return
+        rows = [
+            [
+                env_name,
+                entry.latest_snapshot,
+                str(entry.snapshot_count),
+                entry.last_backup,
+                _fmt_bytes(entry.total_size_bytes),
+                _fmt_bytes(entry.stored_size_bytes),
+            ]
+            for env_name, entry in sorted(catalogue.environments.items())
+        ]
+        Util.render_table(
+            f"Environments on '{remote_cfg.name}'",
+            [
+                {"header": "Env", "style": "cyan"},
+                {"header": "Latest Snapshot"},
+                {"header": "Snapshots"},
+                {"header": "Last Backup"},
+                {"header": "Total Size"},
+                {"header": "Stored Size"},
+            ],
+            rows,
+        )
+
+    def display_snapshots(
+        self, env_name: str, remote_name: Optional[str] = None
+    ) -> None:
+        """Render a table of snapshots for *env_name* on *remote_name*."""
+        remote_cfg, manifests = self.list_snapshots(env_name, remote_name)
+        if not manifests:
+            Util.print(
+                f"No snapshots found for '{env_name}' "
+                f"on remote '{remote_cfg.name}'."
+            )
+            return
+        rows = [
+            [
+                m.snapshot_id,
+                m.created_at,
+                str(m.chunk_count),
+                _fmt_bytes(m.total_size_bytes),
+                _fmt_bytes(m.stored_size_bytes),
+                ", ".join(m.labels) if m.labels else "",
+            ]
+            for m in manifests
+        ]
+        Util.render_table(
+            f"Snapshots for '{env_name}' on '{remote_cfg.name}'",
+            [
+                {"header": "Snapshot ID", "style": "cyan"},
+                {"header": "Created At"},
+                {"header": "Chunks"},
+                {"header": "Total Size"},
+                {"header": "Stored Size"},
+                {"header": "Labels"},
+            ],
+            rows,
+        )

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -922,6 +922,12 @@ def add_remote(
     """Register a new remote storage backend."""
     if not backend_type:
         raise click.UsageError("Specify a transport with --ftp or --sftp.")
+    if backend_type == "ftp" and not password:
+        raise click.UsageError("FTP remotes require --password.")
+    if backend_type == "sftp" and not password and not identity_file:
+        raise click.UsageError(
+            "SFTP remotes require --password or --identity-file."
+        )
     remote_cfg = RemoteCfg(
         name=name,
         type=backend_type,

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -76,19 +76,22 @@ class ShepherdMng:
         self.serviceMng = ServiceMng(
             self.cli_flags, self.configMng, self.svcFactory
         )
+        self.remoteMng = RemoteMng(self.configMng)
         self.pluginRuntimeMng = plugin_runtime_mng
         if self.pluginRuntimeMng is None and load_runtime_plugins:
             self.pluginRuntimeMng = PluginRuntimeMng(
-                self.configMng, self.environmentMng, self.serviceMng
+                self.configMng,
+                self.environmentMng,
+                self.serviceMng,
+                self.remoteMng,
             )
         elif self.pluginRuntimeMng is not None and load_runtime_plugins:
             # Pre-bootstrapped during Click resolution: inject managers now
             # that they are available.
             self.pluginRuntimeMng.attach_managers(
-                self.environmentMng, self.serviceMng
+                self.environmentMng, self.serviceMng, self.remoteMng
             )
         self.configMng.set_plugin_runtime_mng(self.pluginRuntimeMng)
-        self.remoteMng = RemoteMng(self.configMng)
         self.completionMng = CompletionMng(
             self.cli_flags,
             self.configMng,

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -17,9 +17,11 @@ import click
 
 from completion import CompletionMng
 from config import ConfigMng, EnvironmentCfg
+from config.config import RemoteCfg
 from environment import EnvironmentMng
 from factory import ShpdEnvironmentFactory, ShpdServiceFactory
 from plugin import PluginMng, PluginRuntimeMng
+from remote import RemoteMng
 from service import ServiceMng
 from util import Util, setup_logging
 from util.constants import DEFAULT_COMPOSE_COMMAND_LOG_LIMIT
@@ -86,6 +88,7 @@ class ShepherdMng:
                 self.environmentMng, self.serviceMng
             )
         self.configMng.set_plugin_runtime_mng(self.pluginRuntimeMng)
+        self.remoteMng = RemoteMng(self.configMng)
         self.completionMng = CompletionMng(
             self.cli_flags,
             self.configMng,
@@ -853,6 +856,131 @@ def disable_plugin(shepherd: ShepherdMng, plugin_id: str):
 def remove_plugin(shepherd: ShepherdMng, plugin_id: str):
     """Remove one installed plugin."""
     shepherd.pluginMng.remove_plugin(plugin_id)
+
+
+# =====================================================
+# REMOTE
+# =====================================================
+@cli.group(cls=PluginScopeGroup)
+def remote():
+    """Manage remote storage backends."""
+    pass
+
+
+@remote.command(name="add")
+@click.argument("name", required=True)
+@click.option("--ftp", "backend_type", flag_value="ftp", help="FTP transport.")
+@click.option(
+    "--sftp", "backend_type", flag_value="sftp", help="SFTP transport."
+)
+@click.option("--host", required=True, help="Remote server hostname.")
+@click.option("--user", required=True, help="Login username.")
+@click.option(
+    "--port",
+    type=int,
+    default=None,
+    help="Server port (default: 21 for FTP, 22 for SFTP).",
+)
+@click.option(
+    "--password",
+    default=None,
+    help="Login password. Supports ${VAR} placeholders.",
+)
+@click.option(
+    "--identity-file",
+    default=None,
+    help="Path to SSH private key (SFTP only). Supports ${VAR} placeholders.",
+)
+@click.option(
+    "--root-path",
+    required=True,
+    help="Root directory on the remote for the chunk store.",
+)
+@click.option(
+    "--set-default",
+    is_flag=True,
+    default=False,
+    help="Mark this remote as the default.",
+)
+@click.pass_obj
+def add_remote(
+    shepherd: ShepherdMng,
+    name: str,
+    backend_type: Optional[str],
+    host: str,
+    user: str,
+    port: Optional[int],
+    password: Optional[str],
+    identity_file: Optional[str],
+    root_path: str,
+    set_default: bool,
+) -> None:
+    """Register a new remote storage backend."""
+    if not backend_type:
+        raise click.UsageError("Specify a transport with --ftp or --sftp.")
+    remote_cfg = RemoteCfg(
+        name=name,
+        type=backend_type,
+        host=host,
+        port=port,
+        user=user,
+        password=password,
+        root_path=root_path,
+        identity_file=identity_file,
+        default="true" if set_default else "false",
+    )
+    try:
+        shepherd.configMng.add_remote(remote_cfg)
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+    Util.print(f"Remote '{name}' registered.")
+
+
+@remote.command(name="list")
+@click.pass_obj
+def list_remotes(shepherd: ShepherdMng) -> None:
+    """List registered remote storage backends."""
+    shepherd.remoteMng.display_registered()
+
+
+@remote.command(name="delete")
+@click.argument("name", required=True)
+@click.pass_obj
+def delete_remote(shepherd: ShepherdMng, name: str) -> None:
+    """Unregister a remote (does not delete remote data)."""
+    if shepherd.configMng.get_remote(name) is None:
+        raise click.UsageError(f"Remote '{name}' is not configured.")
+    shepherd.configMng.remove_remote(name)
+    Util.print(f"Remote '{name}' removed.")
+
+
+@remote.command(name="envs")
+@click.option(
+    "--remote",
+    "remote_name",
+    default=None,
+    help="Remote name (uses default if omitted).",
+)
+@click.pass_obj
+def list_remote_envs(shepherd: ShepherdMng, remote_name: Optional[str]) -> None:
+    """List environments available on a remote."""
+    shepherd.remoteMng.display_envs(remote_name)
+
+
+@remote.command(name="get")
+@click.argument("env_name", required=True)
+@click.option(
+    "--remote",
+    "remote_name",
+    default=None,
+    help="Remote name (uses default if omitted).",
+)
+@click.pass_obj
+def get_remote_env(
+    shepherd: ShepherdMng, env_name: str, remote_name: Optional[str]
+) -> None:
+    """List snapshots for ENV_NAME on a remote."""
+    shepherd.remoteMng.display_snapshots(env_name, remote_name)
 
 
 if __name__ == "__main__":

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -97,6 +97,7 @@ class ShepherdMng:
                 if self.pluginRuntimeMng is None
                 else self.pluginRuntimeMng.registry
             ),
+            self.remoteMng,
         )
 
 

--- a/src/tests/fixtures/completion/shpd.yaml
+++ b/src/tests/fixtures/completion/shpd.yaml
@@ -77,6 +77,18 @@ service_templates:
       - com.example.label1=value1
       - com.example.label2=value2
     properties: {}
+remotes:
+  - name: ftp-prod
+    type: ftp
+    host: ftp.example.com
+    user: deploy
+    root_path: /shpd
+    default: "true"
+  - name: sftp-backup
+    type: sftp
+    host: sftp.example.com
+    user: backup
+    root_path: /shpd
 envs:
   - template: default
     factory: docker-compose

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -1272,3 +1272,244 @@ def test_completion_probe_check_shows_watch_flag(
     assert "-w" in completions
     assert "--watch" in completions
     assert "--show-commands-limit" in completions
+
+
+# =============================================================================
+# REMOTE completion
+# =============================================================================
+
+
+def _write_shpd_yaml(shpd_path: Path) -> None:
+    """Write the completion fixture yaml (includes two remotes) to *shpd_path*."""
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(read_fixture("completion", "shpd.yaml"))
+
+
+def _remote_sm(shpd_conf: tuple[Path, Path]) -> "ShepherdMng":
+    """Return a ShepherdMng with the completion fixture yaml loaded."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    _write_shpd_yaml(shpd_path)
+    return ShepherdMng(load_runtime_plugins=False)
+
+
+@pytest.mark.compl
+def test_completion_remote_scope_in_scopes(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """'remote' scope is included in the top-level scope list."""
+    sm = ShepherdMng(load_runtime_plugins=False)
+    assert "remote" in sm.completionMng.get_completions([])
+
+
+@pytest.mark.compl
+def test_completion_remote_verbs(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """Completing 'remote' returns the expected verb list."""
+    sm = ShepherdMng(load_runtime_plugins=False)
+    completions = sm.completionMng.get_completions(["remote"])
+    assert completions == ["add", "list", "delete", "envs", "get"]
+
+
+@pytest.mark.compl
+def test_completion_remote_delete_remote_names(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """'remote delete' completes to all registered remote names."""
+    sm = _remote_sm(shpd_conf)
+    completions = sm.completionMng.get_completions(["remote", "delete"])
+    assert completions == ["ftp-prod", "sftp-backup"]
+
+
+@pytest.mark.compl
+def test_completion_remote_delete_prefix_filter(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """'remote delete ftp' completes only names starting with 'ftp'."""
+    sm = _remote_sm(shpd_conf)
+    completions = sm.completionMng.get_completions(["remote", "delete", "ftp"])
+    assert completions == ["ftp-prod"]
+
+
+@pytest.mark.compl
+def test_completion_remote_delete_after_valid_name(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """No completions after a full remote name has been provided."""
+    sm = _remote_sm(shpd_conf)
+    completions = sm.completionMng.get_completions(
+        ["remote", "delete", "ftp-prod"]
+    )
+    assert completions == []
+
+
+@pytest.mark.compl
+def test_completion_remote_envs_no_extra_args(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """'remote envs' with no positional args suggests the --remote option."""
+    sm = _remote_sm(shpd_conf)
+    completions = sm.completionMng.get_completions(["remote", "envs"])
+    assert completions == ["--remote"]
+
+
+@pytest.mark.compl
+def test_completion_remote_envs_remote_option_value(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """'remote envs --remote' returns all registered remote names."""
+    sm = _remote_sm(shpd_conf)
+    completions = sm.completionMng.get_completions(
+        ["remote", "envs", "--remote"]
+    )
+    assert completions == ["ftp-prod", "sftp-backup"]
+
+
+@pytest.mark.compl
+def test_completion_remote_envs_remote_option_prefix(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """'remote envs --remote ftp-' returns only names starting with 'ftp-'."""
+    sm = _remote_sm(shpd_conf)
+    completions = sm.completionMng.get_completions(
+        ["remote", "envs", "--remote", "ftp-"]
+    )
+    assert completions == ["ftp-prod"]
+
+
+@pytest.mark.compl
+def test_completion_remote_get_env_names(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """'remote get' completes ENV_NAME from the default remote index."""
+    from config.config import RemoteCfg
+    from storage.snapshot import IndexCatalogue, IndexCatalogueEntry
+
+    sm = _remote_sm(shpd_conf)
+    fake_cfg = RemoteCfg(
+        name="ftp-prod", type="ftp", host="h", user="u", root_path="/"
+    )
+    fake_catalogue = IndexCatalogue(
+        updated_at="2026-01-01T00:00:00Z",
+        environments={
+            "my-env": IndexCatalogueEntry(
+                latest_snapshot="snap-1",
+                snapshot_count=1,
+                last_backup="2026-01-01T00:00:00Z",
+                labels=[],
+                total_size_bytes=0,
+                stored_size_bytes=0,
+            ),
+            "other-env": IndexCatalogueEntry(
+                latest_snapshot="snap-2",
+                snapshot_count=1,
+                last_backup="2026-01-01T00:00:00Z",
+                labels=[],
+                total_size_bytes=0,
+                stored_size_bytes=0,
+            ),
+        },
+    )
+    mocker.patch.object(
+        sm.remoteMng,
+        "list_envs",
+        return_value=(fake_cfg, fake_catalogue),
+    )
+
+    completions = sm.completionMng.get_completions(["remote", "get"])
+    assert sorted(completions) == ["my-env", "other-env"]
+
+
+@pytest.mark.compl
+def test_completion_remote_get_env_names_prefix(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """'remote get my-' filters env names by the given prefix."""
+    from config.config import RemoteCfg
+    from storage.snapshot import IndexCatalogue, IndexCatalogueEntry
+
+    sm = _remote_sm(shpd_conf)
+    fake_cfg = RemoteCfg(
+        name="ftp-prod", type="ftp", host="h", user="u", root_path="/"
+    )
+    fake_catalogue = IndexCatalogue(
+        updated_at="2026-01-01T00:00:00Z",
+        environments={
+            "my-env": IndexCatalogueEntry(
+                latest_snapshot="snap-1",
+                snapshot_count=1,
+                last_backup="2026-01-01T00:00:00Z",
+                labels=[],
+                total_size_bytes=0,
+                stored_size_bytes=0,
+            ),
+            "other-env": IndexCatalogueEntry(
+                latest_snapshot="snap-2",
+                snapshot_count=1,
+                last_backup="2026-01-01T00:00:00Z",
+                labels=[],
+                total_size_bytes=0,
+                stored_size_bytes=0,
+            ),
+        },
+    )
+    mocker.patch.object(
+        sm.remoteMng,
+        "list_envs",
+        return_value=(fake_cfg, fake_catalogue),
+    )
+
+    completions = sm.completionMng.get_completions(["remote", "get", "my-"])
+    assert completions == ["my-env"]
+
+
+@pytest.mark.compl
+def test_completion_remote_get_remote_option_value(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """'remote get <env> --remote' returns all registered remote names."""
+    sm = _remote_sm(shpd_conf)
+    completions = sm.completionMng.get_completions(
+        ["remote", "get", "my-env", "--remote"]
+    )
+    assert completions == ["ftp-prod", "sftp-backup"]
+
+
+@pytest.mark.compl
+def test_completion_remote_add_flags(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """'remote add -' suggests all add-command flags."""
+    sm = ShepherdMng(load_runtime_plugins=False)
+    completions = sm.completionMng.get_completions(["remote", "add", "-"])
+    assert "--ftp" in completions
+    assert "--sftp" in completions
+    assert "--host" in completions
+    assert "--user" in completions
+    assert "--root-path" in completions
+    assert "--set-default" in completions

--- a/src/tests/test_remote_mng.py
+++ b/src/tests/test_remote_mng.py
@@ -1,0 +1,425 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Unit tests for :class:`~remote.remote_mng.RemoteMng`.
+
+All tests use :class:`FakeRemoteBackend` — an in-memory implementation of
+:class:`~remote.backend.RemoteBackend` — to exercise the orchestration logic
+without touching a real FTP or SFTP server.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+
+from config.config import RemoteCfg
+from remote.backend import RemoteBackend
+from remote.remote_mng import RemoteMng
+from storage.snapshot import (
+    IndexCatalogue,
+    IndexCatalogueEntry,
+    SnapshotManifest,
+)
+
+# ---------------------------------------------------------------------------
+# FakeRemoteBackend
+# ---------------------------------------------------------------------------
+
+
+class FakeRemoteBackend(RemoteBackend):
+    """In-memory :class:`~remote.backend.RemoteBackend` for testing.
+
+    Stores all data in a plain ``dict[str, bytes]``.  Can be pre-seeded via
+    :meth:`seed` before the test calls into ``RemoteMng``.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, bytes] = {}
+
+    def seed(self, path: str, data: bytes) -> None:
+        """Pre-populate *path* with *data* (test helper)."""
+        self._store[path] = data
+
+    # RemoteBackend contract
+
+    def exists(self, path: str) -> bool:
+        return path in self._store
+
+    def upload(self, path: str, data: bytes) -> None:
+        self._store[path] = data
+
+    def download(self, path: str) -> bytes:
+        if path not in self._store:
+            raise FileNotFoundError(f"FakeRemoteBackend: no such path: {path}")
+        return self._store[path]
+
+    def list_prefix(self, prefix: str) -> list[str]:
+        """Return leaf names of all paths that start with *prefix/*."""
+        results: list[str] = []
+        search = prefix.rstrip("/") + "/"
+        for key in self._store:
+            if key.startswith(search):
+                leaf = key[len(search) :]
+                # only one level deep (no nested slashes)
+                if "/" not in leaf:
+                    results.append(leaf)
+        return results
+
+    def delete(self, path: str) -> None:
+        self._store.pop(path, None)
+
+    def close(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_REMOTE_FTP = RemoteCfg(
+    name="test-ftp",
+    type="ftp",
+    host="localhost",
+    user="u",
+    password="p",
+    root_path="/shpd",
+)
+_REMOTE_SFTP = RemoteCfg(
+    name="test-sftp",
+    type="sftp",
+    host="localhost",
+    user="u",
+    root_path="/shpd",
+)
+_REMOTE_DEFAULT = RemoteCfg(
+    name="default-remote",
+    type="ftp",
+    host="localhost",
+    user="u",
+    password="p",
+    root_path="/shpd",
+    default="true",
+)
+
+
+def _make_mng(
+    remotes: list[RemoteCfg],
+    fake_backend: FakeRemoteBackend,
+) -> RemoteMng:
+    """Build a :class:`RemoteMng` wired to *fake_backend*.
+
+    The ``_build_backend`` method is replaced via ``MagicMock`` so that the
+    test can inject ``fake_backend`` regardless of the ``RemoteCfg.type``.
+    """
+    configMng = MagicMock()
+    configMng.get_remotes.return_value = remotes
+    configMng.get_remote.side_effect = lambda name: next(
+        (r for r in remotes if r.name == name), None
+    )
+    configMng.get_default_remote.return_value = next(
+        (r for r in remotes if r.is_default()), None
+    )
+
+    mng = RemoteMng(configMng)
+    mng._build_backend = MagicMock(return_value=fake_backend)  # type: ignore[method-assign]
+    return mng
+
+
+def _make_manifest(
+    snapshot_id: str,
+    env: str = "my-env",
+    created_at: str = "2026-01-01T00:00:00Z",
+) -> SnapshotManifest:
+    return SnapshotManifest(
+        snapshot_id=snapshot_id,
+        environment=env,
+        shepherd_version="0.1.0",
+        created_at=created_at,
+        chunks=["ab" * 32],
+        chunk_count=1,
+        total_size_bytes=1024,
+        stored_size_bytes=512,
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_envs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_list_envs_no_index() -> None:
+    """When the remote has no index.json the returned catalogue is empty."""
+    fake = FakeRemoteBackend()
+    mng = _make_mng([_REMOTE_FTP], fake)
+
+    _, catalogue = mng.list_envs("test-ftp")
+
+    assert isinstance(catalogue, IndexCatalogue)
+    assert catalogue.environments == {}
+
+
+@pytest.mark.remote
+def test_list_envs_with_index() -> None:
+    """A seeded index.json is parsed and returned correctly."""
+    fake = FakeRemoteBackend()
+    entry = IndexCatalogueEntry(
+        latest_snapshot="2026-01-01T00:00:00Z-abc123",
+        snapshot_count=3,
+        last_backup="2026-01-01T00:00:00Z",
+        labels=["prod"],
+        total_size_bytes=1_000_000,
+        stored_size_bytes=600_000,
+    )
+    catalogue = IndexCatalogue(
+        updated_at="2026-01-01T00:00:00Z",
+        environments={"my-env": entry},
+    )
+    fake.seed("index/index.json", json.dumps(catalogue.to_dict()).encode())
+
+    mng = _make_mng([_REMOTE_FTP], fake)
+    _, result = mng.list_envs("test-ftp")
+
+    assert "my-env" in result.environments
+    assert result.environments["my-env"].snapshot_count == 3
+    assert result.environments["my-env"].labels == ["prod"]
+
+
+# ---------------------------------------------------------------------------
+# list_snapshots
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_list_snapshots_empty() -> None:
+    """When no snapshot manifests exist the returned list is empty."""
+    fake = FakeRemoteBackend()
+    mng = _make_mng([_REMOTE_FTP], fake)
+
+    _, manifests = mng.list_snapshots("my-env", "test-ftp")
+
+    assert manifests == []
+
+
+@pytest.mark.remote
+def test_list_snapshots_sorted_newest_first() -> None:
+    """Snapshot manifests are returned sorted newest-first by created_at."""
+    fake = FakeRemoteBackend()
+    for ts, sid in [
+        ("2026-01-01T00:00:00Z", "snap-a"),
+        ("2026-03-01T00:00:00Z", "snap-c"),
+        ("2026-02-01T00:00:00Z", "snap-b"),
+    ]:
+        m = _make_manifest(sid, created_at=ts)
+        path = f"envs/my-env/snapshots/{sid}.json"
+        fake.seed(path, json.dumps(m.to_dict()).encode())
+
+    mng = _make_mng([_REMOTE_FTP], fake)
+    _, manifests = mng.list_snapshots("my-env", "test-ftp")
+
+    assert len(manifests) == 3
+    assert [m.snapshot_id for m in manifests] == ["snap-c", "snap-b", "snap-a"]
+
+
+@pytest.mark.remote
+def test_list_snapshots_ignores_non_json_entries() -> None:
+    """Non-JSON entries returned by list_prefix are silently skipped."""
+    fake = FakeRemoteBackend()
+    m = _make_manifest("snap-a")
+    fake.seed(
+        "envs/my-env/snapshots/snap-a.json",
+        json.dumps(m.to_dict()).encode(),
+    )
+    fake.seed("envs/my-env/snapshots/README", b"ignore me")
+
+    mng = _make_mng([_REMOTE_FTP], fake)
+    _, manifests = mng.list_snapshots("my-env", "test-ftp")
+
+    assert len(manifests) == 1
+    assert manifests[0].snapshot_id == "snap-a"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_remote
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_resolve_remote_by_name() -> None:
+    """_resolve_remote returns the named remote when it exists."""
+    mng = _make_mng([_REMOTE_FTP, _REMOTE_SFTP], FakeRemoteBackend())
+    result = mng._resolve_remote("test-sftp")
+    assert result.name == "test-sftp"
+
+
+@pytest.mark.remote
+def test_resolve_remote_default() -> None:
+    """_resolve_remote falls back to the default remote when name is None."""
+    mng = _make_mng([_REMOTE_FTP, _REMOTE_DEFAULT], FakeRemoteBackend())
+    result = mng._resolve_remote(None)
+    assert result.name == "default-remote"
+
+
+@pytest.mark.remote
+def test_resolve_remote_raises_when_no_remotes() -> None:
+    """_resolve_remote raises UsageError when no remotes are configured."""
+    mng = _make_mng([], FakeRemoteBackend())
+    with pytest.raises(click.UsageError, match="No remotes configured"):
+        mng._resolve_remote(None)
+
+
+@pytest.mark.remote
+def test_resolve_remote_raises_when_no_default() -> None:
+    """_resolve_remote raises UsageError when remotes exist but none is default."""
+    mng = _make_mng([_REMOTE_FTP], FakeRemoteBackend())
+    with pytest.raises(click.UsageError, match="No default remote"):
+        mng._resolve_remote(None)
+
+
+@pytest.mark.remote
+def test_resolve_remote_raises_when_name_unknown() -> None:
+    """_resolve_remote raises UsageError for an unknown remote name."""
+    mng = _make_mng([_REMOTE_FTP], FakeRemoteBackend())
+    with pytest.raises(click.UsageError, match="not configured"):
+        mng._resolve_remote("does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# _build_backend
+# ---------------------------------------------------------------------------
+
+
+def _mng() -> RemoteMng:
+    """Return a bare RemoteMng with a no-op configMng."""
+    return RemoteMng(MagicMock())
+
+
+@pytest.mark.remote
+def test_build_backend_ftp_default_port() -> None:
+    """FTP backend receives port 21 when none is specified."""
+    cfg = RemoteCfg(
+        name="r",
+        type="ftp",
+        host="ftp.example.com",
+        user="u",
+        password="p",
+        root_path="/shpd",
+    )
+    with patch("remote.remote_mng.FTPBackend") as MockFTP:
+        _mng()._build_backend(cfg)
+    MockFTP.assert_called_once_with(
+        host="ftp.example.com",
+        port=21,
+        user="u",
+        password="p",
+        root_path="/shpd",
+    )
+
+
+@pytest.mark.remote
+def test_build_backend_ftp_explicit_port() -> None:
+    """FTP backend forwards an explicit port unchanged."""
+    cfg = RemoteCfg(
+        name="r",
+        type="ftp",
+        host="ftp.example.com",
+        port=2121,
+        user="u",
+        password="p",
+        root_path="/shpd",
+    )
+    with patch("remote.remote_mng.FTPBackend") as MockFTP:
+        _mng()._build_backend(cfg)
+    MockFTP.assert_called_once_with(
+        host="ftp.example.com",
+        port=2121,
+        user="u",
+        password="p",
+        root_path="/shpd",
+    )
+
+
+@pytest.mark.remote
+def test_build_backend_sftp_default_port() -> None:
+    """SFTP backend receives port 22 when none is specified."""
+    cfg = RemoteCfg(
+        name="r",
+        type="sftp",
+        host="sftp.example.com",
+        user="u",
+        root_path="/shpd",
+    )
+    with patch("remote.remote_mng.SFTPBackend") as MockSFTP:
+        _mng()._build_backend(cfg)
+    MockSFTP.assert_called_once_with(
+        host="sftp.example.com",
+        port=22,
+        user="u",
+        password=None,
+        identity_file=None,
+        root_path="/shpd",
+    )
+
+
+@pytest.mark.remote
+def test_build_backend_sftp_with_identity_file() -> None:
+    """SFTP backend forwards identity_file when provided."""
+    cfg = RemoteCfg(
+        name="r",
+        type="sftp",
+        host="sftp.example.com",
+        port=2222,
+        user="u",
+        identity_file="/home/u/.ssh/id_ed25519",
+        root_path="/shpd",
+    )
+    with patch("remote.remote_mng.SFTPBackend") as MockSFTP:
+        _mng()._build_backend(cfg)
+    MockSFTP.assert_called_once_with(
+        host="sftp.example.com",
+        port=2222,
+        user="u",
+        password=None,
+        identity_file="/home/u/.ssh/id_ed25519",
+        root_path="/shpd",
+    )
+
+
+@pytest.mark.remote
+def test_build_backend_unknown_type_raises() -> None:
+    """An unrecognised type string raises click.UsageError."""
+    cfg = RemoteCfg(
+        name="r",
+        type="s3",
+        host="s3.example.com",
+        user="u",
+        root_path="/shpd",
+    )
+    with pytest.raises(click.UsageError, match="Unknown remote type"):
+        _mng()._build_backend(cfg)
+
+
+@pytest.mark.remote
+def test_build_backend_does_not_mutate_original_cfg() -> None:
+    """_build_backend must not modify the RemoteCfg it receives."""
+    cfg = RemoteCfg(
+        name="r",
+        type="ftp",
+        host="ftp.example.com",
+        user="u",
+        password="p",
+        root_path="/shpd",
+    )
+    resolved_before = cfg.is_resolved()
+    with patch("remote.remote_mng.FTPBackend"):
+        _mng()._build_backend(cfg)
+    assert cfg.is_resolved() == resolved_before

--- a/src/tests/test_remote_mng.py
+++ b/src/tests/test_remote_mng.py
@@ -169,6 +169,31 @@ def test_list_envs_no_index() -> None:
 
 
 @pytest.mark.remote
+def test_list_envs_via_default_remote() -> None:
+    """list_envs(None) resolves and uses the configured default remote."""
+    fake = FakeRemoteBackend()
+    entry = IndexCatalogueEntry(
+        latest_snapshot="2026-01-01T00:00:00Z-abc123",
+        snapshot_count=1,
+        last_backup="2026-01-01T00:00:00Z",
+        labels=[],
+        total_size_bytes=512,
+        stored_size_bytes=256,
+    )
+    catalogue = IndexCatalogue(
+        updated_at="2026-01-01T00:00:00Z",
+        environments={"default-env": entry},
+    )
+    fake.seed("index/index.json", json.dumps(catalogue.to_dict()).encode())
+
+    mng = _make_mng([_REMOTE_DEFAULT], fake)
+    cfg, result = mng.list_envs(None)
+
+    assert cfg.name == "default-remote"
+    assert "default-env" in result.environments
+
+
+@pytest.mark.remote
 def test_list_envs_with_index() -> None:
     """A seeded index.json is parsed and returned correctly."""
     fake = FakeRemoteBackend()
@@ -390,6 +415,29 @@ def test_build_backend_sftp_with_identity_file() -> None:
         user="u",
         password=None,
         identity_file="/home/u/.ssh/id_ed25519",
+        root_path="/shpd",
+    )
+
+
+@pytest.mark.remote
+def test_build_backend_sftp_empty_identity_file_treated_as_none() -> None:
+    """An empty-string identity_file is normalised to None (not forwarded)."""
+    cfg = RemoteCfg(
+        name="r",
+        type="sftp",
+        host="sftp.example.com",
+        user="u",
+        identity_file="",
+        root_path="/shpd",
+    )
+    with patch("remote.remote_mng.SFTPBackend") as MockSFTP:
+        _mng()._build_backend(cfg)
+    MockSFTP.assert_called_once_with(
+        host="sftp.example.com",
+        port=22,
+        user="u",
+        password=None,
+        identity_file=None,
         root_path="/shpd",
     )
 

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -1426,6 +1426,8 @@ def test_cli_remote_add_ftp(
             "ftp.example.com",
             "--user",
             "deploy",
+            "--password",
+            "secret",
             "--root-path",
             "/shpd",
         ],
@@ -1459,6 +1461,8 @@ def test_cli_remote_add_sftp(
             "sftp.example.com",
             "--user",
             "backup",
+            "--identity-file",
+            "/home/backup/.ssh/id_ed25519",
             "--root-path",
             "/shpd",
         ],
@@ -1492,6 +1496,8 @@ def test_cli_remote_add_set_default(
             "ftp.example.com",
             "--user",
             "u",
+            "--password",
+            "p",
             "--root-path",
             "/shpd",
             "--set-default",
@@ -1550,6 +1556,8 @@ def test_cli_remote_add_duplicate_name(
             "h",
             "--user",
             "u",
+            "--password",
+            "p",
             "--root-path",
             "/",
         ],
@@ -1702,3 +1710,61 @@ def test_cli_remote_get_with_remote(
 
     assert result.exit_code == 0
     mock_display.assert_called_once_with("my-env", "ftp-prod")
+
+
+@pytest.mark.shpd
+def test_cli_remote_add_ftp_missing_password(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote add --ftp' without --password fails with a usage error."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    (shpd_path / ".shpd.yaml").write_text(read_fixture("shpd", "shpd.yaml"))
+
+    result = runner.invoke(
+        cli,
+        [
+            "remote",
+            "add",
+            "my-ftp",
+            "--ftp",
+            "--host",
+            "ftp.example.com",
+            "--user",
+            "u",
+            "--root-path",
+            "/shpd",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "FTP remotes require --password" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_remote_add_sftp_missing_credentials(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote add --sftp' without --password or --identity-file fails."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    (shpd_path / ".shpd.yaml").write_text(read_fixture("shpd", "shpd.yaml"))
+
+    result = runner.invoke(
+        cli,
+        [
+            "remote",
+            "add",
+            "my-sftp",
+            "--sftp",
+            "--host",
+            "sftp.example.com",
+            "--user",
+            "u",
+            "--root-path",
+            "/shpd",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "SFTP remotes require --password or --identity-file" in result.output

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -1360,3 +1360,345 @@ def test_cli_check_probe_watch_with_probe_tag(
     watch_probes.assert_called_once()
     _, probe_tag = watch_probes.call_args.args
     assert probe_tag == "db-ready"
+
+
+# =============================================================================
+# REMOTE commands
+# =============================================================================
+
+
+def _write_cli_config_with_remotes(config_path: Path) -> None:
+    """Write a shpd.yaml that already contains two registered remotes."""
+    shpd_config = yaml.safe_load(read_fixture("shpd", "shpd.yaml"))
+    shpd_config["remotes"] = [
+        {
+            "name": "ftp-prod",
+            "type": "ftp",
+            "host": "ftp.example.com",
+            "user": "deploy",
+            "root_path": "/shpd",
+            "default": "true",
+        },
+        {
+            "name": "sftp-backup",
+            "type": "sftp",
+            "host": "sftp.example.com",
+            "user": "backup",
+            "root_path": "/shpd",
+            "default": "false",
+        },
+    ]
+    config_path.write_text(yaml.dump(shpd_config, sort_keys=False))
+
+
+def _setup_remote(shpd_conf: tuple[Path, Path]) -> Path:
+    """Create dir + write config with remotes; return shpd_yaml path."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _write_cli_config_with_remotes(shpd_yaml)
+    return shpd_yaml
+
+
+# ------------------------------------------------------------------
+# remote add
+# ------------------------------------------------------------------
+
+
+@pytest.mark.shpd
+def test_cli_remote_add_ftp(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote add' with FTP transport registers the remote and persists it."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(read_fixture("shpd", "shpd.yaml"))
+
+    result = runner.invoke(
+        cli,
+        [
+            "remote",
+            "add",
+            "my-ftp",
+            "--ftp",
+            "--host",
+            "ftp.example.com",
+            "--user",
+            "deploy",
+            "--root-path",
+            "/shpd",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Remote 'my-ftp' registered." in result.output
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    remotes = stored.get("remotes", [])
+    assert any(r["name"] == "my-ftp" and r["type"] == "ftp" for r in remotes)
+
+
+@pytest.mark.shpd
+def test_cli_remote_add_sftp(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote add' with SFTP transport registers the remote."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(read_fixture("shpd", "shpd.yaml"))
+
+    result = runner.invoke(
+        cli,
+        [
+            "remote",
+            "add",
+            "my-sftp",
+            "--sftp",
+            "--host",
+            "sftp.example.com",
+            "--user",
+            "backup",
+            "--root-path",
+            "/shpd",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Remote 'my-sftp' registered." in result.output
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    remotes = stored.get("remotes", [])
+    assert any(r["name"] == "my-sftp" and r["type"] == "sftp" for r in remotes)
+
+
+@pytest.mark.shpd
+def test_cli_remote_add_set_default(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote add --set-default' marks the remote as the default."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(read_fixture("shpd", "shpd.yaml"))
+
+    runner.invoke(
+        cli,
+        [
+            "remote",
+            "add",
+            "my-ftp",
+            "--ftp",
+            "--host",
+            "ftp.example.com",
+            "--user",
+            "u",
+            "--root-path",
+            "/shpd",
+            "--set-default",
+        ],
+    )
+
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    remote = next(r for r in stored["remotes"] if r["name"] == "my-ftp")
+    assert remote["default"] is True
+
+
+@pytest.mark.shpd
+def test_cli_remote_add_missing_transport(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote add' without --ftp/--sftp fails with a usage error."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(read_fixture("shpd", "shpd.yaml"))
+
+    result = runner.invoke(
+        cli,
+        [
+            "remote",
+            "add",
+            "my-remote",
+            "--host",
+            "h",
+            "--user",
+            "u",
+            "--root-path",
+            "/",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Specify a transport" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_remote_add_duplicate_name(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote add' with a name that already exists fails cleanly."""
+    shpd_yaml = _setup_remote(shpd_conf)
+
+    result = runner.invoke(
+        cli,
+        [
+            "remote",
+            "add",
+            "ftp-prod",
+            "--ftp",
+            "--host",
+            "h",
+            "--user",
+            "u",
+            "--root-path",
+            "/",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "already exists" in result.output
+
+
+# ------------------------------------------------------------------
+# remote list
+# ------------------------------------------------------------------
+
+
+@pytest.mark.shpd
+def test_cli_remote_list_empty(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote list' with no remotes configured prints a helpful message."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(read_fixture("shpd", "shpd.yaml"))
+
+    result = runner.invoke(cli, ["remote", "list"])
+
+    assert result.exit_code == 0
+    assert "No remotes configured" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_remote_list(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote list' shows all registered remotes."""
+    _setup_remote(shpd_conf)
+
+    result = runner.invoke(cli, ["remote", "list"])
+
+    assert result.exit_code == 0
+    assert "ftp-prod" in result.output
+    assert "sftp-backup" in result.output
+
+
+# ------------------------------------------------------------------
+# remote delete
+# ------------------------------------------------------------------
+
+
+@pytest.mark.shpd
+def test_cli_remote_delete(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote delete' removes the remote from the config."""
+    shpd_yaml = _setup_remote(shpd_conf)
+
+    result = runner.invoke(cli, ["remote", "delete", "sftp-backup"])
+
+    assert result.exit_code == 0
+    assert "Remote 'sftp-backup' removed." in result.output
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    remotes = stored.get("remotes", [])
+    assert all(r["name"] != "sftp-backup" for r in remotes)
+
+
+@pytest.mark.shpd
+def test_cli_remote_delete_missing(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote delete' on an unknown name fails with a usage error."""
+    _setup_remote(shpd_conf)
+
+    result = runner.invoke(cli, ["remote", "delete", "does-not-exist"])
+
+    assert result.exit_code != 0
+    assert "not configured" in result.output
+
+
+# ------------------------------------------------------------------
+# remote envs
+# ------------------------------------------------------------------
+
+
+@pytest.mark.shpd
+def test_cli_remote_envs(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote envs' delegates to remoteMng.display_envs with no remote name."""
+    from remote import RemoteMng
+
+    _setup_remote(shpd_conf)
+    mock_display = mocker.patch.object(RemoteMng, "display_envs")
+
+    result = runner.invoke(cli, ["remote", "envs"])
+
+    assert result.exit_code == 0
+    mock_display.assert_called_once_with(None)
+
+
+@pytest.mark.shpd
+def test_cli_remote_envs_with_remote(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote envs --remote=<name>' passes the name to display_envs."""
+    from remote import RemoteMng
+
+    _setup_remote(shpd_conf)
+    mock_display = mocker.patch.object(RemoteMng, "display_envs")
+
+    result = runner.invoke(cli, ["remote", "envs", "--remote", "ftp-prod"])
+
+    assert result.exit_code == 0
+    mock_display.assert_called_once_with("ftp-prod")
+
+
+# ------------------------------------------------------------------
+# remote get
+# ------------------------------------------------------------------
+
+
+@pytest.mark.shpd
+def test_cli_remote_get(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote get <env>' delegates to remoteMng.display_snapshots."""
+    from remote import RemoteMng
+
+    _setup_remote(shpd_conf)
+    mock_display = mocker.patch.object(RemoteMng, "display_snapshots")
+
+    result = runner.invoke(cli, ["remote", "get", "my-env"])
+
+    assert result.exit_code == 0
+    mock_display.assert_called_once_with("my-env", None)
+
+
+@pytest.mark.shpd
+def test_cli_remote_get_with_remote(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote get <env> --remote=<name>' passes both args to display_snapshots."""
+    from remote import RemoteMng
+
+    _setup_remote(shpd_conf)
+    mock_display = mocker.patch.object(RemoteMng, "display_snapshots")
+
+    result = runner.invoke(
+        cli, ["remote", "get", "my-env", "--remote", "ftp-prod"]
+    )
+
+    assert result.exit_code == 0
+    mock_display.assert_called_once_with("my-env", "ftp-prod")

--- a/src/util/util.py
+++ b/src/util/util.py
@@ -617,3 +617,15 @@ class Util:
             f"Package extracted to {extract_to}",
             style="green",
         )
+
+    @staticmethod
+    def fmt_bytes(n: int) -> str:
+        """Return a human-readable byte count (e.g. ``1.2 MiB``)."""
+        for unit, threshold in (
+            ("GiB", 1 << 30),
+            ("MiB", 1 << 20),
+            ("KiB", 1 << 10),
+        ):
+            if n >= threshold:
+                return f"{n / threshold:.1f} {unit}"
+        return f"{n} B"


### PR DESCRIPTION
## Summary

Implements the read-only remote management CLI and the `RemoteMng`
orchestration layer — the first CLI milestone toward
[ADR-0006](docs/decisions/0006-remote-storage-deduplication.md).

- **`remote add`** / **`remote list`** / **`remote delete`** — config-only
  registration commands (no network required)
- **`remote envs [--remote=<name>]`** — missing discovery command: browses
  all environments available on a remote by reading `index/index.json`
- **`remote get <env> [--remote=<name>]`** — lists all snapshots for a
  specific environment, sorted newest-first
- **`RemoteMng`** — implements `_resolve_remote`, `_build_backend`
  (FTP/SFTP factory with `${VAR}` resolution), `list_envs`, `list_snapshots`,
  and matching `display_*` methods that render Rich tables
- **`ShepherdMng`** — wires `self.remoteMng = RemoteMng(self.configMng)`
- **11 new unit tests** using `FakeRemoteBackend` (in-memory
  `RemoteBackend`), covering index/snapshot listing and all
  `_resolve_remote` error paths

Push/pull/hydrate/dehydrate/prune are out of scope and tracked separately.

## Test plan

- [ ] `cd src && pytest -k remote` — all 38 remote tests pass
- [ ] `pyright` — no type errors
- [ ] `black src && isort src` — no formatting changes
- [ ] `pre-commit run --all-files` — all hooks pass

Fixes: #216