### PR TITLE
feat(remote): dispatch plugin-registered backends in RemoteMng

### DIFF
--- a/src/plugin/api.py
+++ b/src/plugin/api.py
@@ -21,6 +21,7 @@ from typing import (
 import click
 
 from config import ConfigMng
+from config.config import RemoteCfg
 from environment import EnvironmentFactory
 from plugin.context import PluginContext
 from remote import RemoteBackend
@@ -85,13 +86,17 @@ instance.  A pre-built instance or a builder callable with the same
 signature are also accepted.
 """
 
-RemoteBackendProvider: TypeAlias = RemoteBackend | Callable[[], RemoteBackend]
+RemoteBackendProvider: TypeAlias = (
+    RemoteBackend | Callable[[RemoteCfg], RemoteBackend]
+)
 """
 Accepted value for :attr:`PluginRemoteBackendSpec.provider`.
 
 Pass the **class** of your ``RemoteBackend`` subclass — the runtime calls
-it with no arguments to produce the instance.  A pre-built instance is
-also accepted.
+it with the resolved :class:`~config.config.RemoteCfg` to produce the
+instance.  Read plugin-specific connection parameters from
+``cfg.properties``.  A pre-built ``RemoteBackend`` instance is also
+accepted (no factory call is made in that case).
 """
 
 
@@ -163,10 +168,10 @@ class PluginRemoteBackendSpec:
     transport (e.g. ``"s3"`` or ``"azure-blob"``).  It must not collide
     with the core built-ins ``"ftp"`` and ``"sftp"``.
 
-    ``provider`` must satisfy :data:`RemoteBackendProvider` — either a
-    pre-built ``RemoteBackend`` instance or the **class** (zero-argument
-    factory callable) of your ``RemoteBackend`` subclass.  The runtime
-    calls it with no arguments to produce the instance on demand.
+    ``provider`` must satisfy :data:`RemoteBackendProvider` — either the
+    **class** of your ``RemoteBackend`` subclass (called with the resolved
+    ``RemoteCfg``) or a pre-built instance.  Read plugin-specific
+    connection parameters from ``cfg.properties``.
     """
 
     type_id: str

--- a/src/plugin/runtime.py
+++ b/src/plugin/runtime.py
@@ -32,6 +32,7 @@ from config import (
     ServiceTemplateRefCfg,
     parse_plugin_descriptor,
 )
+from config.config import RemoteCfg
 from environment import EnvironmentFactory, EnvironmentMng
 from plugin.api import (
     PluginCommandSpec,
@@ -1016,7 +1017,9 @@ class PluginRuntimeMng:
         """Return whether the remote backend provider can be materialized."""
         return isinstance(provider, RemoteBackend) or callable(provider)
 
-    def build_remote_backend(self, type_id: str) -> RemoteBackend | None:
+    def build_remote_backend(
+        self, type_id: str, cfg: RemoteCfg
+    ) -> RemoteBackend | None:
         """Return a plugin-owned RemoteBackend for *type_id*, or None."""
         spec = self.registry.remote_backends.get(type_id)
         if spec is None:
@@ -1025,7 +1028,15 @@ class PluginRuntimeMng:
         if isinstance(provider, RemoteBackend):
             return provider
         if callable(provider):
-            return provider()
+            try:
+                return provider(cfg)
+            except TypeError as exc:
+                raise ValueError(
+                    f"Plugin remote backend '{type_id}' provider raised "
+                    f"TypeError when called with RemoteCfg. "
+                    f"Ensure the provider accepts a single RemoteCfg "
+                    f"argument: {exc}"
+                ) from exc
         raise ValueError(
             f"Plugin remote backend '{type_id}' provider is invalid."
         )

--- a/src/remote/remote_mng.py
+++ b/src/remote/remote_mng.py
@@ -42,6 +42,7 @@ from .sftp_backend import SFTPBackend
 
 if TYPE_CHECKING:
     from environment.environment import Environment, EnvironmentMng
+    from plugin.runtime import PluginRuntimeMng
 
 
 def _utcnow() -> str:
@@ -71,6 +72,12 @@ class RemoteMng:
 
     def __init__(self, configMng: ConfigMng) -> None:
         self.configMng = configMng
+        self._plugin_runtime: Optional[PluginRuntimeMng] = None
+
+    def attach_plugin_runtime(
+        self, plugin_runtime: Optional[PluginRuntimeMng]
+    ) -> None:
+        self._plugin_runtime = plugin_runtime
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -106,11 +113,13 @@ class RemoteMng:
         """Instantiate the transport backend described by *cfg*.
 
         Resolves ``${VAR}`` placeholders in connection fields before passing
-        them to the backend constructor.
+        them to the backend constructor.  After the built-in ``ftp`` /
+        ``sftp`` checks the method falls through to the plugin registry;
+        plugins receive the resolved ``cfg`` and may read type-specific
+        parameters from ``cfg.properties``.
 
-        :raises NotImplementedError: For plugin-registered backend types
-            (not yet supported in this release).
-        :raises click.UsageError: For unknown built-in type strings.
+        :raises click.UsageError: For unknown type strings with no matching
+            plugin backend.
         """
         cfg = deepcopy(cfg)
         cfg.set_resolved()
@@ -138,10 +147,14 @@ class RemoteMng:
                 root_path=root_path,
             )
 
+        if self._plugin_runtime is not None:
+            backend = self._plugin_runtime.build_remote_backend(cfg.type, cfg)
+            if backend is not None:
+                return backend
         raise click.UsageError(
             f"Unknown remote type '{cfg.type}'. "
             "Built-in types are 'ftp' and 'sftp'. "
-            "Plugin-registered backends are not yet supported."
+            "Use a plugin to add additional transport backends."
         )
 
     def _update_index(

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -91,6 +91,7 @@ class ShepherdMng:
             self.pluginRuntimeMng.attach_managers(
                 self.environmentMng, self.serviceMng, self.remoteMng
             )
+        self.remoteMng.attach_plugin_runtime(self.pluginRuntimeMng)
         self.configMng.set_plugin_runtime_mng(self.pluginRuntimeMng)
         self.completionMng = CompletionMng(
             self.cli_flags,

--- a/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py
+++ b/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py
@@ -7,6 +7,7 @@ from config import (
     EnvironmentTemplateCfg,
     ServiceCfg,
 )
+from config.config import RemoteCfg
 from docker import DockerComposeEnv, DockerComposeSvc
 from environment import Environment, EnvironmentFactory
 from plugin import (
@@ -23,6 +24,9 @@ from service import Service, ServiceFactory
 
 class FakeRemoteBackend(RemoteBackend):
     """Minimal no-op backend for plugin registry tests."""
+
+    def __init__(self, cfg: RemoteCfg) -> None:
+        pass
 
     def exists(self, path: str) -> bool:
         return False

--- a/src/tests/test_plugin_runtime.py
+++ b/src/tests/test_plugin_runtime.py
@@ -18,6 +18,7 @@ from click.testing import CliRunner
 from pytest_mock import MockerFixture
 from test_util import read_fixture
 
+from config.config import RemoteCfg
 from plugin import PluginRuntimeMng
 from shepctl import ShepherdMng, cli
 
@@ -1030,10 +1031,16 @@ def test_plugin_remote_backend_lands_in_registry(
     registry = shepherd.pluginRuntimeMng.registry
     assert "fake-store" in registry.remote_backends
 
-    backend = shepherd.pluginRuntimeMng.build_remote_backend("fake-store")
+    fake_cfg = RemoteCfg(name="fake-store", type="fake-store")
+    backend = shepherd.pluginRuntimeMng.build_remote_backend(
+        "fake-store", fake_cfg
+    )
     assert isinstance(backend, RemoteBackend)
 
-    assert shepherd.pluginRuntimeMng.build_remote_backend("unknown") is None
+    assert (
+        shepherd.pluginRuntimeMng.build_remote_backend("unknown", fake_cfg)
+        is None
+    )
 
 
 @pytest.mark.shpd
@@ -1046,9 +1053,11 @@ def test_plugin_remote_backend_rejects_core_type_id(
     _install_fixture_plugin(
         shpd_path,
         main_content=(
+            "from config.config import RemoteCfg\n"
             "from remote import RemoteBackend\n"
             "from plugin import PluginRemoteBackendSpec, ShepherdPlugin\n\n"
             "class FakeBackend(RemoteBackend):\n"
+            "    def __init__(self, cfg: RemoteCfg) -> None: pass\n"
             "    def exists(self, p): return False\n"
             "    def upload(self, p, d): pass\n"
             "    def download(self, p): return b''\n"

--- a/src/tests/test_remote_mng.py
+++ b/src/tests/test_remote_mng.py
@@ -1403,3 +1403,51 @@ def test_prune_prints_summary(capsys: pytest.CaptureFixture[str]) -> None:
     out = capsys.readouterr().out
     assert "2 chunk(s) scanned" in out
     assert "1 orphan(s) deleted" in out
+
+
+# ---------------------------------------------------------------------------
+# Plugin backend dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.shpd
+def test_build_backend_dispatches_plugin_registered_type() -> None:
+    """_build_backend returns the backend produced by a plugin factory."""
+    fake = FakeRemoteBackend()
+    plugin_runtime = MagicMock()
+    plugin_runtime.build_remote_backend.return_value = fake
+
+    cfg = RemoteCfg(
+        name="plugin-remote",
+        type="fake-store",
+        host="h",
+        user="u",
+        root_path="/r",
+    )
+    mng = RemoteMng(MagicMock())
+    mng.attach_plugin_runtime(plugin_runtime)
+
+    assert mng._build_backend(cfg) is fake
+    plugin_runtime.build_remote_backend.assert_called_once_with(
+        "fake-store", cfg
+    )
+
+
+@pytest.mark.shpd
+def test_build_backend_unknown_type_raises() -> None:
+    """_build_backend raises UsageError when no plugin matches the type."""
+    plugin_runtime = MagicMock()
+    plugin_runtime.build_remote_backend.return_value = None
+
+    cfg = RemoteCfg(
+        name="bad-remote",
+        type="no-such-type",
+        host="h",
+        user="u",
+        root_path="/r",
+    )
+    mng = RemoteMng(MagicMock())
+    mng.attach_plugin_runtime(plugin_runtime)
+
+    with pytest.raises(click.UsageError):
+        mng._build_backend(cfg)


### PR DESCRIPTION
## Summary

- `RemoteBackendProvider` signature changed to `Callable[[RemoteCfg], RemoteBackend]` — plugin factories receive the resolved config and read type-specific connection parameters from `cfg.properties` (already present in the schema)
- `PluginRuntimeMng.build_remote_backend()` gains a `cfg: RemoteCfg` parameter and forwards it to the provider callable
- `RemoteMng` gains `_plugin_runtime` + `attach_plugin_runtime()` (same late-binding pattern as `PluginRuntimeMng.attach_managers()`); `ShepherdMng` calls it after both objects are wired
- `_build_backend()` falls through to the plugin registry before raising `click.UsageError`; "not yet supported" wording removed from the error message
- Fixture plugin's `FakeRemoteBackend` updated for the new factory signature; two new `shpd`-marked unit tests cover plugin dispatch and the unknown-type error path

## Testing

```bash
cd src
pytest -m "remote or shpd" -v   # 188 passed
pyright                          # 0 errors
black src && isort src           # no changes
pre-commit run --all-files       # all hooks passed
```

Fixes: #221