### PR TITLE
fix(remote,storage): pre-check all permissions and obtain sudo consent

### DIFF
--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import subprocess
 import time
 from typing import IO, Any, Optional, cast, override
@@ -98,13 +97,39 @@ class DockerComposeEnv(Environment):
                         )
 
     @override
-    def get_volume_tar_streams(self) -> list[tuple[str, IO[bytes]]]:
+    def volumes_need_elevated_permissions(self) -> bool:
+        """Return True if any bind-mount volume path requires sudo to archive.
+
+        Uses a recursive ``os.walk`` check (same approach as
+        ``TarStreamProducer._is_env_readable``) so that directories whose
+        root is accessible but whose contents are owned by a container user
+        (e.g. a postgres data directory) are correctly detected.  Docker
+        named/external volumes are excluded — they are streamed via a
+        ``docker run`` container, so host-side permission checks do not apply.
+        """
+        for vol in self.envCfg.volumes or []:
+            if (
+                vol.driver == "local"
+                and vol.driver_opts
+                and vol.driver_opts.get("type") == "none"
+                and vol.driver_opts.get("o") == "bind"
+            ):
+                device = vol.driver_opts.get("device", "")
+                if device and not self._is_path_tree_readable(device):
+                    return True
+        return False
+
+    @override
+    def get_volume_tar_streams(
+        self, allow_sudo: bool = False
+    ) -> list[tuple[str, IO[bytes]]]:
         """Return one ``(volume_tag, tar_stream)`` pair per volume.
 
-        Bind-mounts are streamed directly from the host path (sudo when the
-        path is not readable by the current process).  Named and external
-        volumes are streamed via a temporary ``docker run`` container so no
-        knowledge of Docker's internal volume storage layout is required.
+        Bind-mounts are streamed directly from the host path (sudo only when
+        ``allow_sudo=True`` *and* the path is not fully readable by the
+        current process).  Named and external volumes are streamed via a
+        temporary ``docker run`` container so no knowledge of Docker's
+        internal volume storage layout is required.
         """
         if not self.envCfg.volumes:
             return []
@@ -117,7 +142,9 @@ class DockerComposeEnv(Environment):
                 and vol.driver_opts.get("o") == "bind"
             ):
                 device = vol.driver_opts.get("device", "")
-                result.append((vol.tag, self._path_tar_stream(device)))
+                result.append(
+                    (vol.tag, self._path_tar_stream(device, allow_sudo))
+                )
             else:
                 vol_name = (
                     vol.name if vol.is_external() and vol.name else vol.tag
@@ -127,14 +154,17 @@ class DockerComposeEnv(Environment):
                 )
         return result
 
-    def _is_readable(self, path: str) -> bool:
-        return os.access(path, os.R_OK)
+    def _is_path_tree_readable(self, path: str) -> bool:
+        return Util.is_tree_readable(path)
 
-    def _path_tar_stream(self, path: str) -> IO[bytes]:
+    def _path_tar_stream(
+        self, path: str, allow_sudo: bool = False
+    ) -> IO[bytes]:
+        readable = self._is_path_tree_readable(path)
         cmd = (
-            ["tar", "-cC", path, "."]
-            if self._is_readable(path)
-            else ["sudo", "tar", "-cC", path, "."]
+            ["sudo", "tar", "-cC", path, "."]
+            if not readable and allow_sudo
+            else ["tar", "-cC", path, "."]
         )
         proc = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -358,13 +358,25 @@ class Environment(ABC):
         """Return the directory for the environment with a given tag."""
         return os.path.join(self.configMng.config.envs_path, env_tag)
 
-    def get_volume_tar_streams(self) -> list[tuple[str, IO[bytes]]]:
+    def volumes_need_elevated_permissions(self) -> bool:
+        """Return True if any volume path requires sudo to archive.
+
+        Backends override this for backends where host-side paths can be owned
+        by container users.  The default is False (no volumes, or volumes that
+        are always accessible without privilege escalation).
+        """
+        return False
+
+    def get_volume_tar_streams(
+        self, allow_sudo: bool = False
+    ) -> list[tuple[str, IO[bytes]]]:
         """Return one ``(volume_tag, tar_stream)`` pair per environment volume.
 
         Each stream is uncompressed, rooted at ``.`` (entries like
         ``./subdir/file``).  The tag binds the stream to the volume for
         identity-preserving restore.  The default returns an empty list;
-        backends override this.
+        backends override this.  Pass ``allow_sudo=True`` only after the user
+        has consented to elevated-privilege operations.
         """
         return []
 

--- a/src/remote/remote_mng.py
+++ b/src/remote/remote_mng.py
@@ -307,9 +307,21 @@ class RemoteMng:
         env: Environment = environment_mng.get_environment_from_cfg(env_cfg)
         self._stop_if_running(env, environment_mng)
 
+        env_path = env.get_path()
+        env_needs_sudo = not Util.is_tree_readable(env_path)
+        vols_need_sudo = env.volumes_need_elevated_permissions()
+        allow_sudo = env_needs_sudo or vols_need_sudo
+        if allow_sudo:
+            if not Util.confirm(
+                "Some environment files (e.g. container-written data "
+                "directories) are not readable by the current user. "
+                "Proceed using sudo to read them?"
+            ):
+                Util.print_error_and_die("Push cancelled.")
         producer = TarStreamProducer(
-            env_path=env.get_path(),
-            volume_streams=env.get_volume_tar_streams(),
+            env_path=env_path,
+            volume_streams=env.get_volume_tar_streams(allow_sudo=allow_sudo),
+            env_needs_sudo=env_needs_sudo,
         )
         chunker = Chunker(
             min_size=remote_cfg.chunk.min_size_kb * 1024,

--- a/src/storage/tar_stream.py
+++ b/src/storage/tar_stream.py
@@ -11,9 +11,12 @@ including host-mounted volumes (with sudo escalation when required)."""
 from __future__ import annotations
 
 import os
+import subprocess
 import tarfile
 import threading
-from typing import IO, cast
+from typing import IO, Optional, cast
+
+from util.util import Util
 
 
 class _CheckedStream:
@@ -79,8 +82,7 @@ class TarStreamProducer:
     Parameters
     ----------
     env_path:
-        Absolute path to the environment directory.  This path must be
-        readable by the current process.
+        Absolute path to the environment directory.
     volume_streams:
         Ordered list of ``(volume_tag, uncompressed_tar_stream)`` pairs.
         Each stream must be in tar streaming format (``r|``-readable, entries
@@ -91,9 +93,58 @@ class TarStreamProducer:
         self,
         env_path: str,
         volume_streams: list[tuple[str, IO[bytes]]],
+        env_needs_sudo: Optional[bool] = None,
     ) -> None:
         self._env_path = env_path
         self._volume_streams = volume_streams
+        self._env_needs_sudo = (
+            env_needs_sudo
+            if env_needs_sudo is not None
+            else not self._is_env_readable()
+        )
+
+    def needs_elevated_permissions(self) -> bool:
+        """Return True if archiving env_path requires sudo.
+
+        Callers should check this before calling ``stream()`` and ask the user
+        for consent before proceeding, since the stream will invoke ``sudo tar``
+        to read container-owned subdirectories.
+        """
+        return self._env_needs_sudo
+
+    def _is_env_readable(self) -> bool:
+        return Util.is_tree_readable(self._env_path)
+
+    def _add_env_sudo(self, out_tar: tarfile.TarFile) -> None:
+        """Stream env_path via sudo tar; inject entries under env/ arcname."""
+        proc = subprocess.Popen(
+            ["sudo", "tar", "-cC", self._env_path, "."],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if proc.stdout is None:
+            raise RuntimeError("subprocess stdout is None — this is a bug")
+        try:
+            with tarfile.open(mode="r|", fileobj=proc.stdout) as src_tar:
+                for member in src_tar:
+                    rel = member.name.lstrip("./")
+                    member.name = f"env/{rel}" if rel else "env"
+                    fobj = (
+                        src_tar.extractfile(member) if member.isreg() else None
+                    )
+                    out_tar.addfile(member, fobj)
+        finally:
+            proc.stdout.close()
+            stderr_bytes = proc.stderr.read() if proc.stderr else b""
+            if proc.stderr:
+                proc.stderr.close()
+            proc.wait()
+        if proc.returncode != 0:
+            msg = stderr_bytes.decode(errors="replace").strip()
+            raise RuntimeError(
+                f"sudo tar failed for {self._env_path} "
+                f"(exit {proc.returncode})" + (f": {msg}" if msg else "")
+            )
 
     def stream(self) -> IO[bytes]:
         """Return a readable, uncompressed tar byte stream.
@@ -109,9 +160,14 @@ class TarStreamProducer:
             try:
                 with os.fdopen(w_fd, "wb") as out_file:
                     with tarfile.open(mode="w|", fileobj=out_file) as out_tar:
-                        out_tar.add(
-                            self._env_path, arcname="env", recursive=True
-                        )
+                        if self._env_needs_sudo:
+                            self._add_env_sudo(out_tar)
+                        else:
+                            out_tar.add(
+                                self._env_path,
+                                arcname="env",
+                                recursive=True,
+                            )
                         for tag, vol_stream in self._volume_streams:
                             self._reinject(out_tar, tag, vol_stream)
             except BrokenPipeError:
@@ -133,12 +189,25 @@ class TarStreamProducer:
         vol_stream: IO[bytes],
     ) -> None:
         """Copy entries from *vol_stream* into *out_tar* prefixed by tag."""
-        with tarfile.open(mode="r|", fileobj=vol_stream) as src_tar:
-            for member in src_tar:
-                rel = member.name.lstrip("./")
-                member.name = (
-                    f"volumes/{tag}/{rel}" if rel else f"volumes/{tag}"
-                )
-                fobj = src_tar.extractfile(member) if member.isreg() else None
-                out_tar.addfile(member, fobj)
-        vol_stream.close()
+        try:
+            with tarfile.open(mode="r|", fileobj=vol_stream) as src_tar:
+                for member in src_tar:
+                    rel = member.name.lstrip("./")
+                    member.name = (
+                        f"volumes/{tag}/{rel}" if rel else f"volumes/{tag}"
+                    )
+                    fobj = (
+                        src_tar.extractfile(member) if member.isreg() else None
+                    )
+                    out_tar.addfile(member, fobj)
+            vol_stream.close()
+        except tarfile.ReadError as exc:
+            try:
+                vol_stream.close()
+            except Exception:
+                pass
+            raise RuntimeError(
+                f"volume stream for '{tag}' is empty or corrupt — "
+                "the subprocess producing it likely failed due to "
+                "insufficient permissions (check sudo access)"
+            ) from exc

--- a/src/tests/integration/test_ftp_sftp_backends.py
+++ b/src/tests/integration/test_ftp_sftp_backends.py
@@ -94,6 +94,7 @@ def _make_push_mng(
     env_mock = MagicMock()
     env_mock.get_path.return_value = env_path
     env_mock.get_volume_tar_streams.return_value = []
+    env_mock.volumes_need_elevated_permissions.return_value = False
     env_mock.is_running.return_value = False
 
     env_mng = MagicMock()

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -1833,6 +1833,28 @@ def _external_vol(tag: str, name: str) -> object:
 
 
 @pytest.mark.env
+def test_volumes_need_elevated_permissions_readable(
+    mocker: MockerFixture,
+) -> None:
+    """volumes_need_elevated_permissions returns False when all paths are readable."""
+    env_cfg = _make_env_cfg_with_volumes([_bind_vol("db_data", "/data/db")])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    mocker.patch.object(env, "_is_path_tree_readable", return_value=True)
+    assert env.volumes_need_elevated_permissions() is False
+
+
+@pytest.mark.env
+def test_volumes_need_elevated_permissions_unreadable(
+    mocker: MockerFixture,
+) -> None:
+    """volumes_need_elevated_permissions returns True when a path is unreadable."""
+    env_cfg = _make_env_cfg_with_volumes([_bind_vol("db_data", "/data/db")])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    mocker.patch.object(env, "_is_path_tree_readable", return_value=False)
+    assert env.volumes_need_elevated_permissions() is True
+
+
+@pytest.mark.env
 def test_volume_streams_empty(mocker: MockerFixture) -> None:
     """No volumes → empty list returned."""
     env_cfg = _make_env_cfg_with_volumes([])
@@ -1846,7 +1868,7 @@ def test_volume_streams_bind_mount_readable(mocker: MockerFixture) -> None:
     env_cfg = _make_env_cfg_with_volumes([_bind_vol("db_data", "/data/db")])
     env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
 
-    mocker.patch.object(env, "_is_readable", return_value=True)
+    mocker.patch.object(env, "_is_path_tree_readable", return_value=True)
     mock_popen = mocker.patch(
         "docker.docker_compose_env.subprocess.Popen",
         return_value=mocker.Mock(stdout=mocker.Mock()),
@@ -1863,17 +1885,17 @@ def test_volume_streams_bind_mount_readable(mocker: MockerFixture) -> None:
 
 @pytest.mark.env
 def test_volume_streams_bind_mount_sudo(mocker: MockerFixture) -> None:
-    """Bind-mount whose path is not readable → ``sudo tar -cC``."""
+    """Bind-mount with unreadable path and allow_sudo=True → ``sudo tar -cC``."""
     env_cfg = _make_env_cfg_with_volumes([_bind_vol("db_data", "/data/db")])
     env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
 
-    mocker.patch.object(env, "_is_readable", return_value=False)
+    mocker.patch.object(env, "_is_path_tree_readable", return_value=False)
     mock_popen = mocker.patch(
         "docker.docker_compose_env.subprocess.Popen",
         return_value=mocker.Mock(stdout=mocker.Mock()),
     )
 
-    streams = env.get_volume_tar_streams()
+    streams = env.get_volume_tar_streams(allow_sudo=True)
 
     assert len(streams) == 1
     tag, _ = streams[0]

--- a/src/tests/test_remote_integration.py
+++ b/src/tests/test_remote_integration.py
@@ -78,6 +78,7 @@ def _make_push_mng(
     env_mock = MagicMock()
     env_mock.get_path.return_value = env_path
     env_mock.get_volume_tar_streams.return_value = []
+    env_mock.volumes_need_elevated_permissions.return_value = False
     env_mock.is_running.return_value = False
 
     env_mng = MagicMock()

--- a/src/tests/test_remote_mng.py
+++ b/src/tests/test_remote_mng.py
@@ -468,6 +468,7 @@ def _make_push_mng(
     env_mock = MagicMock()
     env_mock.get_path.return_value = env_path
     env_mock.get_volume_tar_streams.return_value = []
+    env_mock.volumes_need_elevated_permissions.return_value = False
     env_mock.is_running.return_value = False
 
     env_mng_mock = MagicMock()

--- a/src/tests/test_storage_tar_stream.py
+++ b/src/tests/test_storage_tar_stream.py
@@ -95,3 +95,86 @@ def test_stream_env_and_volume_arcnames(tmp_path: Path) -> None:
     )
     # No numeric index in any name
     assert not any(n.startswith("volumes/0") for n in names)
+
+
+@pytest.mark.storage
+def test_needs_elevated_permissions_cached(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """needs_elevated_permissions() reflects the eager check done in __init__."""
+    import os as _os
+
+    env_dir = tmp_path / "env"
+    env_dir.mkdir()
+
+    real_walk = _os.walk
+
+    def _patched_walk(path: str, onerror=None, **kwargs):  # type: ignore[override]
+        yield from real_walk(path, **kwargs)
+        if onerror is not None:
+            onerror(PermissionError(13, "Permission denied", str(path)))
+
+    monkeypatch.setattr("util.util.os.walk", _patched_walk)
+    monkeypatch.setattr("util.util.shutil.which", lambda _: "/usr/bin/sudo")
+
+    producer = TarStreamProducer(str(env_dir), [])
+    assert producer.needs_elevated_permissions() is True
+
+
+class _FakeProc:
+    """Minimal subprocess.Popen stand-in for _add_env_sudo tests."""
+
+    def __init__(self, stream: io.BytesIO, returncode: int = 0) -> None:
+        self.stdout = stream
+        self.stderr = io.BytesIO(b"")
+        self.returncode = returncode
+
+    def wait(self) -> int:
+        return self.returncode
+
+
+@pytest.mark.storage
+def test_stream_env_sudo_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Falls back to sudo tar and emits env/ entries when env is not readable."""
+    env_dir = tmp_path / "env"
+    env_dir.mkdir()
+    (env_dir / "cfg.yml").write_text("x: 1")
+
+    sudo_stream = _make_tar_stream({"./cfg.yml": b"x: 1"})
+
+    popen_calls: list[list[str]] = []
+
+    def _fake_popen(cmd: list[str], **kwargs):  # type: ignore[override]
+        popen_calls.append(cmd)
+        return _FakeProc(sudo_stream)
+
+    monkeypatch.setattr("storage.tar_stream.subprocess.Popen", _fake_popen)
+    monkeypatch.setattr(
+        TarStreamProducer, "_is_env_readable", lambda self: False
+    )
+
+    producer = TarStreamProducer(str(env_dir), [])
+    names = _list_tar_names(producer.stream())
+
+    assert any(n.startswith("env") for n in names)
+    assert len(popen_calls) == 1
+    assert popen_calls[0][:3] == ["sudo", "tar", "-cC"]
+    assert popen_calls[0][3] == str(env_dir)
+
+
+@pytest.mark.storage
+def test_reinject_empty_stream_raises_runtime_error(
+    tmp_path: Path,
+) -> None:
+    """_reinject raises RuntimeError with a readable message on empty volume stream."""
+    env_dir = tmp_path / "env"
+    env_dir.mkdir()
+
+    empty_stream = io.BytesIO(b"")
+
+    producer = TarStreamProducer(str(env_dir), [("db_data", empty_stream)])
+    with pytest.raises(RuntimeError, match="db_data"):
+        with producer.stream() as s:
+            s.read()

--- a/src/util/util.py
+++ b/src/util/util.py
@@ -428,6 +428,23 @@ class Util:
         return os.geteuid() == 0
 
     @staticmethod
+    def is_tree_readable(path: str) -> bool:
+        """Return False if any entry under path is unreadable by this process.
+
+        Uses os.walk with an onerror hook so that a PermissionError from any
+        nested os.listdir call is captured.  On non-POSIX hosts or when sudo
+        is unavailable, always returns True — escalation is impossible and
+        callers will surface the PermissionError naturally.
+        """
+        if os.name != "posix" or not shutil.which("sudo"):
+            return True
+        errors: list[OSError] = []
+        for _ in os.walk(path, onerror=errors.append):
+            if errors:
+                return False
+        return not errors
+
+    @staticmethod
     def run_command(
         cmd: Union[list[str], str],
         check: bool = True,


### PR DESCRIPTION
When a bind-mount volume path or env dir contained container-owned subdirectories, sudo tar and Util.confirm() raced for the terminal, leaving sudo with no input and causing _reinject to fail with "empty file".

Restructure the push flow so all permission checks are pure (no subprocesses) and a single Util.confirm() prompt is presented before any subprocess starts:

- TarStreamProducer: add _is_env_readable() / _add_env_sudo() to detect unreadable subdirs and stream via `sudo tar`; needs_elevated_permissions() exposes the result; _reinject raises RuntimeError on empty/corrupt streams.

- DockerComposeEnv: volumes_need_elevated_permissions() walks each bind-mount path recursively (no subprocess); _is_path_tree_readable() replaces the shallow os.access() check; get_volume_tar_streams() / _path_tar_stream() only use sudo when allow_sudo=True.

- remote_mng.push(): probes env path and volumes before any subprocess, then issues one Util.confirm() if either needs elevated permissions.

Fixes: #241

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
to change)
- [ ] Change or update to the documentation (with no functional changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Contributor License Agreement
<!--- All contributors must sign the CLA before this PR can be merged. -->
<!--- The CLA Assistant bot will post instructions if you have not yet signed. -->
- [ ] I have signed the [Contributor License Agreement](../CLA.md)
      (or I will follow the CLA Assistant bot instructions posted in this PR).
