### PR TITLE
test(remote): FTP and SFTP integration tests against real backends

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -26,7 +26,14 @@ extend_skip_glob = ["resources/*"]
 typeCheckingMode = "strict"
 venvPath = ".."
 venv = ".venv"
-exclude = ["../examples", "tests"]
+exclude = [
+  "../examples",
+  "tests",
+  "**/node_modules",
+  "**/__pycache__",
+  "**/.*",
+  ".venv",
+]
 reportMissingTypeStubs = "none"
 
 [tool.pytest.ini_options]
@@ -37,6 +44,17 @@ addopts = [
   "--cov-report=xml",
   "--cov-report=html",
   "--cov-config=.coveragerc",
-  "-m", "not integration",
+  "-m",
+  "not integration",
 ]
-markers = ["env", "svc", "cfg", "shpd", "compl", "docker", "integration", "storage", "remote"]
+markers = [
+  "env",
+  "svc",
+  "cfg",
+  "shpd",
+  "compl",
+  "docker",
+  "integration",
+  "storage",
+  "remote",
+]

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -7,13 +7,84 @@
 
 from __future__ import annotations
 
+import ftplib
 import os
+import subprocess
+import time
 from pathlib import Path
+from typing import Generator
 
+import paramiko
 import pytest
 from click.testing import CliRunner
 
+from config.config import RemoteCfg, RemoteChunkCfg
 from shepctl import cli
+
+_COMPOSE = (
+    Path(__file__).resolve().parent
+    / "fixtures"
+    / "remote"
+    / "docker-compose.yml"
+)
+
+_CHUNK_CFG = RemoteChunkCfg(
+    min_size_kb=64,
+    avg_size_kb=256,
+    max_size_kb=1024,
+)
+
+
+def _wait_ftp_ready(
+    host: str, port: int, user: str, password: str, timeout: float = 30.0
+) -> None:
+    """Probe until an FTP login succeeds (not just TCP open)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            ftp = ftplib.FTP()
+            ftp.connect(host, port, timeout=2)
+            ftp.login(user, password)
+            ftp.quit()
+            return
+        except Exception:
+            time.sleep(0.5)
+    raise TimeoutError(f"FTP {host}:{port} not ready after {timeout}s")
+
+
+def _wait_sftp_ready(
+    host: str,
+    port: int,
+    user: str,
+    password: str,
+    upload_dir: str = "upload",
+    timeout: float = 30.0,
+) -> None:
+    """Probe until SFTP auth succeeds AND upload_dir is visible in root.
+
+    atmoz/sftp creates the upload subdir asynchronously in its entrypoint;
+    TCP-ready and even auth-ready are not enough — we must wait for the dir.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        transport = None
+        try:
+            transport = paramiko.Transport((host, port))
+            transport.connect(username=user, password=password)
+            sftp = paramiko.SFTPClient.from_transport(transport)
+            if sftp and upload_dir in sftp.listdir("/"):
+                sftp.close()
+                transport.close()
+                return
+            if sftp:
+                sftp.close()
+        except Exception:
+            pass
+        finally:
+            if transport and transport.is_active():
+                transport.close()
+        time.sleep(0.5)
+    raise TimeoutError(f"SFTP {host}:{port} not ready after {timeout}s")
 
 
 def read_fixture(*parts: str) -> str:
@@ -111,3 +182,44 @@ def shpd_redis_gated_env(tmp_path: Path):
 @pytest.fixture
 def runner() -> CliRunner:
     return CliRunner()
+
+
+@pytest.fixture(scope="session")
+def remote_backends() -> Generator[dict[str, RemoteCfg], None, None]:
+    """Start FTP + SFTP containers once for the whole session."""
+    subprocess.run(
+        ["docker", "compose", "-f", str(_COMPOSE), "up", "-d"],
+        check=True,
+    )
+    try:
+        _wait_ftp_ready("127.0.0.1", 2121, "ftpuser", "ftppass")
+        _wait_sftp_ready("127.0.0.1", 2222, "sftpuser", "sftppass")
+        yield {
+            "ftp": RemoteCfg(
+                name="ftp",
+                type="ftp",
+                host="127.0.0.1",
+                port=2121,
+                user="ftpuser",
+                password="ftppass",
+                # delfer/alpine-ftp-server places home at /ftp/<user>;
+                # vsftpd is not chrooted so we use the absolute server path.
+                root_path="/ftp/ftpuser",
+                chunk=_CHUNK_CFG,
+            ),
+            "sftp": RemoteCfg(
+                name="sftp",
+                type="sftp",
+                host="127.0.0.1",
+                port=2222,
+                user="sftpuser",
+                password="sftppass",
+                root_path="/upload",
+                chunk=_CHUNK_CFG,
+            ),
+        }
+    finally:
+        subprocess.run(
+            ["docker", "compose", "-f", str(_COMPOSE), "down", "-v"],
+            check=True,
+        )

--- a/src/tests/integration/fixtures/remote/docker-compose.yml
+++ b/src/tests/integration/fixtures/remote/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  ftp:
+    image: delfer/alpine-ftp-server
+    environment:
+      USERS: "ftpuser|ftppass"
+      ADDRESS: 127.0.0.1
+      MIN_PORT: "21000"
+      MAX_PORT: "21100"
+    ports:
+      - "2121:21"
+      - "21000-21100:21000-21100"
+
+  sftp:
+    image: atmoz/sftp
+    command: "sftpuser:sftppass:1001::upload"
+    ports:
+      - "2222:22"

--- a/src/tests/integration/test_ftp_sftp_backends.py
+++ b/src/tests/integration/test_ftp_sftp_backends.py
@@ -1,0 +1,382 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Integration tests for remote push/pull/dehydrate/hydrate/prune flows
+against real FTP and SFTP backends running in Docker containers.
+
+Each test receives a ``backend_cfg`` fixture parametrized over ``ftp`` and
+``sftp``, giving 12 test runs total (6 tests × 2 backends).  Docker containers
+are started once per session via the ``remote_backends`` fixture in conftest.py.
+
+Marker: ``integration`` + ``docker``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from config.config import EnvironmentCfg, RemoteCfg
+from remote.backend import RemoteBackend
+from remote.remote_mng import RemoteMng
+from storage.snapshot import IndexCatalogue, SnapshotManifest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.docker,
+    pytest.mark.skipif(
+        subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            timeout=5,
+        ).returncode
+        != 0,
+        reason="Docker daemon not available",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(params=["ftp", "sftp"])
+def backend_cfg(
+    remote_backends: dict[str, RemoteCfg], request: pytest.FixtureRequest
+) -> RemoteCfg:
+    return remote_backends[request.param]  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# Setup helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_env_cfg(
+    tag: str = "my-env",
+    dehydrated: Optional[bool] = None,
+) -> EnvironmentCfg:
+    return EnvironmentCfg(
+        template="default",
+        factory="docker-compose",
+        tag=tag,
+        services=[],
+        probes=[],
+        networks=[],
+        volumes=[],
+        dehydrated=dehydrated,
+    )
+
+
+def _make_push_mng(
+    cfg: RemoteCfg,
+    env_cfg: EnvironmentCfg,
+    env_path: str,
+) -> tuple[RemoteMng, MagicMock]:
+    configMng = MagicMock()
+    configMng.get_remotes.return_value = [cfg]
+    configMng.get_remote.return_value = cfg
+    configMng.get_default_remote.return_value = None
+    configMng.get_environment.return_value = env_cfg
+    configMng.constants.APP_VERSION = "0.0.0-test"
+    configMng.config.envs_path = str(Path(env_path).parent)
+
+    env_mock = MagicMock()
+    env_mock.get_path.return_value = env_path
+    env_mock.get_volume_tar_streams.return_value = []
+    env_mock.is_running.return_value = False
+
+    env_mng = MagicMock()
+    env_mng.get_environment_from_cfg.return_value = env_mock
+
+    # _build_backend NOT mocked — real FTP/SFTP connection
+    return RemoteMng(configMng), env_mng
+
+
+def _make_pull_mng(
+    cfg: RemoteCfg,
+    envs_path: str,
+    existing_env_cfg: Optional[EnvironmentCfg] = None,
+) -> RemoteMng:
+    configMng = MagicMock()
+    configMng.get_remotes.return_value = [cfg]
+    configMng.get_remote.return_value = cfg
+    configMng.get_default_remote.return_value = None
+    configMng.get_environment.return_value = existing_env_cfg
+    configMng.constants.APP_VERSION = "0.0.0-test"
+    configMng.config.envs_path = envs_path
+
+    mng = RemoteMng(configMng)
+    mng._build_cache = MagicMock(  # type: ignore[method-assign]
+        return_value=MagicMock(
+            contains=lambda h: False,
+            get=lambda h: None,
+            put=lambda h, d: None,
+        )
+    )
+    return mng
+
+
+def _make_prune_mng(cfg: RemoteCfg) -> RemoteMng:
+    configMng = MagicMock()
+    configMng.get_remotes.return_value = [cfg]
+    configMng.get_remote.return_value = cfg
+    configMng.get_default_remote.return_value = None
+
+    return RemoteMng(configMng)
+
+
+def _make_dehydrate_mng(
+    cfg: RemoteCfg,
+    env_cfg: EnvironmentCfg,
+    env_path: str,
+) -> tuple[RemoteMng, MagicMock]:
+    """Dehydrate is local-only; wires configMng so env_dir resolves correctly."""
+    configMng = MagicMock()
+    configMng.get_remotes.return_value = [cfg]
+    configMng.get_remote.return_value = cfg
+    configMng.get_default_remote.return_value = None
+    configMng.get_environment.return_value = env_cfg
+    configMng.constants.APP_VERSION = "0.0.0-test"
+    # dehydrate computes env_dir as envs_path / env_name
+    configMng.config.envs_path = str(Path(env_path).parent)
+
+    env_mock = MagicMock()
+    env_mock.get_path.return_value = env_path
+    env_mock.is_running.return_value = False
+
+    env_mng = MagicMock()
+    env_mng.get_environment_from_cfg.return_value = env_mock
+
+    return RemoteMng(configMng), env_mng
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.docker
+def test_push_first_time(
+    backend_cfg: RemoteCfg,
+    tmp_path: Path,
+) -> None:
+    """push uploads chunks, manifest, and index on first push."""
+    env_name = f"env-push-first-{backend_cfg.type}"
+    env_dir = tmp_path / env_name
+    env_dir.mkdir()
+    (env_dir / "sentinel.bin").write_bytes(os.urandom(4 * 1024 * 1024))
+
+    mng, env_mng = _make_push_mng(
+        backend_cfg, _make_env_cfg(env_name), str(env_dir)
+    )
+    mng.push(env_name, env_mng, remote_name=backend_cfg.name)
+
+    with mng._build_backend(backend_cfg) as backend:
+        index_bytes = backend.download(RemoteBackend.index_path())
+        catalogue = IndexCatalogue.from_dict(json.loads(index_bytes))
+        assert env_name in catalogue.environments
+
+        latest_bytes = backend.download(RemoteBackend.latest_path(env_name))
+        latest = json.loads(latest_bytes)
+        snapshot_id = latest["snapshot_id"]
+
+        manifest_bytes = backend.download(
+            RemoteBackend.snapshot_path(env_name, snapshot_id)
+        )
+        manifest = SnapshotManifest.from_dict(json.loads(manifest_bytes))
+        assert manifest.chunk_count >= 1
+
+        for chunk_hash in manifest.chunks:
+            assert backend.exists(RemoteBackend.chunk_path(chunk_hash))
+
+
+@pytest.mark.integration
+@pytest.mark.docker
+def test_push_second_time_no_new_chunks(
+    backend_cfg: RemoteCfg,
+    tmp_path: Path,
+) -> None:
+    """Pushing unchanged data a second time uploads zero new chunks."""
+    env_name = f"env-push-second-{backend_cfg.type}"
+    env_dir = tmp_path / env_name
+    env_dir.mkdir()
+    (env_dir / "sentinel.bin").write_bytes(os.urandom(4 * 1024 * 1024))
+
+    mng, env_mng = _make_push_mng(
+        backend_cfg, _make_env_cfg(env_name), str(env_dir)
+    )
+    mng.push(env_name, env_mng, remote_name=backend_cfg.name)
+
+    with mng._build_backend(backend_cfg) as backend:
+        manifest_bytes = backend.download(
+            RemoteBackend.snapshot_path(
+                env_name,
+                json.loads(
+                    backend.download(RemoteBackend.latest_path(env_name))
+                )["snapshot_id"],
+            )
+        )
+        chunks_after_first = set(
+            SnapshotManifest.from_dict(json.loads(manifest_bytes)).chunks
+        )
+
+    mng.push(env_name, env_mng, remote_name=backend_cfg.name)
+
+    with mng._build_backend(backend_cfg) as backend:
+        manifest_bytes = backend.download(
+            RemoteBackend.snapshot_path(
+                env_name,
+                json.loads(
+                    backend.download(RemoteBackend.latest_path(env_name))
+                )["snapshot_id"],
+            )
+        )
+        chunks_after_second = set(
+            SnapshotManifest.from_dict(json.loads(manifest_bytes)).chunks
+        )
+
+    assert chunks_after_first == chunks_after_second
+
+
+@pytest.mark.integration
+@pytest.mark.docker
+def test_pull_creates_env(
+    backend_cfg: RemoteCfg,
+    tmp_path: Path,
+) -> None:
+    """pull restores env directory; sentinel bytes are identical to original."""
+    env_name = f"env-pull-{backend_cfg.type}"
+    src_dir = tmp_path / "src" / env_name
+    src_dir.mkdir(parents=True)
+    sentinel_data = os.urandom(4 * 1024 * 1024)
+    (src_dir / "sentinel.bin").write_bytes(sentinel_data)
+
+    push_mng, env_mng = _make_push_mng(
+        backend_cfg, _make_env_cfg(env_name), str(src_dir)
+    )
+    push_mng.push(env_name, env_mng, remote_name=backend_cfg.name)
+
+    fresh_envs = str(tmp_path / "dest")
+    os.makedirs(fresh_envs, exist_ok=True)
+    pull_mng = _make_pull_mng(backend_cfg, fresh_envs)
+    pull_mng.pull(env_name, remote_name=backend_cfg.name)
+
+    restored = Path(fresh_envs) / env_name / "env" / "sentinel.bin"
+    assert restored.exists(), f"restored file not found at {restored}"
+    assert restored.read_bytes() == sentinel_data
+
+
+@pytest.mark.integration
+@pytest.mark.docker
+def test_dehydrate_strips_data(
+    backend_cfg: RemoteCfg,
+    tmp_path: Path,
+) -> None:
+    """dehydrate removes local env dir and sets dehydrated=True."""
+    env_name = f"env-dehy-{backend_cfg.type}"
+    env_dir = tmp_path / env_name
+    env_dir.mkdir()
+    (env_dir / "sentinel.bin").write_bytes(os.urandom(4 * 1024 * 1024))
+
+    env_cfg = _make_env_cfg(env_name)
+    push_mng, env_mng = _make_push_mng(backend_cfg, env_cfg, str(env_dir))
+    push_mng.push(env_name, env_mng, remote_name=backend_cfg.name)
+
+    dehy_mng, dehy_env_mng = _make_dehydrate_mng(
+        backend_cfg, env_cfg, str(env_dir)
+    )
+    dehy_mng.dehydrate(env_name, dehy_env_mng)
+
+    assert not env_dir.exists()
+    assert env_cfg.dehydrated is True
+
+
+@pytest.mark.integration
+@pytest.mark.docker
+def test_hydrate_restores_data(
+    backend_cfg: RemoteCfg,
+    tmp_path: Path,
+) -> None:
+    """hydrate restores env after dehydrate; bytes are identical to original."""
+    env_name = f"env-hydrate-{backend_cfg.type}"
+    env_dir = tmp_path / env_name
+    env_dir.mkdir()
+    sentinel_data = os.urandom(4 * 1024 * 1024)
+    (env_dir / "sentinel.bin").write_bytes(sentinel_data)
+
+    env_cfg = _make_env_cfg(env_name)
+    push_mng, env_mng = _make_push_mng(backend_cfg, env_cfg, str(env_dir))
+    push_mng.push(env_name, env_mng, remote_name=backend_cfg.name)
+
+    dehy_mng, dehy_env_mng = _make_dehydrate_mng(
+        backend_cfg, env_cfg, str(env_dir)
+    )
+    dehy_mng.dehydrate(env_name, dehy_env_mng)
+    assert not env_dir.exists()
+
+    envs_path = str(tmp_path)
+    hydrate_mng = _make_pull_mng(
+        backend_cfg,
+        envs_path,
+        existing_env_cfg=_make_env_cfg(env_name, dehydrated=True),
+    )
+    hydrate_mng.hydrate(env_name, remote_name=backend_cfg.name)
+
+    restored = Path(envs_path) / env_name / "env" / "sentinel.bin"
+    assert restored.exists(), f"restored file not found at {restored}"
+    assert restored.read_bytes() == sentinel_data
+
+
+@pytest.mark.integration
+@pytest.mark.docker
+def test_prune_removes_orphans(
+    backend_cfg: RemoteCfg,
+    tmp_path: Path,
+) -> None:
+    """prune removes orphan chunks; referenced chunks remain intact."""
+    env_name = f"env-prune-{backend_cfg.type}"
+    env_dir = tmp_path / env_name
+    env_dir.mkdir()
+    (env_dir / "sentinel.bin").write_bytes(os.urandom(4 * 1024 * 1024))
+
+    push_mng, env_mng = _make_push_mng(
+        backend_cfg, _make_env_cfg(env_name), str(env_dir)
+    )
+    push_mng.push(env_name, env_mng, remote_name=backend_cfg.name)
+
+    orphan_hash = "aa" * 32
+    with push_mng._build_backend(backend_cfg) as backend:
+        backend.upload(RemoteBackend.chunk_path(orphan_hash), b"orphan-data")
+        assert backend.exists(RemoteBackend.chunk_path(orphan_hash))
+
+        manifest_bytes = backend.download(
+            RemoteBackend.snapshot_path(
+                env_name,
+                json.loads(
+                    backend.download(RemoteBackend.latest_path(env_name))
+                )["snapshot_id"],
+            )
+        )
+        referenced = SnapshotManifest.from_dict(
+            json.loads(manifest_bytes)
+        ).chunks
+
+    prune_mng = _make_prune_mng(backend_cfg)
+    prune_mng.prune(remote_name=backend_cfg.name, dry_run=False)
+
+    with push_mng._build_backend(backend_cfg) as backend:
+        assert not backend.exists(RemoteBackend.chunk_path(orphan_hash))
+        for chunk_hash in referenced:
+            assert backend.exists(RemoteBackend.chunk_path(chunk_hash))


### PR DESCRIPTION
## Summary

- Adds a session-scoped Docker fixture that starts `delfer/alpine-ftp-server` and `atmoz/sftp` containers once per test session and tears them down on exit
- Implements 6 tests parametrised over `ftp`/`sftp` (12 runs total) covering the full remote flow: push, second-push deduplication, pull with byte-level restore, dehydrate, hydrate with byte-level restore, and prune
- Uses 4 MB of `os.urandom()` data with `avg_size_kb=256` to exercise multiple passive-mode FTP data connections and SFTP file writes
- All tests carry `@pytest.mark.integration` and `@pytest.mark.docker` and are excluded from the default `pytest` run

## Testing

```bash
# Requires Docker daemon
cd src
pytest -m "integration and docker" -v --no-header
# Expect: 12 passed (6 tests × 2 backends)

# Default run must not pick these up
pytest --co -q | grep test_ftp_sftp
# Expect: 0 lines
```

Pre-commit checks: `black`, `isort`, `codespell` all pass.

Fixes: #223