### PR TITLE
feat(env): block operational commands on dehydrated environments

### DIFF
--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -186,6 +186,13 @@ class PluginScopeGroup(click.Group):
         return registered.spec.command
 
 
+def _get_active_env_or_raise(shepherd: ShepherdMng) -> EnvironmentCfg:
+    envCfg = shepherd.configMng.get_active_environment()
+    if not envCfg:
+        raise click.UsageError("No active environment found.")
+    return envCfg
+
+
 def require_active_env(func: Callable[..., Any]) -> Callable[..., Any]:
     """
     Ensure an active environment exists before running a command handler.
@@ -198,9 +205,26 @@ def require_active_env(func: Callable[..., Any]) -> Callable[..., Any]:
     def wrapper(
         shepherd: ShepherdMng, *args: List[str], **kwargs: dict[str, str]
     ) -> Callable[..., Any]:
-        envCfg = shepherd.configMng.get_active_environment()
-        if not envCfg:
-            raise click.UsageError("No active environment found.")
+        return func(
+            shepherd, _get_active_env_or_raise(shepherd), *args, **kwargs
+        )
+
+    return wrapper
+
+
+def require_hydrated_env(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Like require_active_env but also rejects dehydrated environments."""
+
+    @functools.wraps(func)
+    def wrapper(
+        shepherd: ShepherdMng, *args: List[str], **kwargs: dict[str, str]
+    ) -> Callable[..., Any]:
+        envCfg = _get_active_env_or_raise(shepherd)
+        if envCfg.dehydrated:
+            raise click.UsageError(
+                f"Environment '{envCfg.tag}' is dehydrated. "
+                "Restore local data with 'env hydrate' first."
+            )
         return func(shepherd, envCfg, *args, **kwargs)
 
     return wrapper
@@ -443,7 +467,7 @@ def list_envs(shepherd: ShepherdMng):
     ),
 )
 @click.pass_obj
-@require_active_env
+@require_hydrated_env
 def up_env(
     shepherd: ShepherdMng,
     envCfg: EnvironmentCfg,
@@ -470,7 +494,7 @@ def up_env(
     help="Return after issuing the stop command without waiting.",
 )
 @click.pass_obj
-@require_active_env
+@require_hydrated_env
 def halt_env(shepherd: ShepherdMng, envCfg: EnvironmentCfg, no_wait: bool):
     """Stop environment."""
     shepherd.environmentMng.stop_env(envCfg, wait=not no_wait)
@@ -499,7 +523,7 @@ def halt_env(shepherd: ShepherdMng, envCfg: EnvironmentCfg, no_wait: bool):
     help="Keep updating the output until interrupted.",
 )
 @click.pass_obj
-@require_active_env
+@require_hydrated_env
 def reload_env(
     shepherd: ShepherdMng,
     envCfg: EnvironmentCfg,
@@ -535,7 +559,7 @@ def reload_env(
     help="Keep updating the output until interrupted.",
 )
 @click.pass_obj
-@require_active_env
+@require_hydrated_env
 def status_env(
     shepherd: ShepherdMng,
     envCfg: EnvironmentCfg,
@@ -589,6 +613,12 @@ def push_env(
 ) -> None:
     """Push a new snapshot of ENV_TAG (or the checked-out env) to a remote."""
     env_tag = _resolve_env_tag(shepherd, env_tag)
+    existing = shepherd.configMng.get_environment(env_tag)
+    if existing and existing.dehydrated:
+        raise click.UsageError(
+            f"Environment '{env_tag}' is dehydrated. "
+            "Restore local data with 'env hydrate' first."
+        )
     label_list = [lbl.strip() for lbl in labels.split(",")] if labels else []
     shepherd.remoteMng.push(
         env_name=env_tag,
@@ -630,6 +660,12 @@ def pull_env(
 ) -> None:
     """Download ENV_TAG (or the checked-out env) from a remote snapshot."""
     env_tag = _resolve_env_tag(shepherd, env_tag)
+    existing = shepherd.configMng.get_environment(env_tag)
+    if existing and existing.dehydrated:
+        raise click.UsageError(
+            f"Environment '{env_tag}' is dehydrated. "
+            "Restore local data with 'env hydrate' instead."
+        )
     shepherd.remoteMng.pull(
         env_name=env_tag,
         remote_name=remote_name,

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -2116,6 +2116,69 @@ def test_cli_env_push_no_active_env_error(
 
 
 @pytest.mark.shpd
+def test_cli_env_up_dehydrated_env_error(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'env up' on a dehydrated environment fails with a UsageError."""
+    from config import ConfigMng
+
+    _setup_remote(shpd_conf)
+    mocker.patch.object(
+        ConfigMng,
+        "get_active_environment",
+        return_value=mocker.Mock(tag="test-1", dehydrated=True),
+    )
+
+    result = runner.invoke(cli, ["env", "up"])
+
+    assert result.exit_code != 0
+    assert "dehydrated" in result.output
+    assert "hydrate" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_env_push_dehydrated_env_error(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'env push' on a dehydrated environment fails with a UsageError."""
+    from config import ConfigMng
+
+    _setup_remote(shpd_conf)
+    mocker.patch.object(
+        ConfigMng,
+        "get_environment",
+        return_value=mocker.Mock(tag="test-1", dehydrated=True),
+    )
+
+    result = runner.invoke(cli, ["env", "push", "test-1"])
+
+    assert result.exit_code != 0
+    assert "dehydrated" in result.output
+    assert "hydrate" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_env_pull_dehydrated_env_error(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+) -> None:
+    """'env pull' on an already-registered dehydrated env fails with a UsageError."""
+    from config import ConfigMng
+
+    _setup_remote(shpd_conf)
+    mocker.patch.object(
+        ConfigMng,
+        "get_environment",
+        return_value=mocker.Mock(tag="test-1", dehydrated=True),
+    )
+
+    result = runner.invoke(cli, ["env", "pull", "test-1"])
+
+    assert result.exit_code != 0
+    assert "dehydrated" in result.output
+    assert "hydrate" in result.output
+
+
+@pytest.mark.shpd
 def test_cli_env_dehydrate_defaults_to_active_env(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ) -> None:


### PR DESCRIPTION
Add a `require_hydrated_env` decorator that mirrors `require_active_env` but additionally raises `click.UsageError` when the checked-out environment has `dehydrated=True`.
Apply it to `up`, `halt`, `reload`, and `status`.

Add an inline dehydrated check in `pull_env` before the `remoteMng.pull()` call, since `RemoteMng.pull()` would otherwise silently overwrite an existing dehydrated config entry with a fresh one.

Fixes: #243

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
to change)
- [ ] Change or update to the documentation (with no functional changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Contributor License Agreement
<!--- All contributors must sign the CLA before this PR can be merged. -->
<!--- The CLA Assistant bot will post instructions if you have not yet signed. -->
- [ ] I have signed the [Contributor License Agreement](../CLA.md)
      (or I will follow the CLA Assistant bot instructions posted in this PR).
