### PR TITLE
feat(remote): add --anon flag for anonymous FTP login

### DIFF
--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -148,6 +148,7 @@ class CompletionMng(AbstractCompletionMng):
             OptionSpec(tokens=("--sftp",)),
             OptionSpec(tokens=("--host",), takes_value=True),
             OptionSpec(tokens=("--user",), takes_value=True),
+            OptionSpec(tokens=("--anon",)),
             OptionSpec(tokens=("--port",), takes_value=True),
             OptionSpec(tokens=("--password",), takes_value=True),
             OptionSpec(tokens=("--root-path",), takes_value=True),

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -982,7 +982,13 @@ def remote():
     "--sftp", "backend_type", flag_value="sftp", help="SFTP transport."
 )
 @click.option("--host", required=True, help="Remote server hostname.")
-@click.option("--user", required=True, help="Login username.")
+@click.option("--user", default=None, help="Login username.")
+@click.option(
+    "--anon",
+    is_flag=True,
+    default=False,
+    help="Use anonymous FTP login (FTP only).",
+)
 @click.option(
     "--port",
     type=int,
@@ -1016,7 +1022,8 @@ def add_remote(
     name: str,
     backend_type: Optional[str],
     host: str,
-    user: str,
+    user: Optional[str],
+    anon: bool,
     port: Optional[int],
     password: Optional[str],
     identity_file: Optional[str],
@@ -1026,8 +1033,20 @@ def add_remote(
     """Register a new remote storage backend."""
     if not backend_type:
         raise click.UsageError("Specify a transport with --ftp or --sftp.")
-    if backend_type == "ftp" and not password:
-        raise click.UsageError("FTP remotes require --password.")
+    if anon and backend_type != "ftp":
+        raise click.UsageError("--anon is only valid for FTP remotes.")
+    if backend_type == "ftp":
+        if anon and (user or password):
+            raise click.UsageError(
+                "--anon cannot be combined with --user or --password."
+            )
+        if not anon and not (user and password):
+            raise click.UsageError(
+                "FTP remotes require --user and --password, or --anon."
+            )
+        if anon:
+            user = "anonymous"
+            password = ""
     if backend_type == "sftp" and not password and not identity_file:
         raise click.UsageError(
             "SFTP remotes require --password or --identity-file."

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -1441,6 +1441,157 @@ def test_cli_remote_add_ftp(
 
 
 @pytest.mark.shpd
+def test_cli_remote_add_ftp_anon(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+) -> None:
+    """'remote add --ftp --anon' registers an anonymous FTP remote."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_yaml.write_text(read_fixture("shpd", "shpd.yaml"))
+
+    result = runner.invoke(
+        cli,
+        [
+            "remote",
+            "add",
+            "anon-ftp",
+            "--ftp",
+            "--anon",
+            "--host",
+            "nas2.test.test",
+            "--root-path",
+            "/ftp/shpdng",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Remote 'anon-ftp' registered." in result.output
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    remotes = stored.get("remotes", [])
+    anon_remote = next((r for r in remotes if r["name"] == "anon-ftp"), None)
+    assert anon_remote is not None
+    assert anon_remote["type"] == "ftp"
+    assert anon_remote["user"] == "anonymous"
+    assert not anon_remote.get("password")
+
+
+@pytest.mark.shpd
+def test_cli_remote_add_ftp_anon_rejects_user(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+) -> None:
+    """'remote add --ftp --anon --user' is rejected as a usage error."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    (shpd_path / ".shpd.yaml").write_text(read_fixture("shpd", "shpd.yaml"))
+
+    result = runner.invoke(
+        cli,
+        [
+            "remote",
+            "add",
+            "bad-ftp",
+            "--ftp",
+            "--anon",
+            "--host",
+            "nas2.test.test",
+            "--user",
+            "alice",
+            "--root-path",
+            "/ftp/shpdng",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--anon" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_remote_add_ftp_anon_rejects_password(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+) -> None:
+    """'remote add --ftp --anon --password' is rejected as a usage error."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    (shpd_path / ".shpd.yaml").write_text(read_fixture("shpd", "shpd.yaml"))
+
+    result = runner.invoke(
+        cli,
+        [
+            "remote",
+            "add",
+            "bad-ftp",
+            "--ftp",
+            "--anon",
+            "--host",
+            "nas2.test.test",
+            "--password",
+            "s3cr3t",
+            "--root-path",
+            "/ftp/shpdng",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--anon" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_remote_add_ftp_missing_creds(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+) -> None:
+    """'remote add --ftp' without credentials or --anon is rejected."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    (shpd_path / ".shpd.yaml").write_text(read_fixture("shpd", "shpd.yaml"))
+
+    result = runner.invoke(
+        cli,
+        [
+            "remote",
+            "add",
+            "bad-ftp",
+            "--ftp",
+            "--host",
+            "ftp.example.com",
+            "--root-path",
+            "/shpd",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--anon" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_remote_add_sftp_rejects_anon(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+) -> None:
+    """'remote add --sftp --anon' is rejected as a usage error."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    (shpd_path / ".shpd.yaml").write_text(read_fixture("shpd", "shpd.yaml"))
+
+    result = runner.invoke(
+        cli,
+        [
+            "remote",
+            "add",
+            "bad-sftp",
+            "--sftp",
+            "--anon",
+            "--host",
+            "sftp.example.com",
+            "--root-path",
+            "/shpd",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--anon" in result.output
+
+
+@pytest.mark.shpd
 def test_cli_remote_add_sftp(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ) -> None:
@@ -1772,7 +1923,9 @@ def test_cli_remote_add_ftp_missing_password(
     )
 
     assert result.exit_code != 0
-    assert "FTP remotes require --password" in result.output
+    assert (
+        "FTP remotes require --user and --password, or --anon" in result.output
+    )
 
 
 @pytest.mark.shpd


### PR DESCRIPTION
Add an --anon flag to `remote add --ftp` for anonymous FTPs. Combining --anon with --user or --password is rejected as a usage error.
Non-anonymous FTP continues to require both --user and --password.
The completion spec is updated.

Fixes: #238

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
to change)
- [ ] Change or update to the documentation (with no functional changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Contributor License Agreement
<!--- All contributors must sign the CLA before this PR can be merged. -->
<!--- The CLA Assistant bot will post instructions if you have not yet signed. -->
- [ ] I have signed the [Contributor License Agreement](../CLA.md)
      (or I will follow the CLA Assistant bot instructions posted in this PR).
