### PR TITLE
perf(remote): batch-check existing chunks via list_prefix in push()

### DIFF
--- a/src/remote/remote_mng.py
+++ b/src/remote/remote_mng.py
@@ -25,7 +25,7 @@ import zstandard
 
 from config import ConfigMng
 from config.config import EnvironmentCfg, RemoteCfg
-from storage.chunker import Chunker
+from storage.chunker import Chunker, ChunkResult
 from storage.local_cache import LocalChunkCache, NullLocalChunkCache
 from storage.snapshot import (
     IndexCatalogue,
@@ -323,15 +323,30 @@ class RemoteMng:
         uploaded = 0
 
         with self._build_backend(remote_cfg) as backend:
+            # Phase 1 — buffer all chunks from the streaming tar.
+            buffered: list[ChunkResult] = []
             with producer.stream() as stream:
                 for chunk in chunker.chunk_stream(stream):
-                    path = RemoteBackend.chunk_path(chunk.hash)
-                    chunk_hashes.append(chunk.hash)
-                    total_raw += chunk.raw_size
-                    total_stored += len(chunk.data)
-                    if not backend.exists(path):
-                        backend.upload(path, chunk.data)
-                        uploaded += 1
+                    buffered.append(chunk)
+
+            # Phase 2 — one list_prefix per unique shard (O(shards) RPCs).
+            shards = {c.hash[:2] for c in buffered}
+            existing: dict[str, set[str]] = {
+                shard: set(backend.list_prefix(f"chunks/{shard}"))
+                for shard in shards
+            }
+
+            # Phase 3 — upload only the delta.
+            for chunk in buffered:
+                shard = chunk.hash[:2]
+                chunk_hashes.append(chunk.hash)
+                total_raw += chunk.raw_size
+                total_stored += len(chunk.data)
+                if chunk.hash not in existing[shard]:
+                    backend.upload(
+                        RemoteBackend.chunk_path(chunk.hash), chunk.data
+                    )
+                    uploaded += 1
 
             now = _utcnow()
 

--- a/src/tests/test_remote_mng.py
+++ b/src/tests/test_remote_mng.py
@@ -559,6 +559,47 @@ def test_push_second_time_uploads_zero_new_chunks(
 
 
 @pytest.mark.remote
+def test_push_batch_shard_check(tmp_path: pathlib.Path) -> None:
+    """push() uses list_prefix per shard, not per-chunk exists(), for dedup."""
+    env_dir = tmp_path / "my-env"
+    env_dir.mkdir()
+    (env_dir / "data.txt").write_bytes(b"hello" * 1024)
+
+    fake = FakeRemoteBackend()
+    mng, env_mng = _make_push_mng(fake, _make_env_cfg(), str(env_dir))
+    mng.push("my-env", env_mng, remote_name="test-ftp")
+
+    # Instrument the second push to capture list_prefix and exists calls.
+    original_list_prefix = fake.list_prefix
+    list_prefix_calls: list[str] = []
+
+    def _list_prefix_spy(prefix: str) -> list[str]:
+        list_prefix_calls.append(prefix)
+        return original_list_prefix(prefix)
+
+    original_exists = fake.exists
+    chunk_exists_calls: list[str] = []
+
+    def _exists_spy(path: str) -> bool:
+        if path.startswith("chunks/"):
+            chunk_exists_calls.append(path)
+        return original_exists(path)
+
+    fake.list_prefix = _list_prefix_spy  # type: ignore[method-assign]
+    fake.exists = _exists_spy  # type: ignore[method-assign]
+
+    mng.push("my-env", env_mng, remote_name="test-ftp")
+
+    # At least one shard was batch-listed.
+    chunk_shard_calls = [
+        p for p in list_prefix_calls if p.startswith("chunks/")
+    ]
+    assert len(chunk_shard_calls) >= 1
+    # No per-chunk exists() round-trips.
+    assert chunk_exists_calls == []
+
+
+@pytest.mark.remote
 def test_push_increments_snapshot_count(tmp_path: pathlib.Path) -> None:
     """index snapshot_count is incremented on each successive push."""
     env_dir = tmp_path / "my-env"


### PR DESCRIPTION
## Summary

- Replace O(N) per-chunk `backend.exists()` in `RemoteMng.push()` with O(unique_shards ≤ 256) `backend.list_prefix()` batch calls
- Buffer all `ChunkResult` objects, call `list_prefix("chunks/<shard>")` once per unique shard prefix, then upload only the delta
- Significant latency improvement on high-latency links (FTP, SFTP) where per-chunk probe cost dominated even when most chunks existed remotely

## Test plan

- [ ] `cd src && pytest -m "not integration" -q` — 507 passed, no regressions
- [ ] `cd src && pytest -m remote -v --no-header --no-cov` — `test_push_batch_shard_check` verifies batch behaviour: at least one `list_prefix` call for a shard prefix, zero per-chunk `exists()` calls
- [ ] `cd src && black src && isort src && pyright` — all clean (enforced by pre-commit hook on commit)

Fixes: #227