### PR TITLE
Make ENV_TAG optional for pull/push/hydrate/dehydrate

### DIFF
--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -548,8 +548,19 @@ def status_env(
     shepherd.environmentMng.status_env(envCfg, watch=watch)
 
 
+def _resolve_env_tag(shepherd: ShepherdMng, env_tag: Optional[str]) -> str:
+    if env_tag:
+        return env_tag
+    active = shepherd.configMng.get_active_environment()
+    if not active:
+        raise click.UsageError(
+            "No environment checked out. Pass ENV_TAG explicitly."
+        )
+    return active.tag
+
+
 @env.command(name="push")
-@click.argument("env_tag")
+@click.argument("env_tag", required=False)
 @click.option(
     "--remote",
     "remote_name",
@@ -571,12 +582,13 @@ def status_env(
 @click.pass_obj
 def push_env(
     shepherd: ShepherdMng,
-    env_tag: str,
+    env_tag: Optional[str],
     remote_name: Optional[str],
     set_tracking: bool,
     labels: Optional[str],
 ) -> None:
-    """Push a new snapshot of ENV_TAG to a remote."""
+    """Push a new snapshot of ENV_TAG (or the checked-out env) to a remote."""
+    env_tag = _resolve_env_tag(shepherd, env_tag)
     label_list = [lbl.strip() for lbl in labels.split(",")] if labels else []
     shepherd.remoteMng.push(
         env_name=env_tag,
@@ -588,15 +600,16 @@ def push_env(
 
 
 @env.command(name="dehydrate")
-@click.argument("env_tag")
+@click.argument("env_tag", required=False)
 @click.pass_obj
-def dehydrate_env(shepherd: ShepherdMng, env_tag: str) -> None:
-    """Strip local data for ENV_TAG while preserving its config entry."""
+def dehydrate_env(shepherd: ShepherdMng, env_tag: Optional[str]) -> None:
+    """Strip local data for ENV_TAG (or the checked-out env)."""
+    env_tag = _resolve_env_tag(shepherd, env_tag)
     shepherd.remoteMng.dehydrate(env_tag, shepherd.environmentMng)
 
 
 @env.command(name="pull")
-@click.argument("env_tag")
+@click.argument("env_tag", required=False)
 @click.option(
     "--remote",
     "remote_name",
@@ -611,11 +624,12 @@ def dehydrate_env(shepherd: ShepherdMng, env_tag: str) -> None:
 @click.pass_obj
 def pull_env(
     shepherd: ShepherdMng,
-    env_tag: str,
+    env_tag: Optional[str],
     remote_name: Optional[str],
     snapshot_id: Optional[str],
 ) -> None:
-    """Download ENV_TAG from a remote snapshot and register it locally."""
+    """Download ENV_TAG (or the checked-out env) from a remote snapshot."""
+    env_tag = _resolve_env_tag(shepherd, env_tag)
     shepherd.remoteMng.pull(
         env_name=env_tag,
         remote_name=remote_name,
@@ -624,7 +638,7 @@ def pull_env(
 
 
 @env.command(name="hydrate")
-@click.argument("env_tag")
+@click.argument("env_tag", required=False)
 @click.option(
     "--remote",
     "remote_name",
@@ -639,11 +653,12 @@ def pull_env(
 @click.pass_obj
 def hydrate_env(
     shepherd: ShepherdMng,
-    env_tag: str,
+    env_tag: Optional[str],
     remote_name: Optional[str],
     snapshot_id: Optional[str],
 ) -> None:
-    """Restore local data for the dehydrated ENV_TAG from a remote snapshot."""
+    """Restore local data for ENV_TAG (or the checked-out env) from a remote."""
+    env_tag = _resolve_env_tag(shepherd, env_tag)
     shepherd.remoteMng.hydrate(
         env_name=env_tag,
         remote_name=remote_name,

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -1955,3 +1955,141 @@ def test_cli_remote_add_sftp_missing_credentials(
 
     assert result.exit_code != 0
     assert "SFTP remotes require --password or --identity-file" in result.output
+
+
+# ------------------------------------------------------------------
+# env push / pull / hydrate / dehydrate — default to checked-out env
+# ------------------------------------------------------------------
+
+
+@pytest.mark.shpd
+def test_cli_env_push_defaults_to_active_env(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'env push' without ENV_TAG pushes the checked-out environment."""
+    from remote import RemoteMng
+
+    _setup_remote(shpd_conf)
+    mock_push = mocker.patch.object(RemoteMng, "push")
+
+    result = runner.invoke(cli, ["env", "push"])
+
+    assert result.exit_code == 0, result.output
+    mock_push.assert_called_once()
+    assert mock_push.call_args.kwargs["env_name"] == "test-1"
+
+
+@pytest.mark.shpd
+def test_cli_env_push_no_active_env_error(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'env push' without ENV_TAG and no checked-out env fails."""
+    from config import ConfigMng
+
+    _setup_remote(shpd_conf)
+    mocker.patch.object(ConfigMng, "get_active_environment", return_value=None)
+
+    result = runner.invoke(cli, ["env", "push"])
+
+    assert result.exit_code != 0
+    assert "No environment checked out" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_env_dehydrate_defaults_to_active_env(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'env dehydrate' without ENV_TAG dehydrates the checked-out environment."""
+    from remote import RemoteMng
+
+    _setup_remote(shpd_conf)
+    mock_dehydrate = mocker.patch.object(RemoteMng, "dehydrate")
+
+    result = runner.invoke(cli, ["env", "dehydrate"])
+
+    assert result.exit_code == 0, result.output
+    mock_dehydrate.assert_called_once()
+    # dehydrate takes env_tag as a positional arg, not keyword
+    assert mock_dehydrate.call_args.args[0] == "test-1"
+
+
+@pytest.mark.shpd
+def test_cli_env_dehydrate_no_active_env_error(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'env dehydrate' without ENV_TAG and no checked-out env fails."""
+    from config import ConfigMng
+
+    _setup_remote(shpd_conf)
+    mocker.patch.object(ConfigMng, "get_active_environment", return_value=None)
+
+    result = runner.invoke(cli, ["env", "dehydrate"])
+
+    assert result.exit_code != 0
+    assert "No environment checked out" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_env_pull_defaults_to_active_env(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'env pull' without ENV_TAG pulls the checked-out environment."""
+    from remote import RemoteMng
+
+    _setup_remote(shpd_conf)
+    mock_pull = mocker.patch.object(RemoteMng, "pull")
+
+    result = runner.invoke(cli, ["env", "pull"])
+
+    assert result.exit_code == 0, result.output
+    mock_pull.assert_called_once()
+    assert mock_pull.call_args.kwargs["env_name"] == "test-1"
+
+
+@pytest.mark.shpd
+def test_cli_env_pull_no_active_env_error(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'env pull' without ENV_TAG and no checked-out env fails."""
+    from config import ConfigMng
+
+    _setup_remote(shpd_conf)
+    mocker.patch.object(ConfigMng, "get_active_environment", return_value=None)
+
+    result = runner.invoke(cli, ["env", "pull"])
+
+    assert result.exit_code != 0
+    assert "No environment checked out" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_env_hydrate_defaults_to_active_env(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'env hydrate' without ENV_TAG hydrates the checked-out environment."""
+    from remote import RemoteMng
+
+    _setup_remote(shpd_conf)
+    mock_hydrate = mocker.patch.object(RemoteMng, "hydrate")
+
+    result = runner.invoke(cli, ["env", "hydrate"])
+
+    assert result.exit_code == 0, result.output
+    mock_hydrate.assert_called_once()
+    assert mock_hydrate.call_args.kwargs["env_name"] == "test-1"
+
+
+@pytest.mark.shpd
+def test_cli_env_hydrate_no_active_env_error(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'env hydrate' without ENV_TAG and no checked-out env fails."""
+    from config import ConfigMng
+
+    _setup_remote(shpd_conf)
+    mocker.patch.object(ConfigMng, "get_active_environment", return_value=None)
+
+    result = runner.invoke(cli, ["env", "hydrate"])
+
+    assert result.exit_code != 0
+    assert "No environment checked out" in result.output


### PR DESCRIPTION
Make the ENV_TAG argument optional for:
- env push
- env pull
- env hydrate
- env dehydrate

When omitted, the command resolves to the currently checked-out environment.
If no environment is checked out a UsageError is raised.

Fixes: #239

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
to change)
- [ ] Change or update to the documentation (with no functional changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Contributor License Agreement
<!--- All contributors must sign the CLA before this PR can be merged. -->
<!--- The CLA Assistant bot will post instructions if you have not yet signed. -->
- [ ] I have signed the [Contributor License Agreement](../CLA.md)
      (or I will follow the CLA Assistant bot instructions posted in this PR).
