### PR TITLE
feat(remote): add modify subcommand to update existing remotes

### DIFF
--- a/src/completion/completion.py
+++ b/src/completion/completion.py
@@ -58,7 +58,7 @@ class CompletionMng(AbstractCompletionMng):
         ],
         "svc": ["get", "add", "up", "halt", "reload", "build", "logs", "shell"],
         "probe": ["get", "check"],
-        "remote": ["add", "list", "delete", "envs", "get", "prune"],
+        "remote": ["add", "list", "delete", "modify", "envs", "get", "prune"],
     }
     SCOPE_VERBS = CORE_SCOPE_VERBS
 
@@ -153,6 +153,16 @@ class CompletionMng(AbstractCompletionMng):
             OptionSpec(tokens=("--password",), takes_value=True),
             OptionSpec(tokens=("--root-path",), takes_value=True),
             OptionSpec(tokens=("--identity-file",), takes_value=True),
+            OptionSpec(tokens=("--set-default",)),
+        ),
+        ("remote", "modify"): (
+            OptionSpec(tokens=("--host",), takes_value=True),
+            OptionSpec(tokens=("--port",), takes_value=True),
+            OptionSpec(tokens=("--user",), takes_value=True),
+            OptionSpec(tokens=("--password",), takes_value=True),
+            OptionSpec(tokens=("--anon",)),
+            OptionSpec(tokens=("--identity-file",), takes_value=True),
+            OptionSpec(tokens=("--root-path",), takes_value=True),
             OptionSpec(tokens=("--set-default",)),
         ),
         ("remote", "envs"): (

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1837,6 +1837,27 @@ class ConfigMng:
         self.config.remotes = remotes
         self.store()
 
+    def update_remote(self, name: str, **updates: Any) -> None:
+        """Update fields of an existing remote and persist the config.
+
+        :raises ValueError: If no remote with the given name exists.
+        """
+        remotes = list(self.config.remotes or [])
+        target = next((r for r in remotes if r.name == name), None)
+        if target is None:
+            raise ValueError(f"Remote '{name}' does not exist.")
+        if updates.get("default") == "true":
+            for r in remotes:
+                r.default = "false"
+        valid_keys = {f.name for f in fields(target)}
+        for key, val in updates.items():
+            if key not in valid_keys:
+                raise ValueError(f"Unknown field '{key}' for RemoteCfg.")
+            if val is not None:
+                setattr(target, key, val)
+        self.config.remotes = remotes
+        self.store()
+
     def remove_remote(self, name: str) -> None:
         """Remove a remote entry by name and persist the config."""
         if self.config.remotes:

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -1102,6 +1102,76 @@ def delete_remote(shepherd: ShepherdMng, name: str) -> None:
     Util.print(f"Remote '{name}' removed.")
 
 
+@remote.command(name="modify")
+@click.argument("name", required=True)
+@click.option("--host", default=None, help="New hostname or IP address.")
+@click.option("--port", type=int, default=None, help="New port number.")
+@click.option("--user", default=None, help="New username.")
+@click.option("--password", default=None, help="New password.")
+@click.option(
+    "--anon",
+    is_flag=True,
+    default=False,
+    help="Switch FTP remote to anonymous login.",
+)
+@click.option(
+    "--identity-file",
+    default=None,
+    help="New path to SSH identity file (SFTP only).",
+)
+@click.option("--root-path", default=None, help="New root path on remote.")
+@click.option(
+    "--set-default",
+    is_flag=True,
+    default=False,
+    help="Mark this remote as the default.",
+)
+@click.pass_obj
+def modify_remote(
+    shepherd: ShepherdMng,
+    name: str,
+    host: Optional[str],
+    port: Optional[int],
+    user: Optional[str],
+    password: Optional[str],
+    anon: bool,
+    identity_file: Optional[str],
+    root_path: Optional[str],
+    set_default: bool,
+) -> None:
+    """Modify an existing remote storage backend."""
+    if anon and (user or password):
+        raise click.UsageError(
+            "--anon cannot be combined with --user or --password."
+        )
+    updates: dict[str, Any] = {}
+    if host:
+        updates["host"] = host
+    if port is not None:
+        updates["port"] = port
+    if anon:
+        updates["user"] = "anonymous"
+        updates["password"] = ""
+    else:
+        if user:
+            updates["user"] = user
+        if password:
+            updates["password"] = password
+    if identity_file:
+        updates["identity_file"] = identity_file
+    if root_path:
+        updates["root_path"] = root_path
+    if set_default:
+        updates["default"] = "true"
+    if not updates:
+        raise click.UsageError("No modifications specified.")
+    try:
+        shepherd.configMng.update_remote(name, **updates)
+    except ValueError as e:
+        raise click.UsageError(str(e))
+    Util.print(f"Remote '{name}' updated.")
+
+
 @remote.command(name="envs")
 @click.option(
     "--remote",

--- a/src/tests/test_completion.py
+++ b/src/tests/test_completion.py
@@ -1480,7 +1480,15 @@ def test_completion_remote_verbs(
     """Completing 'remote' returns the expected verb list."""
     sm = ShepherdMng(load_runtime_plugins=False)
     completions = sm.completionMng.get_completions(["remote"])
-    assert completions == ["add", "list", "delete", "envs", "get", "prune"]
+    assert completions == [
+        "add",
+        "list",
+        "delete",
+        "modify",
+        "envs",
+        "get",
+        "prune",
+    ]
 
 
 @pytest.mark.compl

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -1788,6 +1788,126 @@ def test_cli_remote_delete_missing(
 
 
 # ------------------------------------------------------------------
+# remote modify
+# ------------------------------------------------------------------
+
+
+@pytest.mark.shpd
+def test_cli_remote_modify_host(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+) -> None:
+    """'remote modify --host' updates the host field and leaves others."""
+    shpd_yaml = _setup_remote(shpd_conf)
+
+    result = runner.invoke(
+        cli, ["remote", "modify", "sftp-backup", "--host", "new.host.com"]
+    )
+
+    assert result.exit_code == 0
+    assert "Remote 'sftp-backup' updated." in result.output
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    remote = next(r for r in stored["remotes"] if r["name"] == "sftp-backup")
+    assert remote["host"] == "new.host.com"
+    ftp = next(r for r in stored["remotes"] if r["name"] == "ftp-prod")
+    assert ftp["host"] == "ftp.example.com"
+
+
+@pytest.mark.shpd
+def test_cli_remote_modify_set_default(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+) -> None:
+    """'remote modify --set-default' promotes a remote and demotes the old one."""
+    shpd_yaml = _setup_remote(shpd_conf)
+
+    result = runner.invoke(
+        cli, ["remote", "modify", "sftp-backup", "--set-default"]
+    )
+
+    assert result.exit_code == 0
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    sftp = next(r for r in stored["remotes"] if r["name"] == "sftp-backup")
+    ftp = next(r for r in stored["remotes"] if r["name"] == "ftp-prod")
+    assert sftp["default"] is True
+    assert ftp["default"] is False
+
+
+@pytest.mark.shpd
+def test_cli_remote_modify_set_default_already_default(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+) -> None:
+    """'remote modify --set-default' on an already-default remote is a no-op."""
+    shpd_yaml = _setup_remote(shpd_conf)
+
+    result = runner.invoke(
+        cli, ["remote", "modify", "ftp-prod", "--set-default"]
+    )
+
+    assert result.exit_code == 0
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    ftp = next(r for r in stored["remotes"] if r["name"] == "ftp-prod")
+    assert ftp["default"] is True
+
+
+@pytest.mark.shpd
+def test_cli_remote_modify_no_flags(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+) -> None:
+    """'remote modify' with no modifying flags is rejected as a usage error."""
+    _setup_remote(shpd_conf)
+
+    result = runner.invoke(cli, ["remote", "modify", "ftp-prod"])
+
+    assert result.exit_code != 0
+    assert "No modifications specified" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_remote_modify_unknown_name(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+) -> None:
+    """'remote modify' on an unknown remote name fails with a usage error."""
+    _setup_remote(shpd_conf)
+
+    result = runner.invoke(
+        cli, ["remote", "modify", "does-not-exist", "--host", "h"]
+    )
+
+    assert result.exit_code != 0
+    assert "does not exist" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_remote_modify_anon_switches_ftp_to_anonymous(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+) -> None:
+    """'remote modify --anon' sets user=anonymous and clears password."""
+    shpd_yaml = _setup_remote(shpd_conf)
+
+    result = runner.invoke(cli, ["remote", "modify", "ftp-prod", "--anon"])
+
+    assert result.exit_code == 0, result.output
+    stored = yaml.safe_load(shpd_yaml.read_text())
+    ftp = next(r for r in stored["remotes"] if r["name"] == "ftp-prod")
+    assert ftp["user"] == "anonymous"
+    assert not ftp.get("password")
+
+
+@pytest.mark.shpd
+def test_cli_remote_modify_anon_rejects_user(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+) -> None:
+    """'remote modify --anon --user' is rejected as a usage error."""
+    _setup_remote(shpd_conf)
+
+    result = runner.invoke(
+        cli, ["remote", "modify", "ftp-prod", "--anon", "--user", "alice"]
+    )
+
+    assert result.exit_code != 0
+    assert "--anon" in result.output
+
+
+# ------------------------------------------------------------------
 # remote envs
 # ------------------------------------------------------------------
 


### PR DESCRIPTION
Added `remote modify <name>` so that any mutable field of a registered remote can be updated.

New public API: `ConfigMng.update_remote(name, **updates)`.

Fixes: #240

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
to change)
- [ ] Change or update to the documentation (with no functional changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Contributor License Agreement
<!--- All contributors must sign the CLA before this PR can be merged. -->
<!--- The CLA Assistant bot will post instructions if you have not yet signed. -->
- [ ] I have signed the [Contributor License Agreement](../CLA.md)
      (or I will follow the CLA Assistant bot instructions posted in this PR).
