### PR TITLE
feat(remote): implement prune operation and remote prune CLI

### DIFF
--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -58,7 +58,7 @@ class CompletionMng(AbstractCompletionMng):
         ],
         "svc": ["get", "add", "up", "halt", "reload", "build", "logs", "shell"],
         "probe": ["get", "check"],
-        "remote": ["add", "list", "delete", "envs", "get"],
+        "remote": ["add", "list", "delete", "envs", "get", "prune"],
     }
     SCOPE_VERBS = CORE_SCOPE_VERBS
 
@@ -159,6 +159,10 @@ class CompletionMng(AbstractCompletionMng):
         ),
         ("remote", "get"): (
             OptionSpec(tokens=("--remote",), takes_value=True),
+        ),
+        ("remote", "prune"): (
+            OptionSpec(tokens=("--remote",), takes_value=True),
+            OptionSpec(tokens=("--dry-run",)),
         ),
     }
 

--- a/src/completion/completion_remote.py
+++ b/src/completion/completion_remote.py
@@ -46,6 +46,10 @@ class CompletionRemoteMng(AbstractCompletionMng):
                 return self._complete_remote_option(args[2:])
             case "get":
                 return self._complete_get(args[2:])
+            case "prune":
+                # No positional arguments; --remote and --dry-run are served
+                # by the static CONTEXT_OPTIONS table in CompletionMng.
+                return []
             case _:
                 # "add" and "list" have no dynamic positional completions —
                 # their flags are served entirely by the static CONTEXT_OPTIONS

--- a/src/remote/remote_mng.py
+++ b/src/remote/remote_mng.py
@@ -611,6 +611,70 @@ class RemoteMng:
             f"{Util.fmt_bytes(manifest.stored_size_bytes)} stored."
         )
 
+    # ------------------------------------------------------------------
+    # Prune
+    # ------------------------------------------------------------------
+
+    def prune(
+        self,
+        remote_name: Optional[str] = None,
+        dry_run: bool = False,
+    ) -> None:
+        """Delete orphan chunks on *remote_name*.
+
+        A chunk is considered orphaned when no snapshot manifest for any
+        environment references it.  Env names are discovered from
+        ``index/index.json``; chunks are enumerated by iterating all 256
+        two-character hex shards under ``chunks/``.
+
+        :param remote_name: Remote to prune, or ``None`` for the default.
+        :param dry_run: When ``True``, report orphans but do not delete them.
+        """
+        remote_cfg = self._resolve_remote(remote_name)
+
+        with self._build_backend(remote_cfg) as backend:
+            # Collect env names from the global index.
+            index_path = RemoteBackend.index_path()
+            if backend.exists(index_path):
+                catalogue = IndexCatalogue.from_dict(
+                    json.loads(backend.download(index_path))
+                )
+                env_names = list(catalogue.environments.keys())
+            else:
+                env_names = []
+
+            # Collect all chunk hashes referenced by any snapshot.
+            referenced: set[str] = set()
+            for env_name in env_names:
+                prefix = RemoteBackend.snapshots_prefix(env_name)
+                for name in backend.list_prefix(prefix):
+                    if not name.endswith(".json"):
+                        continue
+                    raw = backend.download(f"{prefix}/{name}")
+                    manifest = SnapshotManifest.from_dict(json.loads(raw))
+                    referenced.update(manifest.chunks)
+
+            # Enumerate every stored chunk across all 256 hex shards.
+            orphans: list[str] = []
+            total = 0
+            for shard in (f"{i:02x}" for i in range(256)):
+                for chunk_hash in backend.list_prefix(f"chunks/{shard}"):
+                    total += 1
+                    if chunk_hash not in referenced:
+                        orphans.append(chunk_hash)
+
+            # Delete (or dry-run report) orphaned chunks.
+            if not dry_run:
+                for chunk_hash in orphans:
+                    backend.delete(RemoteBackend.chunk_path(chunk_hash))
+
+        action = "would be deleted" if dry_run else "deleted"
+        Util.print(
+            f"Prune '{remote_cfg.name}': "
+            f"{total} chunk(s) scanned, "
+            f"{len(orphans)} orphan(s) {action}."
+        )
+
     def _delete_dir(self, path: str) -> None:
         """Delete *path* recursively; retry under sudo on PermissionError."""
         try:

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -1096,5 +1096,26 @@ def get_remote_env(
     shepherd.remoteMng.display_snapshots(env_name, remote_name)
 
 
+@remote.command(name="prune")
+@click.option(
+    "--remote",
+    "remote_name",
+    default=None,
+    help="Remote name (uses default if omitted).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Report orphan chunks without deleting them.",
+)
+@click.pass_obj
+def prune_remote(
+    shepherd: ShepherdMng, remote_name: Optional[str], dry_run: bool
+) -> None:
+    """Delete orphan chunks on a remote."""
+    shepherd.remoteMng.prune(remote_name, dry_run=dry_run)
+
+
 if __name__ == "__main__":
     cli(obj=None)

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -1480,7 +1480,7 @@ def test_completion_remote_verbs(
     """Completing 'remote' returns the expected verb list."""
     sm = ShepherdMng(load_runtime_plugins=False)
     completions = sm.completionMng.get_completions(["remote"])
-    assert completions == ["add", "list", "delete", "envs", "get"]
+    assert completions == ["add", "list", "delete", "envs", "get", "prune"]
 
 
 @pytest.mark.compl
@@ -1680,3 +1680,16 @@ def test_completion_remote_add_flags(
     assert "--user" in completions
     assert "--root-path" in completions
     assert "--set-default" in completions
+
+
+@pytest.mark.compl
+def test_completion_remote_prune_flags(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+) -> None:
+    """'remote prune -' suggests --remote and --dry-run."""
+    sm = ShepherdMng(load_runtime_plugins=False)
+    completions = sm.completionMng.get_completions(["remote", "prune", "-"])
+    assert "--remote" in completions
+    assert "--dry-run" in completions

--- a/src/tests/test_remote_mng.py
+++ b/src/tests/test_remote_mng.py
@@ -1246,3 +1246,160 @@ def test_cli_env_hydrate(
         )
 
     assert result.exit_code in (0, 1)
+
+
+# ---------------------------------------------------------------------------
+# prune helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_prune_mng(fake_backend: FakeRemoteBackend) -> RemoteMng:
+    """Return a RemoteMng wired to *fake_backend* for prune tests."""
+    configMng = MagicMock()
+    configMng.get_remotes.return_value = [_REMOTE_FTP]
+    configMng.get_remote.return_value = _REMOTE_FTP
+    configMng.get_default_remote.return_value = None
+
+    mng = RemoteMng(configMng)
+    mng._build_backend = MagicMock(return_value=fake_backend)  # type: ignore[method-assign]
+    return mng
+
+
+def _seed_prune_backend(
+    fake: FakeRemoteBackend,
+    env_name: str,
+    referenced_hashes: list[str],
+    orphan_hashes: list[str],
+) -> None:
+    """Seed *fake* with an index, a snapshot manifest, and raw chunk entries.
+
+    *referenced_hashes* are included in the manifest (and therefore safe).
+    *orphan_hashes* are stored as raw chunks but not referenced by any manifest.
+    """
+    import datetime as _dt
+
+    now = (
+        _dt.datetime.now(_dt.timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+    # Store all chunks (referenced + orphans) as raw bytes.
+    all_hashes = referenced_hashes + orphan_hashes
+    for h in all_hashes:
+        fake._store[RemoteBackend.chunk_path(h)] = b"x"
+
+    # Build and store snapshot manifest referencing only *referenced_hashes*.
+    from storage.snapshot import (
+        IndexCatalogue,
+        IndexCatalogueEntry,
+        LatestPointer,
+    )
+
+    manifest = SnapshotManifest(
+        snapshot_id="",
+        environment=env_name,
+        shepherd_version="0.0.0-test",
+        created_at=now,
+        chunks=referenced_hashes,
+        chunk_count=len(referenced_hashes),
+        total_size_bytes=len(referenced_hashes) * 1024,
+        stored_size_bytes=len(referenced_hashes) * 512,
+    )
+    manifest_bytes = json.dumps(manifest.to_dict(), indent=2).encode()
+    snapshot_id = SnapshotManifest.build_id(now, manifest_bytes)
+    manifest.snapshot_id = snapshot_id
+    manifest_bytes = json.dumps(manifest.to_dict(), indent=2).encode()
+
+    fake._store[RemoteBackend.snapshot_path(env_name, snapshot_id)] = (
+        manifest_bytes
+    )
+    pointer = LatestPointer(snapshot_id=snapshot_id, updated_at=now)
+    fake._store[RemoteBackend.latest_path(env_name)] = json.dumps(
+        pointer.to_dict()
+    ).encode()
+
+    # Seed the global index.
+    catalogue = IndexCatalogue(updated_at=now)
+    catalogue.environments[env_name] = IndexCatalogueEntry(
+        latest_snapshot=snapshot_id,
+        snapshot_count=1,
+        last_backup=now,
+        labels=[],
+        total_size_bytes=len(referenced_hashes) * 1024,
+        stored_size_bytes=len(referenced_hashes) * 512,
+    )
+    fake._store[RemoteBackend.index_path()] = json.dumps(
+        catalogue.to_dict(), indent=2
+    ).encode()
+
+
+# ---------------------------------------------------------------------------
+# prune
+# ---------------------------------------------------------------------------
+
+# 64-char hex strings that look like real SHA-256 hashes.
+_HASH_A = "aa" * 32  # referenced
+_HASH_B = "bb" * 32  # orphan
+
+
+@pytest.mark.remote
+def test_prune_no_orphans() -> None:
+    """prune with all chunks referenced deletes nothing."""
+    fake = FakeRemoteBackend()
+    _seed_prune_backend(fake, "my-env", [_HASH_A], [])
+    mng = _make_prune_mng(fake)
+
+    mng.prune(remote_name="test-ftp")
+
+    assert RemoteBackend.chunk_path(_HASH_A) in fake._store
+
+
+@pytest.mark.remote
+def test_prune_deletes_orphan_chunks() -> None:
+    """prune removes chunks not referenced by any manifest."""
+    fake = FakeRemoteBackend()
+    _seed_prune_backend(fake, "my-env", [_HASH_A], [_HASH_B])
+    mng = _make_prune_mng(fake)
+
+    mng.prune(remote_name="test-ftp")
+
+    assert RemoteBackend.chunk_path(_HASH_A) in fake._store
+    assert RemoteBackend.chunk_path(_HASH_B) not in fake._store
+
+
+@pytest.mark.remote
+def test_prune_dry_run_does_not_delete() -> None:
+    """prune --dry-run reports orphans without deleting them."""
+    fake = FakeRemoteBackend()
+    _seed_prune_backend(fake, "my-env", [_HASH_A], [_HASH_B])
+    mng = _make_prune_mng(fake)
+
+    mng.prune(remote_name="test-ftp", dry_run=True)
+
+    # Both chunks must still be present.
+    assert RemoteBackend.chunk_path(_HASH_A) in fake._store
+    assert RemoteBackend.chunk_path(_HASH_B) in fake._store
+
+
+@pytest.mark.remote
+def test_prune_empty_remote() -> None:
+    """prune on a remote with no index and no chunks completes without error."""
+    fake = FakeRemoteBackend()
+    mng = _make_prune_mng(fake)
+
+    mng.prune(remote_name="test-ftp")  # must not raise
+
+
+@pytest.mark.remote
+def test_prune_prints_summary(capsys: pytest.CaptureFixture[str]) -> None:
+    """prune prints a summary line with scanned and orphaned counts."""
+    fake = FakeRemoteBackend()
+    _seed_prune_backend(fake, "my-env", [_HASH_A], [_HASH_B])
+    mng = _make_prune_mng(fake)
+
+    mng.prune(remote_name="test-ftp")
+
+    out = capsys.readouterr().out
+    assert "2 chunk(s) scanned" in out
+    assert "1 orphan(s) deleted" in out

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -1713,6 +1713,40 @@ def test_cli_remote_get_with_remote(
 
 
 @pytest.mark.shpd
+def test_cli_remote_prune(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote prune' delegates to remoteMng.prune with correct arguments."""
+    from remote import RemoteMng
+
+    _setup_remote(shpd_conf)
+    mock_prune = mocker.patch.object(RemoteMng, "prune")
+
+    result = runner.invoke(cli, ["remote", "prune"])
+
+    assert result.exit_code == 0
+    mock_prune.assert_called_once_with(None, dry_run=False)
+
+
+@pytest.mark.shpd
+def test_cli_remote_prune_dry_run(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'remote prune --dry-run --remote=<name>' passes both flags."""
+    from remote import RemoteMng
+
+    _setup_remote(shpd_conf)
+    mock_prune = mocker.patch.object(RemoteMng, "prune")
+
+    result = runner.invoke(
+        cli, ["remote", "prune", "--remote", "ftp-prod", "--dry-run"]
+    )
+
+    assert result.exit_code == 0
+    mock_prune.assert_called_once_with("ftp-prod", dry_run=True)
+
+
+@pytest.mark.shpd
 def test_cli_remote_add_ftp_missing_password(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ) -> None:


### PR DESCRIPTION
## Summary

- Add `RemoteMng.prune(remote_name, dry_run)`: scans all snapshot manifests to collect referenced chunk hashes, iterates all 256 hex shards to enumerate stored chunks, and deletes any orphan not referenced by any manifest
- Add `shepctl remote prune` CLI command with `--remote` and `--dry-run` flags
- Extend shell completion: `"prune"` verb in the `remote` scope with `--remote` and `--dry-run` option suggestions

## Test plan

- [ ] `pytest tests/test_remote_mng.py -q -k prune` — 5 new tests: no orphans, deletes orphans, dry-run preserves all chunks, empty remote, summary output
- [ ] `pytest -q` — 483 passed, 0 failed
- [ ] `black --check` — clean
- [ ] `isort --check-only` — clean
- [ ] `pyright src/remote/remote_mng.py src/shepctl.py src/completion/completion.py src/completion/completion_remote.py` — 0 errors

Fixes: #220