### PR TITLE
feat(remote): implement pull and hydrate operations

### DIFF
--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -134,6 +134,14 @@ class CompletionMng(AbstractCompletionMng):
             OptionSpec(tokens=("--set-tracking-remote",)),
             OptionSpec(tokens=("--labels",), takes_value=True),
         ),
+        ("env", "pull"): (
+            OptionSpec(tokens=("--remote",), takes_value=True),
+            OptionSpec(tokens=("--snapshot-id",), takes_value=True),
+        ),
+        ("env", "hydrate"): (
+            OptionSpec(tokens=("--remote",), takes_value=True),
+            OptionSpec(tokens=("--snapshot-id",), takes_value=True),
+        ),
         ("plugin", "install"): (OptionSpec(tokens=("--force",)),),
         ("remote", "add"): (
             OptionSpec(tokens=("--ftp",)),

--- a/src/remote/remote_mng.py
+++ b/src/remote/remote_mng.py
@@ -11,18 +11,22 @@ prune, and remote/env listing."""
 from __future__ import annotations
 
 import datetime
+import io
 import json
 import os
 import shutil
 import subprocess
+import tarfile
 from copy import deepcopy
 from typing import TYPE_CHECKING, Optional
 
 import click
+import zstandard
 
 from config import ConfigMng
-from config.config import RemoteCfg
+from config.config import EnvironmentCfg, RemoteCfg
 from storage.chunker import Chunker
+from storage.local_cache import LocalChunkCache, NullLocalChunkCache
 from storage.snapshot import (
     IndexCatalogue,
     IndexCatalogueEntry,
@@ -414,6 +418,198 @@ class RemoteMng:
         env_cfg.dehydrated = True
         self.configMng.add_or_set_environment(env_name, env_cfg)
         Util.print(f"Dehydrated '{env_name}': local data removed.")
+
+    # ------------------------------------------------------------------
+    # Pull / hydrate
+    # ------------------------------------------------------------------
+
+    def _build_cache(
+        self, cfg: RemoteCfg
+    ) -> LocalChunkCache | NullLocalChunkCache:
+        """Return the configured local chunk cache, or a no-op cache."""
+        if cfg.local_cache and cfg.local_cache.path:
+            return LocalChunkCache(
+                cache_path=cfg.local_cache.path,
+                max_bytes=cfg.local_cache.max_size_gb * (1 << 30),
+            )
+        return NullLocalChunkCache()
+
+    def _resolve_manifest(
+        self,
+        backend: RemoteBackend,
+        env_name: str,
+        snapshot_id: Optional[str],
+    ) -> SnapshotManifest:
+        """Download and return the snapshot manifest for *env_name*.
+
+        If *snapshot_id* is ``None``, the manifest is resolved via
+        ``latest.json``.
+
+        :raises click.UsageError: If ``latest.json`` or the manifest file is
+            absent on the remote.
+        """
+        if snapshot_id is None:
+            latest_path = RemoteBackend.latest_path(env_name)
+            if not backend.exists(latest_path):
+                raise click.UsageError(
+                    f"No snapshots found for '{env_name}' on the remote."
+                )
+            pointer = LatestPointer.from_dict(
+                json.loads(backend.download(latest_path))
+            )
+            snapshot_id = pointer.snapshot_id
+
+        manifest_path = RemoteBackend.snapshot_path(env_name, snapshot_id)
+        if not backend.exists(manifest_path):
+            raise click.UsageError(
+                f"Snapshot '{snapshot_id}' not found for '{env_name}'."
+            )
+        return SnapshotManifest.from_dict(
+            json.loads(backend.download(manifest_path))
+        )
+
+    def _restore_chunks(
+        self,
+        backend: RemoteBackend,
+        manifest: SnapshotManifest,
+        dest_dir: str,
+        cache: LocalChunkCache | NullLocalChunkCache,
+    ) -> tuple[int, int]:
+        """Download, decompress, and untar all chunks into *dest_dir*.
+
+        :returns: A ``(downloaded, from_cache)`` tuple counting chunks.
+        """
+        dctx = zstandard.ZstdDecompressor()
+        downloaded = 0
+        from_cache = 0
+
+        # Concatenate all decompressed chunks into one in-memory buffer,
+        # then extract as a streaming tar archive.
+        buf = io.BytesIO()
+        for chunk_hash in manifest.chunks:
+            cached = cache.get(chunk_hash)
+            if cached is not None:
+                compressed = cached
+                from_cache += 1
+            else:
+                compressed = backend.download(
+                    RemoteBackend.chunk_path(chunk_hash)
+                )
+                cache.put(chunk_hash, compressed)
+                downloaded += 1
+            buf.write(dctx.decompress(compressed))
+
+        buf.seek(0)
+        os.makedirs(dest_dir, exist_ok=True)
+        with tarfile.open(fileobj=buf, mode="r:") as tf:
+            tf.extractall(path=dest_dir, filter="data")
+
+        return downloaded, from_cache
+
+    def pull(
+        self,
+        env_name: str,
+        remote_name: Optional[str] = None,
+        snapshot_id: Optional[str] = None,
+    ) -> None:
+        """Create a local environment entry from a remote snapshot.
+
+        Downloads all chunks for *env_name* (or the specific *snapshot_id*),
+        reconstructs the tar stream, and untars into the local envs directory.
+        A new :class:`~config.config.EnvironmentCfg` entry is created in the
+        local config with ``tracking_remote`` set and ``dehydrated = False``.
+
+        :param env_name: Tag of the environment to restore.
+        :param remote_name: Remote to pull from, or ``None`` for the default.
+        :param snapshot_id: Specific snapshot to restore, or ``None`` for the
+            latest.
+        :raises click.UsageError: If the env is already registered locally.
+        """
+        if self.configMng.get_environment(env_name) is not None:
+            raise click.UsageError(
+                f"Environment '{env_name}' is already registered locally. "
+                "Use 'env hydrate' to restore its data."
+            )
+
+        remote_cfg = self._resolve_remote(remote_name)
+        cache = self._build_cache(remote_cfg)
+        dest_dir = os.path.join(self.configMng.config.envs_path, env_name)
+
+        with self._build_backend(remote_cfg) as backend:
+            manifest = self._resolve_manifest(backend, env_name, snapshot_id)
+            downloaded, from_cache = self._restore_chunks(
+                backend, manifest, dest_dir, cache
+            )
+
+        env_cfg = EnvironmentCfg(
+            tag=env_name,
+            template="",
+            factory="",
+            services=None,
+            probes=None,
+            networks=None,
+            volumes=None,
+            tracking_remote=remote_cfg.name,
+            dehydrated=False,
+        )
+        self.configMng.add_or_set_environment(env_name, env_cfg)
+
+        Util.print(
+            f"Pulled '{env_name}' ← '{remote_cfg.name}' "
+            f"[{manifest.snapshot_id}]: "
+            f"{downloaded} chunk(s) downloaded, "
+            f"{from_cache} from cache, "
+            f"{Util.fmt_bytes(manifest.stored_size_bytes)} stored."
+        )
+
+    def hydrate(
+        self,
+        env_name: str,
+        remote_name: Optional[str] = None,
+        snapshot_id: Optional[str] = None,
+    ) -> None:
+        """Restore local data for a dehydrated environment.
+
+        Same chunk-download and untar logic as :meth:`pull`, but the env must
+        already exist in config with ``dehydrated = True``.  After restoration,
+        ``dehydrated`` is cleared to ``False`` and the config is persisted.
+
+        :param env_name: Tag of the dehydrated environment to restore.
+        :param remote_name: Remote to pull from, or ``None`` for the default.
+        :param snapshot_id: Specific snapshot to restore, or ``None`` for the
+            latest.
+        :raises click.UsageError: If the env is unknown or not dehydrated.
+        """
+        env_cfg = self.configMng.get_environment(env_name)
+        if env_cfg is None:
+            raise click.UsageError(
+                f"Environment '{env_name}' not found in local config."
+            )
+        if not env_cfg.dehydrated:
+            raise click.UsageError(
+                f"Environment '{env_name}' is not dehydrated."
+            )
+
+        remote_cfg = self._resolve_remote(remote_name)
+        cache = self._build_cache(remote_cfg)
+        dest_dir = os.path.join(self.configMng.config.envs_path, env_name)
+
+        with self._build_backend(remote_cfg) as backend:
+            manifest = self._resolve_manifest(backend, env_name, snapshot_id)
+            downloaded, from_cache = self._restore_chunks(
+                backend, manifest, dest_dir, cache
+            )
+
+        env_cfg.dehydrated = False
+        self.configMng.add_or_set_environment(env_name, env_cfg)
+
+        Util.print(
+            f"Hydrated '{env_name}' ← '{remote_cfg.name}' "
+            f"[{manifest.snapshot_id}]: "
+            f"{downloaded} chunk(s) downloaded, "
+            f"{from_cache} from cache, "
+            f"{Util.fmt_bytes(manifest.stored_size_bytes)} stored."
+        )
 
     def _delete_dir(self, path: str) -> None:
         """Delete *path* recursively; retry under sudo on PermissionError."""

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -594,6 +594,62 @@ def dehydrate_env(shepherd: ShepherdMng, env_tag: str) -> None:
     shepherd.remoteMng.dehydrate(env_tag, shepherd.environmentMng)
 
 
+@env.command(name="pull")
+@click.argument("env_tag")
+@click.option(
+    "--remote",
+    "remote_name",
+    default=None,
+    help="Remote to pull from (defaults to the configured default).",
+)
+@click.option(
+    "--snapshot-id",
+    default=None,
+    help="Snapshot ID to restore (defaults to the latest).",
+)
+@click.pass_obj
+def pull_env(
+    shepherd: ShepherdMng,
+    env_tag: str,
+    remote_name: Optional[str],
+    snapshot_id: Optional[str],
+) -> None:
+    """Download ENV_TAG from a remote snapshot and register it locally."""
+    shepherd.remoteMng.pull(
+        env_name=env_tag,
+        remote_name=remote_name,
+        snapshot_id=snapshot_id,
+    )
+
+
+@env.command(name="hydrate")
+@click.argument("env_tag")
+@click.option(
+    "--remote",
+    "remote_name",
+    default=None,
+    help="Remote to pull from (defaults to the configured default).",
+)
+@click.option(
+    "--snapshot-id",
+    default=None,
+    help="Snapshot ID to restore (defaults to the latest).",
+)
+@click.pass_obj
+def hydrate_env(
+    shepherd: ShepherdMng,
+    env_tag: str,
+    remote_name: Optional[str],
+    snapshot_id: Optional[str],
+) -> None:
+    """Restore local data for the dehydrated ENV_TAG from a remote snapshot."""
+    shepherd.remoteMng.hydrate(
+        env_name=env_tag,
+        remote_name=remote_name,
+        snapshot_id=snapshot_id,
+    )
+
+
 # =====================================================
 # SVC
 # =====================================================

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -1058,6 +1058,48 @@ def test_completion_push_env_flags(
 
 
 @pytest.mark.compl
+def test_completion_pull_env_flags(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    """'env pull <tag>' completes available option flags."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("completion", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(
+        ["env", "pull", "test-1", "-"]
+    )
+    assert "--remote" in completions
+    assert "--snapshot-id" in completions
+
+
+@pytest.mark.compl
+def test_completion_hydrate_env_flags(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    """'env hydrate <tag>' completes available option flags."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("completion", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    sm = ShepherdMng()
+    completions = sm.completionMng.get_completions(
+        ["env", "hydrate", "test-3", "-"]
+    )
+    assert "--remote" in completions
+    assert "--snapshot-id" in completions
+
+
+@pytest.mark.compl
 def test_completion_dehydrate_env(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,
@@ -1092,8 +1134,11 @@ def test_completion_pull_env(
 
     sm = ShepherdMng()
     completions = sm.completionMng.get_completions(["env", "pull"])
-    # pull has no local-env completion (env does not exist locally yet).
-    assert completions == [], "Expected pull completion to be empty"
+    # pull has no local-env completion (env does not exist locally yet),
+    # only option flags are suggested as fallback.
+    assert "test-1" not in completions
+    assert "test-2" not in completions
+    assert "test-3" not in completions
 
 
 @pytest.mark.compl

--- a/src/tests/test_remote_mng.py
+++ b/src/tests/test_remote_mng.py
@@ -922,3 +922,327 @@ def test_cli_env_dehydrate_calls_remote_mng(
         result = runner.invoke(cli, ["env", "dehydrate", "my-env"])
 
     assert result.exit_code in (0, 1)
+
+
+# ---------------------------------------------------------------------------
+# pull helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pull_mng(
+    fake_backend: FakeRemoteBackend,
+    envs_path: str,
+    existing_env_cfg: Optional[EnvironmentCfg] = None,
+) -> RemoteMng:
+    """Return a RemoteMng wired to *fake_backend* for pull/hydrate tests."""
+    configMng = MagicMock()
+    configMng.get_remotes.return_value = [_REMOTE_FTP]
+    configMng.get_remote.return_value = _REMOTE_FTP
+    configMng.get_default_remote.return_value = None
+    configMng.get_environment.return_value = existing_env_cfg
+    configMng.constants.APP_VERSION = "0.0.0-test"
+    configMng.config.envs_path = envs_path
+
+    mng = RemoteMng(configMng)
+    mng._build_backend = MagicMock(return_value=fake_backend)  # type: ignore[method-assign]
+    mng._build_cache = MagicMock(  # type: ignore[method-assign]
+        return_value=MagicMock(
+            contains=lambda h: False,
+            get=lambda h: None,
+            put=lambda h, d: None,
+        )
+    )
+    return mng
+
+
+def _seed_fake_backend(
+    fake: FakeRemoteBackend,
+    env_name: str,
+    content: bytes,
+) -> SnapshotManifest:
+    """Push *content* to *fake* via a real RemoteMng.push call and return the
+    manifest, so pull / hydrate tests start from a realistic state."""
+    import io
+    import tarfile as _tarfile
+
+    from storage.chunker import Chunker
+    from storage.snapshot import LatestPointer, SnapshotManifest
+
+    # Build a minimal tar stream from *content*.
+    buf = io.BytesIO()
+    with _tarfile.open(fileobj=buf, mode="w:") as tf:
+        info = _tarfile.TarInfo(name="data.bin")
+        info.size = len(content)
+        tf.addfile(info, io.BytesIO(content))
+    tar_bytes = buf.getvalue()
+
+    chunker = Chunker(
+        min_size=64 * 1024,
+        avg_size=256 * 1024,
+        max_size=1024 * 1024,
+    )
+    chunk_hashes: list[str] = []
+    total_raw = 0
+    total_stored = 0
+    import io as _io
+
+    stream = _io.BytesIO(tar_bytes)
+    for chunk in chunker.chunk_stream(stream):
+        path = RemoteBackend.chunk_path(chunk.hash)
+        fake._store[path] = chunk.data
+        chunk_hashes.append(chunk.hash)
+        total_raw += chunk.raw_size
+        total_stored += len(chunk.data)
+
+    import datetime as _dt
+
+    now = (
+        _dt.datetime.now(_dt.timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+    manifest = SnapshotManifest(
+        snapshot_id="",
+        environment=env_name,
+        shepherd_version="0.0.0-test",
+        created_at=now,
+        chunks=chunk_hashes,
+        chunk_count=len(chunk_hashes),
+        total_size_bytes=total_raw,
+        stored_size_bytes=total_stored,
+    )
+    manifest_bytes = json.dumps(manifest.to_dict(), indent=2).encode()
+    snapshot_id = SnapshotManifest.build_id(now, manifest_bytes)
+    manifest.snapshot_id = snapshot_id
+    manifest_bytes = json.dumps(manifest.to_dict(), indent=2).encode()
+
+    fake._store[RemoteBackend.snapshot_path(env_name, snapshot_id)] = (
+        manifest_bytes
+    )
+    pointer = LatestPointer(snapshot_id=snapshot_id, updated_at=now)
+    fake._store[RemoteBackend.latest_path(env_name)] = json.dumps(
+        pointer.to_dict()
+    ).encode()
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# pull
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_pull_creates_env_dir_and_config_entry(
+    tmp_path: pathlib.Path,
+) -> None:
+    """pull restores files and registers the env in config."""
+    content = b"restore me" * 512
+    fake = FakeRemoteBackend()
+    manifest = _seed_fake_backend(fake, "my-env", content)
+
+    envs_path = str(tmp_path / "envs")
+    mng = _make_pull_mng(fake, envs_path)
+
+    mng.pull("my-env", remote_name="test-ftp")
+
+    mng.configMng.add_or_set_environment.assert_called_once()  # type: ignore[union-attr]
+    saved = mng.configMng.add_or_set_environment.call_args[0][1]  # type: ignore[union-attr]
+    assert saved.tracking_remote == "test-ftp"
+    assert saved.dehydrated is False
+
+
+@pytest.mark.remote
+def test_pull_raises_for_already_registered_env(
+    tmp_path: pathlib.Path,
+) -> None:
+    """pull raises UsageError when the env is already registered locally."""
+    fake = FakeRemoteBackend()
+    envs_path = str(tmp_path / "envs")
+    existing = _make_env_cfg()
+    mng = _make_pull_mng(fake, envs_path, existing_env_cfg=existing)
+
+    with pytest.raises(click.UsageError, match="already registered"):
+        mng.pull("my-env", remote_name="test-ftp")
+
+
+@pytest.mark.remote
+def test_pull_with_explicit_snapshot_id(
+    tmp_path: pathlib.Path,
+) -> None:
+    """pull with snapshot_id= downloads the specific manifest."""
+    content = b"explicit snapshot" * 512
+    fake = FakeRemoteBackend()
+    manifest = _seed_fake_backend(fake, "my-env", content)
+
+    envs_path = str(tmp_path / "envs")
+    mng = _make_pull_mng(fake, envs_path)
+
+    # Should not raise even though latest.json is present.
+    mng.pull(
+        "my-env",
+        remote_name="test-ftp",
+        snapshot_id=manifest.snapshot_id,
+    )
+    mng.configMng.add_or_set_environment.assert_called_once()  # type: ignore[union-attr]
+
+
+@pytest.mark.remote
+def test_pull_raises_when_no_snapshots_on_remote(
+    tmp_path: pathlib.Path,
+) -> None:
+    """pull raises UsageError when latest.json does not exist on remote."""
+    fake = FakeRemoteBackend()
+    envs_path = str(tmp_path / "envs")
+    mng = _make_pull_mng(fake, envs_path)
+
+    with pytest.raises(click.UsageError, match="No snapshots found"):
+        mng.pull("my-env", remote_name="test-ftp")
+
+
+# ---------------------------------------------------------------------------
+# hydrate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_hydrate_restores_data_and_clears_flag(
+    tmp_path: pathlib.Path,
+) -> None:
+    """hydrate downloads chunks and sets dehydrated=False."""
+    content = b"hydrate me" * 512
+    fake = FakeRemoteBackend()
+    _seed_fake_backend(fake, "my-env", content)
+
+    envs_path = str(tmp_path / "envs")
+    dehydrated_cfg = _make_env_cfg(dehydrated=True)
+    mng = _make_pull_mng(fake, envs_path, existing_env_cfg=dehydrated_cfg)
+
+    mng.hydrate("my-env", remote_name="test-ftp")
+
+    mng.configMng.add_or_set_environment.assert_called_once()  # type: ignore[union-attr]
+    saved = mng.configMng.add_or_set_environment.call_args[0][1]  # type: ignore[union-attr]
+    assert saved.dehydrated is False
+
+
+@pytest.mark.remote
+def test_hydrate_raises_for_unknown_env(
+    tmp_path: pathlib.Path,
+) -> None:
+    """hydrate raises UsageError when the env is not in config."""
+    fake = FakeRemoteBackend()
+    envs_path = str(tmp_path / "envs")
+    mng = _make_pull_mng(fake, envs_path, existing_env_cfg=None)
+
+    with pytest.raises(click.UsageError, match="not found"):
+        mng.hydrate("my-env", remote_name="test-ftp")
+
+
+@pytest.mark.remote
+def test_hydrate_raises_for_non_dehydrated_env(
+    tmp_path: pathlib.Path,
+) -> None:
+    """hydrate raises UsageError when the env is not marked dehydrated."""
+    fake = FakeRemoteBackend()
+    envs_path = str(tmp_path / "envs")
+    active_cfg = _make_env_cfg(dehydrated=False)
+    mng = _make_pull_mng(fake, envs_path, existing_env_cfg=active_cfg)
+
+    with pytest.raises(click.UsageError, match="not dehydrated"):
+        mng.hydrate("my-env", remote_name="test-ftp")
+
+
+@pytest.mark.remote
+def test_dehydrate_hydrate_roundtrip(
+    tmp_path: pathlib.Path,
+) -> None:
+    """dehydrate → hydrate round-trip restores the env directory."""
+    # 1. Create a real env directory with content.
+    envs_path = tmp_path / "envs"
+    envs_path.mkdir()
+    env_dir = envs_path / "rt-env"
+    env_dir.mkdir()
+    sentinel = env_dir / "sentinel.txt"
+    sentinel.write_bytes(b"round-trip payload" * 200)
+
+    # 2. Push to FakeRemoteBackend.
+    fake = FakeRemoteBackend()
+    env_cfg = _make_env_cfg(tag="rt-env")
+    mng_push, env_mng = _make_push_mng(fake, env_cfg, str(env_dir))
+    # Override envs_path for dehydrate.
+    mng_push.configMng.config.envs_path = str(envs_path)
+    mng_push.push("rt-env", env_mng, remote_name="test-ftp")
+
+    # 3. Dehydrate.
+    mng_push.configMng.get_environment.return_value = env_cfg  # type: ignore[union-attr]
+    mng_push.dehydrate("rt-env", _make_env_mng_mock_not_running())
+    assert not env_dir.exists()
+
+    # 4. Hydrate from the same backend.
+    dehydrated_cfg = _make_env_cfg(tag="rt-env", dehydrated=True)
+    mng_pull = _make_pull_mng(fake, str(envs_path), dehydrated_cfg)
+    mng_pull.hydrate("rt-env", remote_name="test-ftp")
+
+    # The env dir should exist again (untar lands in envs_path/rt-env).
+    restored_dir = envs_path / "rt-env"
+    assert restored_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# CLI — env pull / env hydrate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.shpd
+def test_cli_env_pull(
+    tmp_path: pathlib.Path,
+    mocker: MagicMock,
+) -> None:
+    """env pull delegates to remoteMng.pull."""
+    from click.testing import CliRunner
+
+    from shepctl import ShepherdMng, cli
+
+    conf_file = tmp_path / ".shpd.conf"
+    conf_file.write_text("envs_path: /tmp\nplugins: []\n")
+    mocker.patch.object(ShepherdMng, "__init__", return_value=None)
+    runner = CliRunner(env={"SHPD_CONF": str(conf_file)})
+
+    with mocker.patch(
+        "shepctl.ShepherdMng.remoteMng",
+        new_callable=MagicMock,
+        create=True,
+    ):
+        result = runner.invoke(
+            cli,
+            ["env", "pull", "my-env", "--remote=prod"],
+        )
+
+    assert result.exit_code in (0, 1)
+
+
+@pytest.mark.shpd
+def test_cli_env_hydrate(
+    tmp_path: pathlib.Path,
+    mocker: MagicMock,
+) -> None:
+    """env hydrate delegates to remoteMng.hydrate."""
+    from click.testing import CliRunner
+
+    from shepctl import ShepherdMng, cli
+
+    conf_file = tmp_path / ".shpd.conf"
+    conf_file.write_text("envs_path: /tmp\nplugins: []\n")
+    mocker.patch.object(ShepherdMng, "__init__", return_value=None)
+    runner = CliRunner(env={"SHPD_CONF": str(conf_file)})
+
+    with mocker.patch(
+        "shepctl.ShepherdMng.remoteMng",
+        new_callable=MagicMock,
+        create=True,
+    ):
+        result = runner.invoke(
+            cli,
+            ["env", "hydrate", "my-env"],
+        )
+
+    assert result.exit_code in (0, 1)


### PR DESCRIPTION
## Summary

- Add `RemoteMng.pull()`: downloads chunks from a remote snapshot, decompresses and untars them into the local envs directory, and registers the env in config with `tracking_remote` set and `dehydrated = False`.
- Add `RemoteMng.hydrate()`: same chunk-download/untar logic as pull, but targets an already-registered dehydrated env and clears `dehydrated = False` after restoration.
- Add `_resolve_manifest()` helper: resolves a snapshot manifest by explicit ID or via `latest.json`.
- Add `_restore_chunks()` helper: downloads, decompresses (Zstd), and untars all chunks; honours the optional local LRU chunk cache.
- Add `_build_cache()` helper: wires `LocalChunkCache` or `NullLocalChunkCache` from `RemoteCfg.local_cache`.
- Expose `env pull` and `env hydrate` CLI commands in `shepctl.py`.

## Test plan

- `pytest tests/test_remote_mng.py` — 42 tests pass (10 new pull/hydrate tests including a full dehydrate→hydrate round-trip)
- `pytest -q` — 478 passed, 0 failures
- `black`, `isort`, `flake8`, `pyright` — all clean (55 pre-existing pyright errors unchanged)

Fixes: #219