### PR TITLE
docs(remote+plugin): document ADR-0006 and remote backend plugin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Plugins can:
 - Provide dynamic command completions
 - Contribute reusable environment templates
 - Define custom service and environment factories
+- Register custom remote storage backends (S3, Azure Blob, and other transports)
 - Extend provisioning logic without modifying core code
 
 This design allows Shepherd to evolve alongside the systems it manages,
@@ -74,6 +75,13 @@ at a specific point in time.
 Once an environment image is pulled and imported into Shepherd, that
 local environment evolves independently for each developer.
 
+### Remote Storage
+
+Environment images can be pushed to and pulled from remote storage using a
+content-deduplicated chunk store — only data that changed since the last push
+is transferred. See [ADR-0006](docs/decisions/0006-remote-storage-deduplication.md)
+for the design rationale and the full list of remote operations.
+
 ## Requirements
 
 ### OS & System Services
@@ -86,6 +94,7 @@ local environment evolves independently for each developer.
 - [Installation guide][install]
 - [Consuming Environment Images][Consuming Environment Images]
 - [Authoring Environment Images][Authoring Environment Images]
+- [Remote storage guide][remote]
 - [shepctl command reference][shepctl]
 - [Development guide][development]
 
@@ -111,6 +120,7 @@ All contributions require signing the [Contributor License Agreement](CLA.md).
 [issues]: https://github.com/MoonyFringers/shepherd/issues
 [Consuming Environment Images]: docs/env-consume.md
 [Authoring Environment Images]: docs/env-auth.md
+[remote]: docs/remote.md
 [shepctl]: docs/shepctl.md
 [development]: docs/development.md
 [install]: docs/install.md

--- a/docs/decisions/0006-remote-storage-deduplication.md
+++ b/docs/decisions/0006-remote-storage-deduplication.md
@@ -150,8 +150,14 @@ delegates to the plugin registry — the same dispatch pattern used by env/svc
 factories.
 
 S3, Azure Blob, and other transports follow as standalone plugin packages.
+See [Plugin-Contributed Remote Backends](../plugins.md#plugin-contributed-remote-backends)
+for the full authoring guide including the `RemoteBackend` contract, a
+worked S3 example, and remote config YAML conventions.
 
 ### Remote Configuration and CLI
+
+See [docs/remote.md](../remote.md) for the full configuration reference,
+built-in transport details, and worked CLI examples.
 
 Remotes are persisted in the main Shepherd config (`~/.shpd.conf`) under a
 top-level `remotes` list. Each entry has a `name`, a `type` (`ftp` or `sftp`

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -108,6 +108,7 @@ capabilities:
   completion: true
   env_factories: true
   svc_factories: true
+  remote_backends: true
 default_config:
   region: eu-west-1
 depends_on:
@@ -374,6 +375,7 @@ The loader builds in-memory registries for:
 - environment factories
 - service factories
 - environment template fragments
+- remote backend transports
 
 Template, factory, and fragment ids are canonicalized under the plugin
 namespace at registration time:
@@ -451,7 +453,7 @@ class MyPlugin(ShepherdPlugin):
         # and in any Click command handler that closes over it.
 ```
 
-`PluginContext` has three fields:
+`PluginContext` has four fields:
 
 - `config: PluginConfigView` — always set; provides read access to
   environments, templates, and plugin metadata.
@@ -459,9 +461,11 @@ class MyPlugin(ShepherdPlugin):
   bootstrap; exposes environment lifecycle operations.
 - `service: PluginServiceView | None` — set after the full CLI bootstrap;
   exposes service operations.
+- `remote: PluginRemoteView | None` — set after the full CLI bootstrap;
+  exposes lightweight index queries for configured remotes.
 
-`environment` and `service` are `None` only during the Click command
-resolution phase (tab completion).  By the time any command handler
+`environment`, `service`, and `remote` are `None` only during the Click
+command resolution phase (tab completion).  By the time any command handler
 executes they are always populated.
 
 ### Available operations
@@ -478,7 +482,9 @@ executes they are always populated.
 `start_svc`, `stop_svc`, `reload_svc`, `logs_svc`, `shell_svc`,
 `render_svc`.
 
-All three are `@runtime_checkable` Protocols satisfied structurally by the
+`PluginRemoteView` exposes: `list_envs`, `list_snapshots`.
+
+All four are `@runtime_checkable` Protocols satisfied structurally by the
 concrete managers — plugin authors can mock them in unit tests without
 any Shepherd-specific fixtures.
 
@@ -489,12 +495,13 @@ below are importable from the `plugin` package.
 
 ### Spec types
 
-| Class                  | Purpose                                         |
-|------------------------|-------------------------------------------------|
-| `PluginCommandSpec`    | Declares a scope + verb + Click command         |
-| `PluginCompletionSpec` | Declares a completion provider for a scope      |
+| Class | Purpose |
+| --- | --- |
+| `PluginCommandSpec` | Declares a scope + verb + Click command |
+| `PluginCompletionSpec` | Declares a completion provider for a scope |
 | `PluginEnvFactorySpec` | Declares an environment factory with a local id |
-| `PluginSvcFactorySpec` | Declares a service factory with a local id      |
+| `PluginSvcFactorySpec` | Declares a service factory with a local id |
+| `PluginRemoteBackendSpec` | Declares a remote transport with a `type_id` |
 
 ### Provider type aliases
 
@@ -512,6 +519,11 @@ below are importable from the `plugin` package.
   **or**
   `Callable[[ConfigMng, ServiceFactory, dict | None],
             EnvironmentFactory]`
+
+`RemoteBackendProvider`
+: `RemoteBackend` instance
+  **or**
+  `Callable[[RemoteCfg], RemoteBackend]`
 
 The most common pattern is to pass the **class** of your factory as the
 provider.  Shepherd instantiates it at runtime with the correct arguments:
@@ -539,11 +551,180 @@ from plugin import (
     PluginCommandSpec,
     PluginCompletionSpec,
     PluginEnvFactorySpec,
+    PluginRemoteBackendSpec,
+    PluginRemoteView,
     PluginSvcFactorySpec,
+    RemoteBackendProvider,
     ShepherdPlugin,
     SvcFactoryProvider,
 )
 ```
+
+## Plugin-Contributed Remote Backends
+
+Plugins can register new remote storage transports — S3, Azure Blob, GCS,
+or any object store with read/write/list semantics — without modifying core
+Shepherd code. For the built-in FTP and SFTP transports, their configuration
+reference and the remote storage layout are documented in
+[docs/remote.md](remote.md).
+
+`RemoteMng._build_backend()` checks the built-in FTP and SFTP transports
+first, then delegates to the plugin registry.  The dispatch pattern is
+identical to the one used for environment and service factories.
+
+### Descriptor capability flag
+
+Declare `remote_backends: true` under `capabilities` in your `plugin.yaml`:
+
+```yaml
+capabilities:
+  remote_backends: true
+```
+
+### Implementing `RemoteBackend`
+
+Subclass `RemoteBackend` (importable from `remote`) and implement its six
+abstract methods:
+
+- **`exists(path: str) -> bool`** — check whether *path* exists.
+- **`upload(path: str, data: bytes) -> None`** — write *data* to *path*,
+  creating parents as needed.
+- **`download(path: str) -> bytes`** — return the full contents of *path*.
+- **`list_prefix(prefix: str) -> list[str]`** — return the leaf names of
+  all objects whose key starts with *prefix/*.
+  Example: `list_prefix("chunks/ab")` → `["ab3f1c9d...", "ab7e2a11..."]`.
+- **`delete(path: str) -> None`** — delete *path* from the remote.
+- **`close() -> None`** — release connections or resources.
+
+`RemoteBackend` provides `__enter__` / `__exit__` so instances can be used
+as context managers — the runtime always opens the backend inside a `with`
+block, so `close()` is guaranteed to be called.
+
+Plugin-specific connection parameters (bucket name, region, access keys,
+etc.) live in the `properties` mapping of `RemoteCfg`.  Core Shepherd does
+not validate this mapping, leaving it entirely to the plugin.
+
+### Registering with `PluginRemoteBackendSpec`
+
+Override `get_remote_backends()` in your plugin class and return one spec
+per transport type:
+
+```python
+from plugin import ShepherdPlugin, PluginRemoteBackendSpec
+from remote import RemoteBackend
+from config.config import RemoteCfg
+
+
+class MyS3Backend(RemoteBackend):
+    def __init__(self, cfg: RemoteCfg) -> None:
+        import boto3  # type: ignore[import]
+        self._client = boto3.client(
+            "s3",
+            region_name=cfg.properties.get("region", "us-east-1"),
+        )
+        self._bucket = cfg.properties["bucket"]
+        self._root = cfg.root_path.rstrip("/")
+
+    def _key(self, path: str) -> str:
+        return f"{self._root}/{path}"
+
+    def exists(self, path: str) -> bool:
+        try:
+            self._client.head_object(Bucket=self._bucket, Key=self._key(path))
+            return True
+        except self._client.exceptions.ClientError:
+            return False
+
+    def upload(self, path: str, data: bytes) -> None:
+        self._client.put_object(
+            Bucket=self._bucket, Key=self._key(path), Body=data
+        )
+
+    def download(self, path: str) -> bytes:
+        resp = self._client.get_object(
+            Bucket=self._bucket, Key=self._key(path)
+        )
+        return resp["Body"].read()
+
+    def list_prefix(self, prefix: str) -> list[str]:
+        paginator = self._client.get_paginator("list_objects_v2")
+        key_prefix = f"{self._root}/{prefix.rstrip('/')}/"
+        results: list[str] = []
+        for page in paginator.paginate(Bucket=self._bucket, Prefix=key_prefix):
+            for obj in page.get("Contents", []):
+                leaf = obj["Key"][len(key_prefix):]
+                if "/" not in leaf and leaf:
+                    results.append(leaf)
+        return results
+
+    def delete(self, path: str) -> None:
+        self._client.delete_object(Bucket=self._bucket, Key=self._key(path))
+
+    def close(self) -> None:
+        pass  # boto3 sessions are stateless
+
+
+class MyS3Plugin(ShepherdPlugin):
+    def get_remote_backends(self):
+        return [PluginRemoteBackendSpec(type_id="s3", provider=MyS3Backend)]
+```
+
+`type_id` is matched against the `type` field of each `remote` entry in
+`~/.shpd.conf`.  It must not collide with the built-in identifiers `"ftp"`
+and `"sftp"` — Shepherd rejects any plugin that tries to claim them.
+
+### Remote config entry for a plugin transport
+
+Once the plugin is installed and enabled, add a remote entry that sets
+`type` to your `type_id` and places plugin-specific parameters in the
+`properties` mapping:
+
+```yaml
+remotes:
+  - name: prod-s3
+    type: s3
+    host: s3.amazonaws.com
+    root_path: /shepherd
+    properties:
+      bucket: my-shepherd-bucket
+      region: eu-west-1
+```
+
+Standard remote fields (`host`, `root_path`, `user`, `password`,
+`identity_file`, chunk tuning, local cache settings) work exactly as they
+do for FTP and SFTP entries.  `${VAR}` placeholders in any field are
+resolved at runtime via the existing `Resolvable` mechanism, so credentials
+do not need to be hard-coded.
+
+### Accessing remote data from a plugin command
+
+`PluginContext.remote` is a `PluginRemoteView` that exposes lightweight
+index queries.  Use it in command handlers to report snapshot state or
+drive cross-remote operations:
+
+```python
+class MyPlugin(ShepherdPlugin):
+    def get_commands(self):
+        import click
+        from plugin import PluginCommandSpec
+
+        @click.command("remote-summary")
+        def remote_summary():
+            """Print a quick summary of the default remote."""
+            remote_cfg, catalogue = self.context.remote.list_envs()
+            for env_name, entry in catalogue.environments.items():
+                click.echo(
+                    f"{env_name}: {entry.snapshot_count} snapshot(s) "
+                    f"on {remote_cfg.name}"
+                )
+
+        return [PluginCommandSpec(scope="remote", verb="remote-summary",
+                                  command=remote_summary)]
+```
+
+`list_envs(remote_name=None)` returns `(RemoteCfg, IndexCatalogue)`.
+`list_snapshots(env_name, remote_name=None)` returns
+`(RemoteCfg, list[SnapshotManifest])`.
 
 ## Example Plugins
 

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -1,0 +1,275 @@
+# Remote Storage
+
+Shepherd can push environment snapshots to a remote storage server and pull
+them back on other machines. Data is transferred as a content-deduplicated
+chunk store — only data that changed since the last push is uploaded. See
+[ADR-0006](decisions/0006-remote-storage-deduplication.md) for the design
+rationale and data model details.
+
+## Remote Storage Layout
+
+Every remote stores its data under a single root directory chosen at
+registration time (`--root-path` / `root_path`). The layout inside that
+root is fixed:
+
+```text
+<root_path>/
+├── index/
+│   └── index.json          # global catalogue — fetch once for discovery
+├── envs/
+│   └── <env-name>/
+│       ├── latest.json     # pointer to the most recent snapshot
+│       └── snapshots/
+│           └── <snapshot-id>.json   # manifest: metadata + chunk list
+└── chunks/
+    ├── ab/                 # first 2 hex chars of the chunk hash
+    │   └── ab3f1c9d...     # individual Zstd-compressed chunk
+    └── ...
+```
+
+Sharding by two-character prefix mirrors git's object store layout and keeps
+any single directory listing to ≤ 256 entries — important for FTP servers
+that degrade with large flat directories.
+
+Shepherd creates all directories automatically on first write. The root path
+itself must exist on the server before the first push.
+
+## Remote Management Commands
+
+### Register a remote
+
+```sh
+# FTP remote
+shepctl remote add prod-ftp --ftp \
+    --host storage.example.com \
+    --user backup \
+    --password "${BACKUP_PWD}" \
+    --root-path /shepherd \
+    --set-default
+
+# SFTP remote — key-based auth (recommended)
+shepctl remote add prod-sftp --sftp \
+    --host storage.example.com \
+    --user deploy \
+    --identity-file ~/.ssh/id_ed25519 \
+    --root-path /backups/shepherd \
+    --set-default
+
+# SFTP remote — password auth
+shepctl remote add dev-sftp --sftp \
+    --host dev.example.com \
+    --user ci \
+    --password "${CI_SFTP_PWD}" \
+    --root-path /ci/shepherd
+```
+
+Other remote management commands:
+
+```sh
+# List all registered remotes
+shepctl remote list
+
+# Inspect snapshots available for an env on a remote
+shepctl remote get <env-tag> [--remote=<name>]
+
+# Remove orphan chunks (chunks not referenced by any manifest)
+shepctl remote prune [--remote=<name>] [--dry-run]
+
+# Unregister a remote (does not delete data on the server)
+shepctl remote delete <name>
+```
+
+### Environment data commands
+
+```sh
+# Create a new remote snapshot from the local env
+shepctl env push [env-tag] [--remote=<name>] \
+    [--set-tracking-remote] [--labels=k=v ...]
+
+# First-time download — env not yet registered locally
+shepctl env pull [env-tag] [--remote=<name>] [--snapshot-id=<id>]
+
+# Restore data for an already-registered dehydrated env
+shepctl env hydrate [env-tag] [--remote=<name>] [--snapshot-id=<id>]
+
+# Strip local data, keep config entry (inverse of hydrate)
+shepctl env dehydrate [env-tag]
+```
+
+State transitions:
+
+```text
+[remote snapshot]
+      │
+      │  env pull    (env unknown locally → creates config + data)
+      ▼
+[local, hydrated] ──── env dehydrate ────► [local, dehydrated]
+      ▲                                             │
+      └──────────── env hydrate ────────────────────┘
+```
+
+## Built-in Transports
+
+### FTP
+
+Use FTP on trusted private networks (local NAS, VPN-protected servers) where
+encryption in transit is not required. For anything internet-facing, prefer
+SFTP.
+
+#### CLI
+
+```sh
+shepctl remote add my-ftp --ftp \
+    --host 192.168.1.10 \
+    --user shepherd \
+    --password "${FTP_PASSWORD}" \
+    --root-path /srv/shepherd \
+    --set-default
+```
+
+`--host`, `--user`, `--password`, and `--root-path` are required for FTP.
+`--port` is optional and defaults to `21`.
+
+#### Config YAML
+
+```yaml
+remotes:
+  - name: my-ftp
+    type: ftp
+    host: 192.168.1.10
+    port: 21               # optional; default 21
+    user: shepherd
+    password: "${FTP_PASSWORD}"
+    root_path: /srv/shepherd
+    default: true          # optional; marks as the default remote
+```
+
+#### Notes
+
+- Uses Python's stdlib `ftplib` — no additional dependencies.
+- Always operates in passive mode (PASV).
+- Existence checks use a single `NLST` listing per 2-char shard directory,
+  cached for the lifetime of the backend connection. This avoids one
+  round-trip per chunk during deduplication checks.
+- Data is **not encrypted in transit**. Use only on private, trusted
+  networks.
+
+---
+
+### SFTP
+
+SFTP is the recommended built-in transport for most real deployments. It
+provides SSH-level encryption and supports both key and password
+authentication.
+
+#### CLI — key-based auth (recommended)
+
+```sh
+shepctl remote add my-sftp --sftp \
+    --host storage.example.com \
+    --user deploy \
+    --identity-file ~/.ssh/id_ed25519 \
+    --root-path /srv/shepherd \
+    --set-default
+```
+
+#### CLI — password auth
+
+```sh
+shepctl remote add my-sftp --sftp \
+    --host storage.example.com \
+    --user deploy \
+    --password "${SFTP_PASSWORD}" \
+    --root-path /srv/shepherd
+```
+
+`--identity-file` takes precedence over `--password` when both are given.
+At least one of the two must be provided.
+
+#### Config YAML (SFTP)
+
+```yaml
+remotes:
+  - name: my-sftp
+    type: sftp
+    host: storage.example.com
+    port: 22                          # optional; default 22
+    user: deploy
+    identity_file: ~/.ssh/id_ed25519  # takes precedence over password
+    # password: "${SFTP_PASSWORD}"    # alternative when no key is available
+    root_path: /srv/shepherd
+    default: true
+```
+
+#### SFTP Notes
+
+- Uses [`paramiko`](https://www.paramiko.org/). Supports Ed25519, ECDSA, and
+  RSA private keys; key type is auto-detected at load time.
+- `${VAR}` placeholders in `password` and `identity_file` are resolved from
+  environment variables at runtime — credentials are never stored in their
+  resolved form in `~/.shpd.conf`.
+- When both `identity_file` and `password` are present, `identity_file`
+  wins.
+
+---
+
+## Advanced: Chunk Tuning
+
+The default FastCDC parameters work well for most environments. Override them
+per remote when snapshots are consistently much smaller or larger than the
+defaults:
+
+```yaml
+remotes:
+  - name: my-sftp
+    type: sftp
+    # ... connection fields ...
+    chunk:
+      min_size_kb: 512    # default 512 KB
+      avg_size_kb: 2048   # default 2 MB
+      max_size_kb: 8192   # default 8 MB
+```
+
+Smaller chunks improve deduplication granularity at the cost of more objects
+on the remote and higher manifest overhead. Larger chunks reduce file count
+and suit bulk transfers on fast links. The constraint `min ≤ avg ≤ max` must
+hold.
+
+## Advanced: Local Chunk Cache
+
+A local on-disk LRU cache avoids re-downloading chunks that were recently
+pulled. Enable it per remote in `~/.shpd.conf`:
+
+```yaml
+remotes:
+  - name: my-sftp
+    type: sftp
+    # ... connection fields ...
+    local_cache:
+      path: /tmp/shepherd-cache   # directory for cached chunk bytes
+      max_size_gb: 20             # default 20 GB; evicts LRU when exceeded
+```
+
+The cache is transparent — Shepherd checks it before downloading from the
+remote and populates it on every download.
+
+## Credential Security
+
+All string fields in a remote config entry support `${VAR_NAME}` placeholders
+resolved from environment variables at runtime:
+
+```yaml
+password: "${SHEPHERD_FTP_PASSWORD}"
+identity_file: "${HOME}/.ssh/shepherd_ed25519"
+```
+
+Values are never written back to disk in their resolved form. This keeps
+credentials out of `~/.shpd.conf` and allows the same config file to be
+shared across machines with different secrets.
+
+## Custom Transports
+
+Additional transports (S3, Azure Blob, GCS, and others) can be added as
+Shepherd plugins without modifying core code. See
+[Plugin-Contributed Remote Backends](plugins.md#plugin-contributed-remote-backends)
+for the full authoring guide.

--- a/src/plugin/__init__.py
+++ b/src/plugin/__init__.py
@@ -24,6 +24,7 @@ from .context import (
     PluginConfigView,
     PluginContext,
     PluginEnvironmentView,
+    PluginRemoteView,
     PluginServiceView,
 )
 from .plugin import PluginMng
@@ -47,6 +48,7 @@ __all__ = [
     "PluginMng",
     "PluginRegistry",
     "PluginRemoteBackendSpec",
+    "PluginRemoteView",
     "PluginRuntimeMng",
     "PluginServiceView",
     "PluginSvcFactorySpec",

--- a/src/plugin/context.py
+++ b/src/plugin/context.py
@@ -238,14 +238,14 @@ class PluginContext:
 
     Shepherd creates one ``PluginContext`` per plugin and passes it to
     :meth:`ShepherdPlugin.__init__`.  Plugin code stores it and accesses
-    managers through the three typed view properties.
+    managers through the four typed view properties.
 
     ``config`` is always populated.
 
     ``environment``, ``service``, and ``remote`` are ``None`` during the Click
     command resolution phase (tab completion) and are set to the live managers
     once the full CLI bootstrap completes.  Plugin command handlers run after
-    the full bootstrap, so by the time any handler executes, all three fields
+    the full bootstrap, so by the time any handler executes, all four fields
     are available.
     """
 


### PR DESCRIPTION
## Summary

- **ADR-0006** (`docs/decisions/0006-remote-storage-deduplication.md`):
  already written; adds cross-references to both the new plugin authoring
  guide and the new remote configuration guide.

- **`docs/remote.md`** (new file) — user-facing reference for remote storage:
  - Remote storage layout on the server (directory tree, file roles)
  - All `shepctl remote` and `shepctl env` commands with examples
  - Pull/dehydrate/hydrate state machine diagram
  - **FTP**: CLI flags, config YAML, field descriptions, passive-mode and
    shard-cache implementation notes, encryption warning
  - **SFTP**: CLI flags (key-based and password auth), config YAML, key-type
    support (Ed25519/ECDSA/RSA), `${VAR}` placeholder resolution
  - Advanced: chunk tuning (`min/avg/max_size_kb`) with rationale
  - Advanced: local chunk cache (`path`, `max_size_gb`)
  - Credential security: `${VAR}` placeholders and runtime resolution
  - Link to plugin authoring guide for custom transports

- **`docs/plugins.md`** — fills all gaps for the `remote_backends` plugin
  extension point (implemented but undocumented):
  - Runtime Registries: `remote backend transports` added to the list
  - Plugin descriptor capabilities example: `remote_backends: true`
  - Plugin Context: four fields instead of three; `remote: PluginRemoteView | None`
    documented with null-during-completion semantics
  - Available operations: `PluginRemoteView` (`list_envs`, `list_snapshots`)
  - Plugin API Types table: `PluginRemoteBackendSpec` row added
  - Provider type aliases: `RemoteBackendProvider` added
  - **New section** "Plugin-Contributed Remote Backends": dispatch overview,
    `RemoteBackend` ABC contract, `cfg.properties` convention, complete S3
    worked example, remote config YAML, collision rules; cross-reference to
    `docs/remote.md` for built-in transport comparison
  - Quick import reference: `PluginRemoteBackendSpec`, `RemoteBackendProvider`,
    `PluginRemoteView` added

- **`src/plugin/__init__.py`**: `PluginRemoteView` was missing from `__all__`
  and from the public re-exports — the other three view types were already
  exported. Fixed as part of this docs pass.

- **`README.md`**:
  - "Plugins can:" list: "Register custom remote storage backends"
  - Key Concepts: brief "Remote Storage" subsection with ADR link
  - Documentation section: link to `docs/remote.md`

## Test plan

- [ ] `pre-commit run --all-files` — all hooks pass (markdownlint, black,
  isort, flake8, pyright)
- [ ] `cd src && pytest` — full suite passes (only `__init__.py` export
  addition, no logic changes)
- [ ] Manual: all cross-reference links resolve; code blocks in `remote.md`
  render correctly; `from plugin import PluginRemoteView` works at the REPL

Fixes: #230