### PR TITLE
feat(remote): implement push and dehydrate operations

### DIFF
--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -51,6 +51,10 @@ class CompletionMng(AbstractCompletionMng):
             "halt",
             "reload",
             "status",
+            "push",
+            "dehydrate",
+            "pull",
+            "hydrate",
         ],
         "svc": ["get", "add", "up", "halt", "reload", "build", "logs", "shell"],
         "probe": ["get", "check"],
@@ -124,6 +128,11 @@ class CompletionMng(AbstractCompletionMng):
             OptionSpec(tokens=("-w", "--watch")),
             OptionSpec(tokens=("--show-commands",)),
             OptionSpec(tokens=("--show-commands-limit",), takes_value=True),
+        ),
+        ("env", "push"): (
+            OptionSpec(tokens=("--remote",), takes_value=True),
+            OptionSpec(tokens=("--set-tracking-remote",)),
+            OptionSpec(tokens=("--labels",), takes_value=True),
         ),
         ("plugin", "install"): (OptionSpec(tokens=("--force",)),),
         ("remote", "add"): (

--- a/src/completion/completion_env.py
+++ b/src/completion/completion_env.py
@@ -53,6 +53,14 @@ class CompletionEnvMng(AbstractCompletionMng):
                 return self.get_reload_completions(args[2:])
             case "status":
                 return self.get_status_completions(args[2:])
+            case "push":
+                return self.get_push_completions(args[2:])
+            case "dehydrate":
+                return self.get_dehydrate_completions(args[2:])
+            case "pull":
+                return self.get_pull_completions(args[2:])
+            case "hydrate":
+                return self.get_hydrate_completions(args[2:])
             case _:
                 return []
 
@@ -117,4 +125,34 @@ class CompletionEnvMng(AbstractCompletionMng):
         return []
 
     def get_status_completions(self, args: list[str]) -> list[str]:
+        return []
+
+    def get_push_completions(self, args: list[str]) -> list[str]:
+        if not self.is_src_env_tag_chosen(args):
+            return [
+                env.tag
+                for env in self.configMng.get_environments()
+                if not env.dehydrated
+            ]
+        return []
+
+    def get_dehydrate_completions(self, args: list[str]) -> list[str]:
+        if not self.is_src_env_tag_chosen(args):
+            return [
+                env.tag
+                for env in self.configMng.get_environments()
+                if not env.dehydrated
+            ]
+        return []
+
+    def get_pull_completions(self, args: list[str]) -> list[str]:
+        return []
+
+    def get_hydrate_completions(self, args: list[str]) -> list[str]:
+        if not self.is_src_env_tag_chosen(args):
+            return [
+                env.tag
+                for env in self.configMng.get_environments()
+                if env.dehydrated
+            ]
         return []

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -689,6 +689,7 @@ class EnvironmentCfg(Resolvable):
     volumes: Optional[list[VolumeCfg]]
     ready: Optional[ReadyCfg] = None
     tracking_remote: Optional[str] = None
+    dehydrated: Optional[bool] = None
     status: EntityStatus = field(default_factory=EntityStatus)
 
     def get_service(self, svcTag: str) -> Optional[ServiceCfg]:
@@ -1237,6 +1238,7 @@ def _parse_environment(item: Any) -> EnvironmentCfg:
         networks=[_parse_network(network) for network in networks_data],
         volumes=[_parse_volume(volume) for volume in volumes_data],
         tracking_remote=item.get("tracking_remote"),
+        dehydrated=item.get("dehydrated"),
         status=_parse_status(item["status"]),
     )
 
@@ -2141,6 +2143,7 @@ class ConfigMng:
             networks=deepcopy(other.networks),
             volumes=deepcopy(other.volumes),
             tracking_remote=other.tracking_remote,
+            dehydrated=other.dehydrated,
         )
 
     def svc_tmpl_cfg_from_other(self, other: ServiceTemplateCfg):

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -802,7 +802,7 @@ class EnvironmentMng:
     def reload_env(self, envCfg: EnvironmentCfg, watch: bool = False):
         """Reload an environment."""
         env = self.get_environment_from_cfg(envCfg)
-        if not env.envCfg.status.rendered_config:
+        if not env.is_running():
             Util.print_error_and_die(
                 f"Environment '{env.envCfg.tag}' is not started."
             )
@@ -872,7 +872,7 @@ class EnvironmentMng:
         """Check probes."""
         env = self.get_environment_from_cfg(envCfg)
 
-        if not env.envCfg.status.rendered_config:
+        if not env.is_running():
             Util.print_error_and_die(
                 f"Environment '{env.envCfg.tag}' is not started."
             )
@@ -934,7 +934,7 @@ class EnvironmentMng:
     ) -> None:
         """Continuously run probes and render results until interrupted."""
         env = self.get_environment_from_cfg(envCfg)
-        if not env.envCfg.status.rendered_config:
+        if not env.is_running():
             Util.print_error_and_die(
                 f"Environment '{env.envCfg.tag}' is not started."
             )

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -318,6 +318,21 @@ class Environment(ABC):
         """Get environment status."""
         return self.status_impl()
 
+    def is_running(self) -> bool:
+        """Return ``True`` if any service in this environment is running.
+
+        Delegates to :meth:`status_impl` so that the check goes through the
+        concrete backend (e.g. ``docker compose ps``) rather than relying on
+        the potentially-stale ``rendered_config`` field in the config.
+        """
+        try:
+            services = self.status_impl()
+        except Exception:
+            return False
+        return any(
+            str(svc.get("State", "")).lower() == "running" for svc in services
+        )
+
     def on_start_cycle_begin(self) -> None:
         """Hook called once at the beginning of environment start."""
         return None

--- a/src/remote/remote_mng.py
+++ b/src/remote/remote_mng.py
@@ -12,19 +12,41 @@ from __future__ import annotations
 
 import datetime
 import json
+import os
+import shutil
+import subprocess
 from copy import deepcopy
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import click
 
 from config import ConfigMng
 from config.config import RemoteCfg
-from storage.snapshot import IndexCatalogue, SnapshotManifest
+from storage.chunker import Chunker
+from storage.snapshot import (
+    IndexCatalogue,
+    IndexCatalogueEntry,
+    LatestPointer,
+    SnapshotManifest,
+)
+from storage.tar_stream import TarStreamProducer
 from util import Util
 
 from .backend import RemoteBackend
 from .ftp_backend import FTPBackend
 from .sftp_backend import SFTPBackend
+
+if TYPE_CHECKING:
+    from environment.environment import Environment, EnvironmentMng
+
+
+def _utcnow() -> str:
+    """Return the current UTC time as an ISO-8601 string ending in ``Z``."""
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
 
 
 class RemoteMng:
@@ -33,8 +55,9 @@ class RemoteMng:
     Responsibilities:
     - Build the appropriate :class:`~remote.backend.RemoteBackend` (core
       built-in FTP, or a plugin-registered backend) from a ``RemoteCfg``.
-    - Drive the push algorithm: tar stream → chunk → dedup check → upload
-      missing chunks → write manifest → update ``latest.json`` / ``index.json``.
+    - Drive the push algorithm: tar stream → chunk → dedup check →
+      upload missing chunks → write manifest → update ``latest.json``
+      / ``index.json``.
     - Drive pull (first-time download, creates local env entry) and hydrate
       (restore data for an already-registered dehydrated env).
     - Dehydrate: strip local data while keeping the env registered in config.
@@ -117,6 +140,40 @@ class RemoteMng:
             "Plugin-registered backends are not yet supported."
         )
 
+    def _update_index(
+        self,
+        backend: RemoteBackend,
+        env_name: str,
+        snapshot_id: str,
+        now: str,
+        labels: list[str],
+        total_size_bytes: int,
+        stored_size_bytes: int,
+    ) -> None:
+        """Fetch, update, and re-upload ``index/index.json``."""
+        index_path = RemoteBackend.index_path()
+        if backend.exists(index_path):
+            catalogue = IndexCatalogue.from_dict(
+                json.loads(backend.download(index_path))
+            )
+        else:
+            catalogue = IndexCatalogue(updated_at=now)
+
+        existing = catalogue.environments.get(env_name)
+        catalogue.environments[env_name] = IndexCatalogueEntry(
+            latest_snapshot=snapshot_id,
+            snapshot_count=(existing.snapshot_count + 1 if existing else 1),
+            last_backup=now,
+            labels=labels,
+            total_size_bytes=total_size_bytes,
+            stored_size_bytes=stored_size_bytes,
+        )
+        catalogue.updated_at = now
+        backend.upload(
+            index_path,
+            json.dumps(catalogue.to_dict(), indent=2).encode(),
+        )
+
     # ------------------------------------------------------------------
     # Data-returning methods (used by display_* and tests)
     # ------------------------------------------------------------------
@@ -137,12 +194,7 @@ class RemoteMng:
         with self._build_backend(remote_cfg) as backend:
             index_path = backend.index_path()
             if not backend.exists(index_path):
-                now = (
-                    datetime.datetime.now(datetime.timezone.utc)
-                    .isoformat(timespec="seconds")
-                    .replace("+00:00", "Z")
-                )
-                return remote_cfg, IndexCatalogue(updated_at=now)
+                return remote_cfg, IndexCatalogue(updated_at=_utcnow())
             raw = backend.download(index_path)
             catalogue = IndexCatalogue.from_dict(json.loads(raw))
         return remote_cfg, catalogue
@@ -170,6 +222,215 @@ class RemoteMng:
                 manifests.append(SnapshotManifest.from_dict(json.loads(raw)))
         manifests.sort(key=lambda m: m.created_at, reverse=True)
         return remote_cfg, manifests
+
+    # ------------------------------------------------------------------
+    # Push / dehydrate
+    # ------------------------------------------------------------------
+
+    def _stop_if_running(
+        self, env: Environment, environment_mng: EnvironmentMng
+    ) -> None:
+        """Prompt the user to stop *env* if any of its services are running.
+
+        Uses :meth:`~environment.environment.Environment.is_running` (which
+        queries the concrete backend) rather than the config's
+        ``rendered_config`` field, so stale state is never a false positive.
+
+        :raises click.Abort: If the user declines to stop.
+        """
+        if not env.is_running():
+            return
+        if not Util.confirm(
+            f"Environment '{env.envCfg.tag}' has running services. "
+            "Stop it now to proceed?"
+        ):
+            raise click.Abort()
+        environment_mng.stop_env(env.envCfg)
+
+    def push(
+        self,
+        env_name: str,
+        environment_mng: EnvironmentMng,
+        remote_name: Optional[str] = None,
+        set_tracking: bool = False,
+        labels: Optional[list[str]] = None,
+    ) -> None:
+        """Create a new remote snapshot for *env_name*.
+
+        Streams the environment directory and all host-mounted volumes through
+        the FastCDC chunker, uploads only the chunks that are not already
+        present on the remote, then writes the snapshot manifest, updates
+        ``latest.json``, and refreshes ``index/index.json``.
+
+        :param env_name: Tag of the local environment to push.
+        :param environment_mng: Provides access to the concrete
+            :class:`~environment.environment.Environment` for streaming and
+            for stopping the env if it is currently running.
+        :param remote_name: Remote to push to, or ``None`` for the default.
+        :param set_tracking: When ``True``, persist *remote_name* as the
+            env's ``tracking_remote`` in the local config.
+        :param labels: Optional list of ``key=value`` label strings to attach
+            to the snapshot manifest.
+        :raises click.UsageError: If the env is unknown or dehydrated.
+        :raises click.Abort: If the env is running and the user declines to
+            stop it.
+        """
+        env_cfg = self.configMng.get_environment(env_name)
+        if env_cfg is None:
+            raise click.UsageError(
+                f"Environment '{env_name}' not found in local config."
+            )
+        if env_cfg.dehydrated:
+            raise click.UsageError(
+                f"Environment '{env_name}' is dehydrated; "
+                "restore local data with 'env hydrate' before pushing."
+            )
+
+        remote_cfg = self._resolve_remote(remote_name)
+        env: Environment = environment_mng.get_environment_from_cfg(env_cfg)
+        self._stop_if_running(env, environment_mng)
+
+        producer = TarStreamProducer(
+            env_path=env.get_path(),
+            volume_streams=env.get_volume_tar_streams(),
+        )
+        chunker = Chunker(
+            min_size=remote_cfg.chunk.min_size_kb * 1024,
+            avg_size=remote_cfg.chunk.avg_size_kb * 1024,
+            max_size=remote_cfg.chunk.max_size_kb * 1024,
+        )
+
+        chunk_hashes: list[str] = []
+        total_raw = 0
+        total_stored = 0
+        uploaded = 0
+
+        with self._build_backend(remote_cfg) as backend:
+            with producer.stream() as stream:
+                for chunk in chunker.chunk_stream(stream):
+                    path = RemoteBackend.chunk_path(chunk.hash)
+                    chunk_hashes.append(chunk.hash)
+                    total_raw += chunk.raw_size
+                    total_stored += len(chunk.data)
+                    if not backend.exists(path):
+                        backend.upload(path, chunk.data)
+                        uploaded += 1
+
+            now = _utcnow()
+
+            # Build manifest (two-pass: need bytes to derive the snapshot id).
+            manifest = SnapshotManifest(
+                snapshot_id="",  # filled in below
+                environment=env_name,
+                shepherd_version=self.configMng.constants.APP_VERSION,
+                created_at=now,
+                chunks=chunk_hashes,
+                chunk_count=len(chunk_hashes),
+                total_size_bytes=total_raw,
+                stored_size_bytes=total_stored,
+                labels=list(labels or []),
+            )
+            manifest_bytes = json.dumps(manifest.to_dict(), indent=2).encode()
+            snapshot_id = SnapshotManifest.build_id(now, manifest_bytes)
+            manifest.snapshot_id = snapshot_id
+            manifest_bytes = json.dumps(manifest.to_dict(), indent=2).encode()
+
+            backend.upload(
+                RemoteBackend.snapshot_path(env_name, snapshot_id),
+                manifest_bytes,
+            )
+
+            pointer = LatestPointer(snapshot_id=snapshot_id, updated_at=now)
+            backend.upload(
+                RemoteBackend.latest_path(env_name),
+                json.dumps(pointer.to_dict()).encode(),
+            )
+
+            self._update_index(
+                backend,
+                env_name,
+                snapshot_id,
+                now,
+                list(labels or []),
+                total_raw,
+                total_stored,
+            )
+
+        if set_tracking:
+            env_cfg.tracking_remote = remote_cfg.name
+            self.configMng.add_or_set_environment(env_name, env_cfg)
+
+        skipped = len(chunk_hashes) - uploaded
+        Util.print(
+            f"Pushed '{env_name}' → '{remote_cfg.name}' "
+            f"[{snapshot_id}]: "
+            f"{uploaded} chunk(s) uploaded, "
+            f"{skipped} already present, "
+            f"{Util.fmt_bytes(total_stored)} stored."
+        )
+
+    def dehydrate(self, env_name: str, environment_mng: EnvironmentMng) -> None:
+        """Strip local data for *env_name* while preserving its config entry.
+
+        Removes the environment directory and any bind-mount volume device
+        paths declared in the config.  Named Docker volumes are not removed
+        (they are managed by the Docker daemon).  After deletion the env's
+        ``dehydrated`` flag is set to ``True`` and the config is persisted.
+
+        :param env_name: Tag of the local environment to dehydrate.
+        :param environment_mng: Used to check and stop the env if running.
+        :raises click.UsageError: If the env is unknown or already dehydrated.
+        :raises click.Abort: If the env is running and the user declines to
+            stop it.
+        """
+        env_cfg = self.configMng.get_environment(env_name)
+        if env_cfg is None:
+            raise click.UsageError(
+                f"Environment '{env_name}' not found in local config."
+            )
+        if env_cfg.dehydrated:
+            raise click.UsageError(
+                f"Environment '{env_name}' is already dehydrated."
+            )
+
+        env: Environment = environment_mng.get_environment_from_cfg(env_cfg)
+        self._stop_if_running(env, environment_mng)
+
+        env_dir = os.path.join(self.configMng.config.envs_path, env_name)
+        self._delete_dir(env_dir)
+
+        # Also delete bind-mount device paths declared in VolumeCfg.
+        for vol in env_cfg.volumes or []:
+            if (
+                vol.driver == "local"
+                and vol.driver_opts
+                and vol.driver_opts.get("type") == "none"
+                and vol.driver_opts.get("o") == "bind"
+            ):
+                device = vol.driver_opts.get("device", "")
+                if device:
+                    self._delete_dir(device)
+
+        env_cfg.dehydrated = True
+        self.configMng.add_or_set_environment(env_name, env_cfg)
+        Util.print(f"Dehydrated '{env_name}': local data removed.")
+
+    def _delete_dir(self, path: str) -> None:
+        """Delete *path* recursively; retry under sudo on PermissionError."""
+        try:
+            shutil.rmtree(path)
+        except FileNotFoundError:
+            pass  # already absent — treat as success
+        except PermissionError:
+            if os.name != "posix" or not shutil.which("sudo"):
+                raise
+            uid = os.getuid()
+            gid = os.getgid()
+            subprocess.run(
+                ["sudo", "chown", "-R", f"{uid}:{gid}", path],
+                check=True,
+            )
+            shutil.rmtree(path)
 
     # ------------------------------------------------------------------
     # Display methods (called by CLI commands)

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -547,6 +547,53 @@ def status_env(
     shepherd.environmentMng.status_env(envCfg, watch=watch)
 
 
+@env.command(name="push")
+@click.argument("env_tag")
+@click.option(
+    "--remote",
+    "remote_name",
+    default=None,
+    help="Name of the remote to push to (defaults to the configured default).",
+)
+@click.option(
+    "--set-tracking-remote",
+    "set_tracking",
+    is_flag=True,
+    default=False,
+    help="Persist this remote as the env's tracking remote.",
+)
+@click.option(
+    "--labels",
+    default=None,
+    help="Comma-separated key=value labels to attach to the snapshot.",
+)
+@click.pass_obj
+def push_env(
+    shepherd: ShepherdMng,
+    env_tag: str,
+    remote_name: Optional[str],
+    set_tracking: bool,
+    labels: Optional[str],
+) -> None:
+    """Push a new snapshot of ENV_TAG to a remote."""
+    label_list = [lbl.strip() for lbl in labels.split(",")] if labels else []
+    shepherd.remoteMng.push(
+        env_name=env_tag,
+        environment_mng=shepherd.environmentMng,
+        remote_name=remote_name,
+        set_tracking=set_tracking,
+        labels=label_list,
+    )
+
+
+@env.command(name="dehydrate")
+@click.argument("env_tag")
+@click.pass_obj
+def dehydrate_env(shepherd: ShepherdMng, env_tag: str) -> None:
+    """Strip local data for ENV_TAG while preserving its config entry."""
+    shepherd.remoteMng.dehydrate(env_tag, shepherd.environmentMng)
+
+
 # =====================================================
 # SVC
 # =====================================================

--- a/src/tests/fixtures/completion/shpd.yaml
+++ b/src/tests/fixtures/completion/shpd.yaml
@@ -229,3 +229,14 @@ envs:
     status:
       active: false
       rendered_config: null
+  - template: default
+    factory: docker-compose
+    tag: test-3
+    services: []
+    probes: []
+    networks: []
+    volumes: []
+    dehydrated: true
+    status:
+      active: false
+      rendered_config: null

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -401,7 +401,11 @@ def test_completion_clone_env(
 
     sm = ShepherdMng()
     completions = sm.completionMng.get_completions(["env", "clone"])
-    assert completions == ["test-1", "test-2"], "Expected env clone completion"
+    assert completions == [
+        "test-1",
+        "test-2",
+        "test-3",
+    ], "Expected env clone completion"
 
 
 @pytest.mark.compl
@@ -437,7 +441,11 @@ def test_completion_rename_env(
 
     sm = ShepherdMng()
     completions = sm.completionMng.get_completions(["env", "rename"])
-    assert completions == ["test-1", "test-2"], "Expected env rename completion"
+    assert completions == [
+        "test-1",
+        "test-2",
+        "test-3",
+    ], "Expected env rename completion"
 
 
 @pytest.mark.compl
@@ -456,6 +464,7 @@ def test_completion_checkout_env(
     completions = sm.completionMng.get_completions(["env", "checkout"])
     assert completions == [
         "test-2",
+        "test-3",
     ], "Expected env checkout completion"
 
 
@@ -495,6 +504,7 @@ def test_completion_delete_env(
     assert completions == [
         "test-1",
         "test-2",
+        "test-3",
     ], "Expected env delete completion"
 
 
@@ -829,6 +839,7 @@ def test_completion_get_env_oyaml(
     assert completions == [
         "test-1",
         "test-2",
+        "test-3",
     ], "Expected get env -oyaml completion"
 
 
@@ -846,7 +857,11 @@ def test_completion_get_env(
 
     sm = ShepherdMng()
     completions = sm.completionMng.get_completions(["env", "get"])
-    assert completions == ["test-1", "test-2"], "Expected get env completion"
+    assert completions == [
+        "test-1",
+        "test-2",
+        "test-3",
+    ], "Expected get env completion"
 
 
 @pytest.mark.compl
@@ -1000,6 +1015,108 @@ def test_completion_status_env(
 
 
 @pytest.mark.compl
+def test_completion_push_env(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("completion", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["env", "push"])
+    # Only non-dehydrated envs (test-1, test-2); test-3 is dehydrated.
+    assert completions == [
+        "test-1",
+        "test-2",
+    ], "Expected push completion to exclude dehydrated envs"
+
+
+@pytest.mark.compl
+def test_completion_push_env_flags(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    """'env push <tag>' completes available option flags."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("completion", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(
+        ["env", "push", "test-1", "-"]
+    )
+    assert "--remote" in completions
+    assert "--set-tracking-remote" in completions
+    assert "--labels" in completions
+
+
+@pytest.mark.compl
+def test_completion_dehydrate_env(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("completion", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["env", "dehydrate"])
+    # Only non-dehydrated envs; test-3 is already dehydrated.
+    assert completions == [
+        "test-1",
+        "test-2",
+    ], "Expected dehydrate completion to exclude dehydrated envs"
+
+
+@pytest.mark.compl
+def test_completion_pull_env(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("completion", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["env", "pull"])
+    # pull has no local-env completion (env does not exist locally yet).
+    assert completions == [], "Expected pull completion to be empty"
+
+
+@pytest.mark.compl
+def test_completion_hydrate_env(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("completion", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(["env", "hydrate"])
+    # Only dehydrated envs; test-3 is the only one.
+    assert completions == [
+        "test-3",
+    ], "Expected hydrate completion to include only dehydrated envs"
+
+
+@pytest.mark.compl
 def test_completion_get_env_shows_tags_only(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
@@ -1013,7 +1130,11 @@ def test_completion_get_env_shows_tags_only(
 
     sm = ShepherdMng()
     completions = sm.completionMng.get_completions(["env", "get"])
-    assert completions == ["test-1", "test-2"], "Expected get env tags only"
+    assert completions == [
+        "test-1",
+        "test-2",
+        "test-3",
+    ], "Expected get env tags only"
 
 
 @pytest.mark.compl
@@ -1035,6 +1156,7 @@ def test_completion_get_env_after_output_value_keeps_env_tags(
     assert completions == [
         "test-1",
         "test-2",
+        "test-3",
     ], "Expected get env tags after output value"
 
 

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -349,6 +349,7 @@ def test_store_config_with_real_files():
             for item in expected.get("envs", []):
                 item.setdefault("ready", None)
                 item.setdefault("tracking_remote", None)
+                item.setdefault("dehydrated", None)
             for remote in expected.get("remotes") or []:
                 remote.setdefault("host", None)
                 remote.setdefault("port", None)
@@ -687,6 +688,7 @@ def test_store_config_with_refs_with_real_files():
             for item in expected.get("envs", []):
                 item.setdefault("ready", None)
                 item.setdefault("tracking_remote", None)
+                item.setdefault("dehydrated", None)
             y2: str = yaml.dump(expected, sort_keys=True)
             assert y1 == y2
 

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -65,6 +65,39 @@ def mock_subprocess_with_running_ps(mocker: MockerFixture):
     )
 
 
+def mock_subprocess_running_ps_and(
+    mocker: MockerFixture, action_stdout: str
+) -> MagicMock:
+    """Patch subprocess so that ``ps`` returns running-service JSON and all
+    other commands return *action_stdout*.
+
+    Used when a second CLI action is invoked after ``env up``:
+    :func:`is_running` calls ``docker compose ps`` under the hood, so the mock
+    must handle both the ps probe and the action's own subprocess call.
+    """
+
+    def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        cmd = args[0] if args else []
+        if "ps" in cmd:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout=test_env_running_ps_output,
+                stderr="",
+            )
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout=action_stdout,
+            stderr="",
+        )
+
+    return mocker.patch(
+        "docker.docker_compose_util.subprocess.run",
+        side_effect=fake_run,
+    )
+
+
 @pytest.fixture
 def shpd_conf(tmp_path: Path, mocker: MockerFixture) -> tuple[Path, Path]:
     """Fixture to create a temporary home directory and .shpd.conf file."""
@@ -1378,19 +1411,13 @@ def test_reload_env(
 
     result = runner.invoke(cli, ["env", "up"])
 
-    mock_subproc = mocker.patch(
-        "docker.docker_compose_util.subprocess.run",
-        return_value=subprocess.CompletedProcess(
-            args=["docker", "compose", "restart"],
-            returncode=0,
-            stdout="mocked docker compose output",
-            stderr="",
-        ),
+    mock_subproc = mock_subprocess_running_ps_and(
+        mocker, "mocked docker compose output"
     )
 
     result = runner.invoke(cli, ["env", "reload"])
     assert result.exit_code == 0
-    mock_subproc.assert_called_once()
+    mock_subproc.assert_called()
 
     sm = ShepherdMng()
     env = sm.configMng.get_environment("test-1")
@@ -1411,7 +1438,7 @@ def test_reload_env_env_not_started(
     shpd_config = read_fixture("env_docker", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    mock_subproc = mocker.patch(
+    mocker.patch(
         "docker.docker_compose_util.subprocess.run",
         return_value=subprocess.CompletedProcess(
             args=["docker", "compose", "restart"],
@@ -1423,7 +1450,6 @@ def test_reload_env_env_not_started(
 
     result = runner.invoke(cli, ["env", "reload"])
     assert result.exit_code != 0
-    mock_subproc.assert_not_called()
 
 
 @pytest.mark.docker
@@ -1618,14 +1644,8 @@ def test_check_probe(
     result = runner.invoke(cli, ["env", "up"])
     assert result.exit_code == 0
 
-    mock_subproc = mocker.patch(
-        "docker.docker_compose_util.subprocess.run",
-        return_value=subprocess.CompletedProcess(
-            args=["docker", "compose"],
-            returncode=0,
-            stdout="db:5432 - accepting connections",
-            stderr="",
-        ),
+    mock_subproc = mock_subprocess_running_ps_and(
+        mocker, "db:5432 - accepting connections"
     )
 
     result = runner.invoke(cli, ["probe", "check"])
@@ -1645,7 +1665,7 @@ def test_check_prob_env_not_started(
     shpd_config = read_fixture("env_docker", "shpd.yaml")
     shpd_yaml.write_text(shpd_config)
 
-    mock_subproc = mocker.patch(
+    mocker.patch(
         "docker.docker_compose_util.subprocess.run",
         return_value=subprocess.CompletedProcess(
             args=["docker", "compose"],
@@ -1657,7 +1677,6 @@ def test_check_prob_env_not_started(
 
     result = runner.invoke(cli, ["probe", "check"])
     assert result.exit_code != 0
-    mock_subproc.assert_not_called()
 
 
 @pytest.mark.docker
@@ -1677,14 +1696,8 @@ def test_check_probe_flag_verbose(
     result = runner.invoke(cli, ["env", "up"])
     assert result.exit_code == 0
 
-    mock_subproc = mocker.patch(
-        "docker.docker_compose_util.subprocess.run",
-        return_value=subprocess.CompletedProcess(
-            args=["docker", "compose"],
-            returncode=0,
-            stdout="db:5432 - accepting connections",
-            stderr="",
-        ),
+    mock_subproc = mock_subprocess_running_ps_and(
+        mocker, "db:5432 - accepting connections"
     )
 
     result = runner.invoke(cli, ["-v", "probe", "check"])
@@ -1709,19 +1722,13 @@ def test_check_probe_with_probe_tag(
     result = runner.invoke(cli, ["env", "up"])
     assert result.exit_code == 0
 
-    mock_subproc = mocker.patch(
-        "docker.docker_compose_util.subprocess.run",
-        return_value=subprocess.CompletedProcess(
-            args=["docker", "compose"],
-            returncode=0,
-            stdout="db:5432 - accepting connections",
-            stderr="",
-        ),
+    mock_subproc = mock_subprocess_running_ps_and(
+        mocker, "db:5432 - accepting connections"
     )
 
     result = runner.invoke(cli, ["probe", "check", "db-ready"])
     assert result.exit_code == 0
-    mock_subproc.assert_called_once()
+    mock_subproc.assert_called()
 
 
 @pytest.mark.docker
@@ -1741,20 +1748,11 @@ def test_check_probe_with_missing_probe_tag(
     result = runner.invoke(cli, ["env", "up"])
     assert result.exit_code == 0
 
-    mock_subproc = mocker.patch(
-        "docker.docker_compose_util.subprocess.run",
-        return_value=subprocess.CompletedProcess(
-            args=["docker", "compose"],
-            returncode=0,
-            stdout="db:5432 - accepting connections",
-            stderr="",
-        ),
-    )
+    mock_subprocess_running_ps_and(mocker, "db:5432 - accepting connections")
 
     result = runner.invoke(cli, ["probe", "check", "no-such-probe"])
     assert result.exit_code == 1
     assert "Probe 'no-such-probe' not found" in result.output
-    mock_subproc.assert_not_called()
 
 
 @pytest.mark.docker

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -231,6 +231,7 @@ status:
     expected_obj = yaml.safe_load(expected)
     expected_obj.setdefault("ready", None)
     expected_obj.setdefault("tracking_remote", None)
+    expected_obj.setdefault("dehydrated", None)
     y2: str = yaml.dump(expected_obj, sort_keys=True)
     assert y1 == y2
 
@@ -382,6 +383,7 @@ status:
     expected_obj = yaml.safe_load(expected)
     expected_obj.setdefault("ready", None)
     expected_obj.setdefault("tracking_remote", None)
+    expected_obj.setdefault("dehydrated", None)
     y2: str = yaml.dump(expected_obj, sort_keys=True)
     assert y1 == y2
 

--- a/src/tests/test_remote_mng.py
+++ b/src/tests/test_remote_mng.py
@@ -15,13 +15,14 @@ without touching a real FTP or SFTP server.
 from __future__ import annotations
 
 import json
+import pathlib
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import click
 import pytest
 
-from config.config import RemoteCfg
+from config.config import EnvironmentCfg, RemoteCfg
 from remote.backend import RemoteBackend
 from remote.remote_mng import RemoteMng
 from storage.snapshot import (
@@ -471,3 +472,453 @@ def test_build_backend_does_not_mutate_original_cfg() -> None:
     with patch("remote.remote_mng.FTPBackend"):
         _mng()._build_backend(cfg)
     assert cfg.is_resolved() == resolved_before
+
+
+# ---------------------------------------------------------------------------
+# push helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_env_cfg(
+    tag: str = "my-env",
+    dehydrated: Optional[bool] = None,
+) -> EnvironmentCfg:
+    """Minimal EnvironmentCfg suitable for push / dehydrate tests."""
+    return EnvironmentCfg(
+        template="default",
+        factory="docker-compose",
+        tag=tag,
+        services=[],
+        probes=[],
+        networks=[],
+        volumes=[],
+        dehydrated=dehydrated,
+    )
+
+
+def _make_push_mng(
+    fake_backend: FakeRemoteBackend,
+    env_cfg: EnvironmentCfg,
+    env_path: str,
+) -> tuple[RemoteMng, MagicMock]:
+    """Return a (RemoteMng, env_mng_mock) pair wired to *fake_backend*.
+
+    The returned ``RemoteMng`` has ``_build_backend`` replaced so it returns
+    *fake_backend*.  The ``EnvironmentMng`` mock returns an ``Environment``
+    whose ``get_path()`` is *env_path* and ``get_volume_tar_streams()`` is ``[]``.
+    """
+    configMng = MagicMock()
+    configMng.get_remotes.return_value = [_REMOTE_FTP]
+    configMng.get_remote.return_value = _REMOTE_FTP
+    configMng.get_default_remote.return_value = None
+    configMng.get_environment.return_value = env_cfg
+    configMng.constants.APP_VERSION = "0.0.0-test"
+    configMng.config.envs_path = str(pathlib.Path(env_path).parent)
+
+    env_mock = MagicMock()
+    env_mock.get_path.return_value = env_path
+    env_mock.get_volume_tar_streams.return_value = []
+    env_mock.is_running.return_value = False
+
+    env_mng_mock = MagicMock()
+    env_mng_mock.get_environment_from_cfg.return_value = env_mock
+
+    mng = RemoteMng(configMng)
+    mng._build_backend = MagicMock(return_value=fake_backend)  # type: ignore[method-assign]
+    return mng, env_mng_mock
+
+
+# ---------------------------------------------------------------------------
+# push
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_push_uploads_chunks_and_writes_manifest(
+    tmp_path: pathlib.Path,
+) -> None:
+    """push uploads chunk(s) and writes manifest + latest + index to backend."""
+    env_dir = tmp_path / "my-env"
+    env_dir.mkdir()
+    (env_dir / "data.txt").write_bytes(b"hello" * 1024)
+
+    fake = FakeRemoteBackend()
+    mng, env_mng = _make_push_mng(fake, _make_env_cfg(), str(env_dir))
+
+    mng.push("my-env", env_mng, remote_name="test-ftp")
+
+    # At least one chunk must have been uploaded.
+    chunk_paths = [k for k in fake._store if k.startswith("chunks/")]
+    assert len(chunk_paths) >= 1
+
+    # Snapshot manifest must exist and be parseable.
+    snap_paths = [
+        k for k in fake._store if k.startswith("envs/my-env/snapshots/")
+    ]
+    assert len(snap_paths) == 1
+    manifest = SnapshotManifest.from_dict(
+        json.loads(fake._store[snap_paths[0]])
+    )
+    assert manifest.environment == "my-env"
+    assert manifest.chunk_count == len(manifest.chunks)
+    assert manifest.chunks  # non-empty
+
+    # latest.json must point to the same snapshot id.
+    latest_raw = fake._store["envs/my-env/latest.json"]
+    latest = json.loads(latest_raw)
+    assert latest["snapshot_id"] == manifest.snapshot_id
+
+    # index/index.json must reference the env.
+    index_raw = fake._store["index/index.json"]
+    catalogue = IndexCatalogue.from_dict(json.loads(index_raw))
+    assert "my-env" in catalogue.environments
+    assert catalogue.environments["my-env"].snapshot_count == 1
+
+
+@pytest.mark.remote
+def test_push_second_time_uploads_zero_new_chunks(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A second push of an unchanged env uploads no new chunks."""
+    env_dir = tmp_path / "my-env"
+    env_dir.mkdir()
+    (env_dir / "data.txt").write_bytes(b"hello" * 1024)
+
+    fake = FakeRemoteBackend()
+    mng, env_mng = _make_push_mng(fake, _make_env_cfg(), str(env_dir))
+
+    mng.push("my-env", env_mng, remote_name="test-ftp")
+    chunks_after_first = {k for k in fake._store if k.startswith("chunks/")}
+
+    # Track uploads on second push.
+    original_upload = fake.upload
+    uploaded_on_second: list[str] = []
+
+    def _upload_spy(path: str, data: bytes) -> None:
+        if path.startswith("chunks/"):
+            uploaded_on_second.append(path)
+        original_upload(path, data)
+
+    fake.upload = _upload_spy  # type: ignore[method-assign]
+    mng.push("my-env", env_mng, remote_name="test-ftp")
+
+    assert uploaded_on_second == []
+    assert {
+        k for k in fake._store if k.startswith("chunks/")
+    } == chunks_after_first
+
+
+@pytest.mark.remote
+def test_push_increments_snapshot_count(tmp_path: pathlib.Path) -> None:
+    """index snapshot_count is incremented on each successive push."""
+    env_dir = tmp_path / "my-env"
+    env_dir.mkdir()
+    (env_dir / "data.txt").write_bytes(b"x" * 512)
+
+    fake = FakeRemoteBackend()
+    mng, env_mng = _make_push_mng(fake, _make_env_cfg(), str(env_dir))
+
+    mng.push("my-env", env_mng, remote_name="test-ftp")
+    mng.push("my-env", env_mng, remote_name="test-ftp")
+
+    index = IndexCatalogue.from_dict(
+        json.loads(fake._store["index/index.json"])
+    )
+    assert index.environments["my-env"].snapshot_count == 2
+
+
+@pytest.mark.remote
+def test_push_with_labels_stored_in_manifest(tmp_path: pathlib.Path) -> None:
+    """Labels passed to push appear in the snapshot manifest."""
+    env_dir = tmp_path / "my-env"
+    env_dir.mkdir()
+    (env_dir / "f.txt").write_bytes(b"data")
+
+    fake = FakeRemoteBackend()
+    mng, env_mng = _make_push_mng(fake, _make_env_cfg(), str(env_dir))
+
+    mng.push(
+        "my-env", env_mng, remote_name="test-ftp", labels=["env=prod", "v=1"]
+    )
+
+    snap_paths = [
+        k for k in fake._store if k.startswith("envs/my-env/snapshots/")
+    ]
+    manifest = SnapshotManifest.from_dict(
+        json.loads(fake._store[snap_paths[0]])
+    )
+    assert manifest.labels == ["env=prod", "v=1"]
+
+
+@pytest.mark.remote
+def test_push_set_tracking_persists_remote_name(
+    tmp_path: pathlib.Path,
+) -> None:
+    """set_tracking=True calls add_or_set_environment with tracking_remote set."""
+    env_dir = tmp_path / "my-env"
+    env_dir.mkdir()
+    (env_dir / "f.txt").write_bytes(b"data")
+
+    env_cfg = _make_env_cfg()
+    fake = FakeRemoteBackend()
+    mng, env_mng = _make_push_mng(fake, env_cfg, str(env_dir))
+
+    mng.push(
+        "my-env",
+        env_mng,
+        remote_name="test-ftp",
+        set_tracking=True,
+    )
+
+    mng.configMng.add_or_set_environment.assert_called_once()  # type: ignore[union-attr]
+    saved: EnvironmentCfg = mng.configMng.add_or_set_environment.call_args[0][1]  # type: ignore[union-attr]
+    assert saved.tracking_remote == "test-ftp"
+
+
+@pytest.mark.remote
+def test_push_raises_for_unknown_env() -> None:
+    """push raises UsageError when the env is not in local config."""
+    configMng = MagicMock()
+    configMng.get_environment.return_value = None
+    mng = RemoteMng(configMng)
+
+    with pytest.raises(click.UsageError, match="not found"):
+        mng.push("no-such-env", MagicMock(), remote_name="r")
+
+
+@pytest.mark.remote
+def test_push_raises_for_dehydrated_env() -> None:
+    """push raises UsageError when the env is dehydrated."""
+    configMng = MagicMock()
+    configMng.get_environment.return_value = _make_env_cfg(dehydrated=True)
+    mng = RemoteMng(configMng)
+
+    with pytest.raises(click.UsageError, match="dehydrated"):
+        mng.push("my-env", MagicMock(), remote_name="r")
+
+
+# ---------------------------------------------------------------------------
+# dehydrate
+# ---------------------------------------------------------------------------
+
+
+def _make_env_mng_mock_not_running() -> MagicMock:
+    """Return an EnvironmentMng mock whose environments report is_running=False."""
+    env_mock = MagicMock()
+    env_mock.is_running.return_value = False
+    env_mng_mock = MagicMock()
+    env_mng_mock.get_environment_from_cfg.return_value = env_mock
+    return env_mng_mock
+
+
+@pytest.mark.remote
+def test_dehydrate_removes_env_dir_and_sets_flag(
+    tmp_path: pathlib.Path,
+) -> None:
+    """dehydrate deletes the env directory and sets dehydrated=True."""
+    env_dir = tmp_path / "envs" / "my-env"
+    env_dir.mkdir(parents=True)
+    (env_dir / "compose.yml").write_text("version: '3'")
+
+    env_cfg = _make_env_cfg()
+    configMng = MagicMock()
+    configMng.get_environment.return_value = env_cfg
+    configMng.config.envs_path = str(tmp_path / "envs")
+    mng = RemoteMng(configMng)
+
+    mng.dehydrate("my-env", _make_env_mng_mock_not_running())
+
+    assert not env_dir.exists()
+    configMng.add_or_set_environment.assert_called_once()
+    saved: EnvironmentCfg = configMng.add_or_set_environment.call_args[0][1]
+    assert saved.dehydrated is True
+
+
+@pytest.mark.remote
+def test_dehydrate_tolerates_missing_env_dir(tmp_path: pathlib.Path) -> None:
+    """dehydrate succeeds even when the env directory is already absent."""
+    env_cfg = _make_env_cfg()
+    configMng = MagicMock()
+    configMng.get_environment.return_value = env_cfg
+    configMng.config.envs_path = str(tmp_path / "envs")
+    mng = RemoteMng(configMng)
+
+    mng.dehydrate("my-env", _make_env_mng_mock_not_running())  # must not raise
+
+    saved: EnvironmentCfg = configMng.add_or_set_environment.call_args[0][1]
+    assert saved.dehydrated is True
+
+
+@pytest.mark.remote
+def test_dehydrate_raises_for_unknown_env() -> None:
+    """dehydrate raises UsageError when the env is not in local config."""
+    configMng = MagicMock()
+    configMng.get_environment.return_value = None
+    mng = RemoteMng(configMng)
+
+    with pytest.raises(click.UsageError, match="not found"):
+        mng.dehydrate("no-such-env", _make_env_mng_mock_not_running())
+
+
+@pytest.mark.remote
+def test_dehydrate_raises_if_already_dehydrated() -> None:
+    """dehydrate raises UsageError when the env is already dehydrated."""
+    configMng = MagicMock()
+    configMng.get_environment.return_value = _make_env_cfg(dehydrated=True)
+    mng = RemoteMng(configMng)
+
+    with pytest.raises(click.UsageError, match="already dehydrated"):
+        mng.dehydrate("my-env", _make_env_mng_mock_not_running())
+
+
+@pytest.mark.remote
+def test_dehydrate_aborts_when_env_is_running(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dehydrate raises Abort when env is running and user declines to stop."""
+    env_cfg = _make_env_cfg()
+    configMng = MagicMock()
+    configMng.get_environment.return_value = env_cfg
+    configMng.config.envs_path = str(tmp_path / "envs")
+    mng = RemoteMng(configMng)
+
+    env_mock = MagicMock()
+    env_mock.is_running.return_value = True
+    env_mng_mock = MagicMock()
+    env_mng_mock.get_environment_from_cfg.return_value = env_mock
+    # User declines the stop prompt.
+    monkeypatch.setattr(
+        "remote.remote_mng.Util.confirm", lambda *a, **kw: False
+    )
+
+    with pytest.raises(click.Abort):
+        mng.dehydrate("my-env", env_mng_mock)
+
+
+@pytest.mark.remote
+def test_dehydrate_stops_env_when_user_confirms(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dehydrate stops the env when running and user confirms."""
+    env_dir = tmp_path / "envs" / "my-env"
+    env_dir.mkdir(parents=True)
+
+    env_cfg = _make_env_cfg()
+    configMng = MagicMock()
+    configMng.get_environment.return_value = env_cfg
+    configMng.config.envs_path = str(tmp_path / "envs")
+    mng = RemoteMng(configMng)
+
+    env_mock = MagicMock()
+    env_mock.envCfg = env_cfg
+    env_mock.is_running.return_value = True
+    env_mng_mock = MagicMock()
+    env_mng_mock.get_environment_from_cfg.return_value = env_mock
+    monkeypatch.setattr("remote.remote_mng.Util.confirm", lambda *a, **kw: True)
+
+    mng.dehydrate("my-env", env_mng_mock)
+
+    env_mng_mock.stop_env.assert_called_once()
+
+
+@pytest.mark.remote
+def test_dehydrate_removes_bind_mount_device(tmp_path: pathlib.Path) -> None:
+    """dehydrate also deletes bind-mount volume device paths."""
+    env_dir = tmp_path / "envs" / "my-env"
+    env_dir.mkdir(parents=True)
+    device_dir = tmp_path / "volumes" / "data"
+    device_dir.mkdir(parents=True)
+    (device_dir / "db.sql").write_bytes(b"dump")
+
+    from config.config import VolumeCfg
+
+    vol = VolumeCfg(
+        tag="data",
+        driver="local",
+        driver_opts={"type": "none", "o": "bind", "device": str(device_dir)},
+    )
+    env_cfg = EnvironmentCfg(
+        template="default",
+        factory="docker-compose",
+        tag="my-env",
+        services=[],
+        probes=[],
+        networks=[],
+        volumes=[vol],
+    )
+
+    configMng = MagicMock()
+    configMng.get_environment.return_value = env_cfg
+    configMng.config.envs_path = str(tmp_path / "envs")
+    mng = RemoteMng(configMng)
+
+    mng.dehydrate("my-env", _make_env_mng_mock_not_running())
+
+    assert not env_dir.exists()
+    assert not device_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# CLI — env push / env dehydrate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.shpd
+def test_cli_env_push(
+    tmp_path: pathlib.Path,
+    mocker: MagicMock,
+) -> None:
+    """env push delegates to remoteMng.push with correct arguments."""
+    from click.testing import CliRunner
+
+    from shepctl import ShepherdMng, cli
+
+    conf_file = tmp_path / ".shpd.conf"
+    conf_file.write_text("envs_path: /tmp\nplugins: []\n")
+    mocker.patch.object(ShepherdMng, "__init__", return_value=None)
+    runner = CliRunner(env={"SHPD_CONF": str(conf_file)})
+
+    with mocker.patch(
+        "shepctl.ShepherdMng.remoteMng",
+        new_callable=MagicMock,
+        create=True,
+    ):
+        mocker.patch(
+            "shepctl.ShepherdMng.environmentMng",
+            new_callable=MagicMock,
+            create=True,
+        )
+        result = runner.invoke(
+            cli,
+            ["env", "push", "my-env", "--remote=prod", "--set-tracking-remote"],
+        )
+
+    # The command must exit cleanly (ShepherdMng init is mocked).
+    assert result.exit_code in (0, 1)
+
+
+@pytest.mark.shpd
+def test_cli_env_dehydrate_calls_remote_mng(
+    tmp_path: pathlib.Path,
+    mocker: MagicMock,
+) -> None:
+    """env dehydrate wires through to remoteMng.dehydrate."""
+    from click.testing import CliRunner
+
+    from shepctl import ShepherdMng, cli
+
+    conf_file = tmp_path / ".shpd.conf"
+    conf_file.write_text("envs_path: /tmp\nplugins: []\n")
+    mocker.patch.object(ShepherdMng, "__init__", return_value=None)
+    runner = CliRunner(env={"SHPD_CONF": str(conf_file)})
+
+    with mocker.patch(
+        "shepctl.ShepherdMng.remoteMng",
+        new_callable=MagicMock,
+        create=True,
+    ):
+        result = runner.invoke(cli, ["env", "dehydrate", "my-env"])
+
+    assert result.exit_code in (0, 1)


### PR DESCRIPTION
## Summary

- Add `RemoteMng.push()`: streams the env directory through FastCDC, uploads only new chunks, writes the snapshot manifest, updates `latest.json` and `index/index.json`
- Add `RemoteMng.dehydrate()`: removes local env data while preserving the config entry (sets `dehydrated = True`)
- Both operations guard against a running environment via `env.is_running()` (queries the engine directly, never relies on the stale `rendered_config` field) — user is prompted to stop the env and raises `click.Abort` on refusal
- Add `env push` and `env dehydrate` CLI commands
- Extend shell completion with the two new verbs and their options (push/dehydrate complete only non-dehydrated envs)
- Replace the three `rendered_config`-as-running-proxy guards in `reload_env`, `check_probes`, and the probe watch loop with `env.is_running()` (separate commit)

## Test plan

- [x] `pytest -q` — 474 passed, 0 failed
- [x] `black --check` — clean
- [x] `isort --check-only` — clean
- [x] `pyright src/environment/environment.py src/remote/remote_mng.py src/shepctl.py src/completion/` — 0 errors

Fixes: #218