### PR TITLE
fix(completion): preserve empty COMP_WORDS token in __complete call

### DIFF
--- a/scripts/shepctl_completion.sh
+++ b/scripts/shepctl_completion.sh
@@ -9,17 +9,16 @@
 
 _shepctl_completion() {
     COMPREPLY=()
-    args="${COMP_WORDS[@]:1}"
     cur="${COMP_WORDS[COMP_CWORD]}"
 
-    tokens=$(shepctl __complete $args)
+    tokens=$(shepctl __complete "${COMP_WORDS[@]:1}")
     readarray -t tokens_array <<< "$tokens"
     if [[ $? -ne 0 ]]; then
         echo "Error: Failed to get completions from shepctl" >&2
         return 1
     fi
 
-    COMPREPLY=( $(compgen -W "${tokens_array[*]}" -- ${cur}) )
+    COMPREPLY=( $(compgen -W "${tokens_array[*]}" -- "$cur") )
     return 0
 }
 


### PR DESCRIPTION
Unquoted `$args` expansion in `_shepctl_completion` dropped the trailing empty string that bash appends to COMP_WORDS when the cursor sits after a space following a fully-typed word.  As a result, shepherd's completion logic never saw the empty last token and treated the preceding value as still-incomplete, returning it as a candidate — which compgen then matched against the empty `cur`, appending a duplicate word.

Replace the two-step unquoted expansion with a single quoted array slice `"${COMP_WORDS[@]:1}"`.

Fixes: #242

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
to change)
- [ ] Change or update to the documentation (with no functional changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Contributor License Agreement
<!--- All contributors must sign the CLA before this PR can be merged. -->
<!--- The CLA Assistant bot will post instructions if you have not yet signed. -->
- [ ] I have signed the [Contributor License Agreement](../CLA.md)
      (or I will follow the CLA Assistant bot instructions posted in this PR).
