### PR TITLE
refactor(remote): decouple volume mgmt from remote_mng

### DIFF
--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import time
 from typing import IO, Any, Optional, cast, override
@@ -17,13 +18,23 @@ from typing import IO, Any, Optional, cast, override
 import yaml
 
 from config import ConfigMng, EnvironmentCfg
-from config.config import InitCfg, ProbeCfg
+from config.config import InitCfg, ProbeCfg, VolumeCfg
 from environment import Environment
 from environment.environment import NonRecoverableStartError, ProbeRunResult
 from service import ServiceFactory
 from util.util import Util
 
 from .docker_compose_util import render_container, run_compose
+
+
+def _is_bind_mount(vol: VolumeCfg) -> bool:
+    """Return True when *vol* is a local bind-mount (type=none, o=bind)."""
+    return bool(
+        vol.driver == "local"
+        and vol.driver_opts
+        and vol.driver_opts.get("type") == "none"
+        and vol.driver_opts.get("o") == "bind"
+    )
 
 
 class _ProcStream:
@@ -82,14 +93,8 @@ class DockerComposeEnv(Environment):
         """Ensure the environment resources are available."""
         if self.envCfg.volumes:
             for vol in self.envCfg.volumes:
-                # Check if it's a host bind mount,
-                # in case create the host path
-                if (
-                    vol.driver == "local"
-                    and vol.driver_opts
-                    and vol.driver_opts.get("type") == "none"
-                    and vol.driver_opts.get("o") == "bind"
-                ):
+                if _is_bind_mount(vol):
+                    assert vol.driver_opts is not None
                     device_path = vol.driver_opts.get("device")
                     if device_path:
                         Util.ensure_dir(
@@ -108,12 +113,8 @@ class DockerComposeEnv(Environment):
         ``docker run`` container, so host-side permission checks do not apply.
         """
         for vol in self.envCfg.volumes or []:
-            if (
-                vol.driver == "local"
-                and vol.driver_opts
-                and vol.driver_opts.get("type") == "none"
-                and vol.driver_opts.get("o") == "bind"
-            ):
+            if _is_bind_mount(vol):
+                assert vol.driver_opts is not None
                 device = vol.driver_opts.get("device", "")
                 if device and not self._is_path_tree_readable(device):
                     return True
@@ -135,12 +136,8 @@ class DockerComposeEnv(Environment):
             return []
         result: list[tuple[str, IO[bytes]]] = []
         for vol in self.envCfg.volumes:
-            if (
-                vol.driver == "local"
-                and vol.driver_opts
-                and vol.driver_opts.get("type") == "none"
-                and vol.driver_opts.get("o") == "bind"
-            ):
+            if _is_bind_mount(vol):
+                assert vol.driver_opts is not None
                 device = vol.driver_opts.get("device", "")
                 result.append(
                     (vol.tag, self._path_tar_stream(device, allow_sudo))
@@ -189,6 +186,63 @@ class DockerComposeEnv(Environment):
             stderr=subprocess.PIPE,
         )
         return cast(IO[bytes], _ProcStream(proc))
+
+    @override
+    def remove_local_volumes(self) -> None:
+        for vol in self.envCfg.volumes or []:
+            if _is_bind_mount(vol):
+                assert vol.driver_opts is not None
+                device = Util.translate_host_path(
+                    vol.driver_opts.get("device", "")
+                )
+                if device:
+                    Util.delete_dir(device)
+            else:
+                vol_name = (
+                    vol.name if vol.is_external() and vol.name else vol.tag
+                )
+                subprocess.run(
+                    ["docker", "volume", "rm", "--force", vol_name],
+                    check=True,
+                )
+
+    @override
+    def restore_local_volumes(self) -> None:
+        for vol in self.envCfg.volumes or []:
+            if _is_bind_mount(vol):
+                continue
+            vol_name = vol.name if vol.is_external() and vol.name else vol.tag
+            src = os.path.join(self.get_path(), "volumes", vol.tag)
+            if not os.path.isdir(src):
+                logging.warning(
+                    "Volume snapshot directory missing, skipping restore: %s",
+                    src,
+                )
+                continue
+            try:
+                subprocess.run(
+                    ["docker", "volume", "create", vol_name], check=True
+                )
+                subprocess.run(
+                    [
+                        "docker",
+                        "run",
+                        "--rm",
+                        "-v",
+                        f"{src}:/src:ro",
+                        "-v",
+                        f"{vol_name}:/dst",
+                        "busybox:stable-glibc",
+                        "sh",
+                        "-c",
+                        "cp -a /src/. /dst/",
+                    ],
+                    check=True,
+                )
+            except subprocess.CalledProcessError as exc:
+                raise RuntimeError(
+                    f"Failed to restore Docker volume '{vol_name}': {exc}"
+                ) from exc
 
     @override
     def clone_impl(self, dst_env_tag: str) -> DockerComposeEnv:

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -380,6 +380,26 @@ class Environment(ABC):
         """
         return []
 
+    def remove_local_volumes(self) -> None:
+        """Remove all local volume data for this environment.
+
+        Backends override this to clean up bind-mount device directories and
+        any backend-managed volumes (e.g. Docker named volumes).  The default
+        is a no-op for backends that have no local volume state.
+        """
+        pass
+
+    def restore_local_volumes(self) -> None:
+        """Restore backend-managed volumes from the extracted tar data.
+
+        Called by ``RemoteMng.hydrate`` after the snapshot tar has been
+        extracted into the env directory.  Backends override this to, e.g.,
+        populate Docker named volumes from ``{env_path}/volumes/{tag}/``.
+        Bind-mount volumes are handled implicitly by the tar extraction and
+        do not need an explicit restore step.
+        """
+        pass
+
     def ensure_resources(self):
         """Ensure the environment resources are available."""
         return self.ensure_resources_impl()

--- a/src/remote/remote_mng.py
+++ b/src/remote/remote_mng.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 import datetime
 import json
 import os
-import shutil
-import subprocess
 import tarfile
 import threading
 from copy import deepcopy
@@ -422,10 +420,9 @@ class RemoteMng:
     def dehydrate(self, env_name: str, environment_mng: EnvironmentMng) -> None:
         """Strip local data for *env_name* while preserving its config entry.
 
-        Removes the environment directory and any bind-mount volume device
-        paths declared in the config.  Named Docker volumes are not removed
-        (they are managed by the Docker daemon).  After deletion the env's
-        ``dehydrated`` flag is set to ``True`` and the config is persisted.
+        Removes all backend-managed volumes, then the environment directory.
+        After deletion the env's ``dehydrated`` flag is set to ``True`` and
+        the config is persisted.
 
         :param env_name: Tag of the local environment to dehydrate.
         :param environment_mng: Used to check and stop the env if running.
@@ -446,20 +443,9 @@ class RemoteMng:
         env: Environment = environment_mng.get_environment_from_cfg(env_cfg)
         self._stop_if_running(env, environment_mng)
 
+        env.remove_local_volumes()
         env_dir = os.path.join(self.configMng.config.envs_path, env_name)
         self._delete_dir(env_dir)
-
-        # Also delete bind-mount device paths declared in VolumeCfg.
-        for vol in env_cfg.volumes or []:
-            if (
-                vol.driver == "local"
-                and vol.driver_opts
-                and vol.driver_opts.get("type") == "none"
-                and vol.driver_opts.get("o") == "bind"
-            ):
-                device = vol.driver_opts.get("device", "")
-                if device:
-                    self._delete_dir(device)
 
         env_cfg.dehydrated = True
         self.configMng.add_or_set_environment(env_name, env_cfg)
@@ -637,6 +623,7 @@ class RemoteMng:
     def hydrate(
         self,
         env_name: str,
+        environment_mng: Optional["EnvironmentMng"] = None,
         remote_name: Optional[str] = None,
         snapshot_id: Optional[str] = None,
     ) -> None:
@@ -644,9 +631,13 @@ class RemoteMng:
 
         Same chunk-download and untar logic as :meth:`pull`, but the env must
         already exist in config with ``dehydrated = True``.  After restoration,
-        ``dehydrated`` is cleared to ``False`` and the config is persisted.
+        backend-managed volumes (e.g. Docker named volumes) are repopulated
+        from the extracted tar data, then ``dehydrated`` is cleared to
+        ``False`` and the config is persisted.
 
         :param env_name: Tag of the dehydrated environment to restore.
+        :param environment_mng: Used to obtain the concrete backend for volume
+            restoration.  When ``None``, the volume-restore step is skipped.
         :param remote_name: Remote to pull from, or ``None`` for the default.
         :param snapshot_id: Specific snapshot to restore, or ``None`` for the
             latest.
@@ -671,6 +662,12 @@ class RemoteMng:
             downloaded, from_cache = self._restore_chunks(
                 backend, manifest, dest_dir, cache
             )
+
+        if environment_mng is not None:
+            env: "Environment" = environment_mng.get_environment_from_cfg(
+                env_cfg
+            )
+            env.restore_local_volumes()
 
         env_cfg.dehydrated = False
         self.configMng.add_or_set_environment(env_name, env_cfg)
@@ -748,21 +745,7 @@ class RemoteMng:
         )
 
     def _delete_dir(self, path: str) -> None:
-        """Delete *path* recursively; retry under sudo on PermissionError."""
-        try:
-            shutil.rmtree(path)
-        except FileNotFoundError:
-            pass  # already absent — treat as success
-        except PermissionError:
-            if os.name != "posix" or not shutil.which("sudo"):
-                raise
-            uid = os.getuid()
-            gid = os.getgid()
-            subprocess.run(
-                ["sudo", "chown", "-R", f"{uid}:{gid}", path],
-                check=True,
-            )
-            shutil.rmtree(path)
+        Util.delete_dir(path)
 
     # ------------------------------------------------------------------
     # Display methods (called by CLI commands)

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -697,6 +697,7 @@ def hydrate_env(
     env_tag = _resolve_env_tag(shepherd, env_tag)
     shepherd.remoteMng.hydrate(
         env_name=env_tag,
+        environment_mng=shepherd.environmentMng,
         remote_name=remote_name,
         snapshot_id=snapshot_id,
     )

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 from pathlib import Path
@@ -1945,3 +1946,129 @@ def test_volume_streams_external_volume(mocker: MockerFixture) -> None:
     assert tag == "ext_vol"
     cmd = mock_popen.call_args[0][0]
     assert "prod_db_backup:/mnt" in cmd
+
+
+# ---------------------------------------------------------------------------
+# remove_local_volumes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.env
+def test_remove_local_volumes_bind_mount(mocker: MockerFixture) -> None:
+    """Bind-mount volumes are removed via Util.delete_dir."""
+    env_cfg = _make_env_cfg_with_volumes([_bind_vol("db_data", "/data/db")])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    mock_delete = mocker.patch("docker.docker_compose_env.Util.delete_dir")
+    mocker.patch(
+        "docker.docker_compose_env.Util.translate_host_path",
+        side_effect=lambda p: p,
+    )
+
+    env.remove_local_volumes()
+
+    mock_delete.assert_called_once_with("/data/db")
+
+
+@pytest.mark.env
+def test_remove_local_volumes_named_volume(mocker: MockerFixture) -> None:
+    """Named volumes are removed via ``docker volume rm --force``."""
+    env_cfg = _make_env_cfg_with_volumes([_named_vol("uploads")])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    mock_run = mocker.patch("docker.docker_compose_env.subprocess.run")
+
+    env.remove_local_volumes()
+
+    mock_run.assert_called_once()
+    cmd = mock_run.call_args[0][0]
+    assert cmd == ["docker", "volume", "rm", "--force", "uploads"]
+
+
+@pytest.mark.env
+def test_remove_local_volumes_no_volumes(mocker: MockerFixture) -> None:
+    """No-op when the environment has no volumes."""
+    env_cfg = _make_env_cfg_with_volumes([])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    mock_run = mocker.patch("docker.docker_compose_env.subprocess.run")
+    mock_delete = mocker.patch("docker.docker_compose_env.Util.delete_dir")
+
+    env.remove_local_volumes()
+
+    mock_run.assert_not_called()
+    mock_delete.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# restore_local_volumes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.env
+def test_restore_local_volumes_named_volume(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Named volume is created and populated from snapshot dir."""
+    vol_src = tmp_path / "volumes" / "uploads"
+    vol_src.mkdir(parents=True)
+    env_cfg = _make_env_cfg_with_volumes([_named_vol("uploads")])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    mocker.patch.object(env, "get_path", return_value=str(tmp_path))
+    mock_run = mocker.patch("docker.docker_compose_env.subprocess.run")
+
+    env.restore_local_volumes()
+
+    assert mock_run.call_count == 2
+    first_cmd = mock_run.call_args_list[0][0][0]
+    assert first_cmd == ["docker", "volume", "create", "uploads"]
+    second_cmd = mock_run.call_args_list[1][0][0]
+    assert "busybox:stable-glibc" in second_cmd
+
+
+@pytest.mark.env
+def test_restore_local_volumes_missing_src_warns(
+    mocker: MockerFixture, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Missing snapshot directory logs a warning and skips restore."""
+    env_cfg = _make_env_cfg_with_volumes([_named_vol("uploads")])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    mocker.patch.object(env, "get_path", return_value=str(tmp_path))
+    mock_run = mocker.patch("docker.docker_compose_env.subprocess.run")
+
+    with caplog.at_level(logging.WARNING):
+        env.restore_local_volumes()
+
+    mock_run.assert_not_called()
+    assert any("missing" in r.message.lower() for r in caplog.records)
+
+
+@pytest.mark.env
+def test_restore_local_volumes_docker_error_raises(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """CalledProcessError from docker is re-raised as RuntimeError."""
+    vol_src = tmp_path / "volumes" / "uploads"
+    vol_src.mkdir(parents=True)
+    env_cfg = _make_env_cfg_with_volumes([_named_vol("uploads")])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    mocker.patch.object(env, "get_path", return_value=str(tmp_path))
+    mocker.patch(
+        "docker.docker_compose_env.subprocess.run",
+        side_effect=subprocess.CalledProcessError(1, "docker"),
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to restore Docker volume"):
+        env.restore_local_volumes()
+
+
+@pytest.mark.env
+def test_restore_local_volumes_skips_bind_mounts(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Bind-mount volumes are always skipped during restore."""
+    env_cfg = _make_env_cfg_with_volumes([_bind_vol("db_data", "/data/db")])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    mocker.patch.object(env, "get_path", return_value=str(tmp_path))
+    mock_run = mocker.patch("docker.docker_compose_env.subprocess.run")
+
+    env.restore_local_volumes()
+
+    mock_run.assert_not_called()

--- a/src/tests/test_remote_integration.py
+++ b/src/tests/test_remote_integration.py
@@ -381,7 +381,11 @@ def test_hydrate_restores_data_clears_flag(
         str(tmp_path / "envs"),
         existing_env_cfg=_make_env_cfg(dehydrated=True),
     )
-    hydrate_mng.hydrate("my-env", remote_name="test-ftp")
+    env_mock_h = MagicMock()
+    env_mock_h.is_running.return_value = False
+    env_mng_h = MagicMock()
+    env_mng_h.get_environment_from_cfg.return_value = env_mock_h
+    hydrate_mng.hydrate("my-env", env_mng_h, remote_name="test-ftp")
 
     hydrate_mng.configMng.add_or_set_environment.assert_called_once()  # type: ignore[union-attr]
     saved = hydrate_mng.configMng.add_or_set_environment.call_args[0][1]  # type: ignore[union-attr]
@@ -420,7 +424,11 @@ def test_dehydrate_hydrate_roundtrip(
     pull_mng = _make_pull_mng(
         fake_remote_backend, str(envs_path), dehydrated_cfg
     )
-    pull_mng.hydrate("rt-env", remote_name="test-ftp")
+    env_mock_rt = MagicMock()
+    env_mock_rt.is_running.return_value = False
+    env_mng_rt = MagicMock()
+    env_mng_rt.get_environment_from_cfg.return_value = env_mock_rt
+    pull_mng.hydrate("rt-env", env_mng_rt, remote_name="test-ftp")
 
     assert (envs_path / "rt-env").exists()
 

--- a/src/tests/test_remote_mng.py
+++ b/src/tests/test_remote_mng.py
@@ -823,40 +823,25 @@ def test_dehydrate_stops_env_when_user_confirms(
 
 
 @pytest.mark.remote
-def test_dehydrate_removes_bind_mount_device(tmp_path: pathlib.Path) -> None:
-    """dehydrate also deletes bind-mount volume device paths."""
+def test_dehydrate_delegates_volume_removal(tmp_path: pathlib.Path) -> None:
+    """dehydrate delegates volume cleanup to the backend via remove_local_volumes."""
     env_dir = tmp_path / "envs" / "my-env"
     env_dir.mkdir(parents=True)
-    device_dir = tmp_path / "volumes" / "data"
-    device_dir.mkdir(parents=True)
-    (device_dir / "db.sql").write_bytes(b"dump")
 
-    from config.config import VolumeCfg
-
-    vol = VolumeCfg(
-        tag="data",
-        driver="local",
-        driver_opts={"type": "none", "o": "bind", "device": str(device_dir)},
-    )
-    env_cfg = EnvironmentCfg(
-        template="default",
-        factory="docker-compose",
-        tag="my-env",
-        services=[],
-        probes=[],
-        networks=[],
-        volumes=[vol],
-    )
-
+    env_cfg = _make_env_cfg()
     configMng = MagicMock()
     configMng.get_environment.return_value = env_cfg
     configMng.config.envs_path = str(tmp_path / "envs")
     mng = RemoteMng(configMng)
 
-    mng.dehydrate("my-env", _make_env_mng_mock_not_running())
+    env_mock = MagicMock()
+    env_mock.is_running.return_value = False
+    env_mng_mock = MagicMock()
+    env_mng_mock.get_environment_from_cfg.return_value = env_mock
 
-    assert not env_dir.exists()
-    assert not device_dir.exists()
+    mng.dehydrate("my-env", env_mng_mock)
+
+    env_mock.remove_local_volumes.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -1129,7 +1114,9 @@ def test_hydrate_restores_data_and_clears_flag(
     dehydrated_cfg = _make_env_cfg(dehydrated=True)
     mng = _make_pull_mng(fake, envs_path, existing_env_cfg=dehydrated_cfg)
 
-    mng.hydrate("my-env", remote_name="test-ftp")
+    mng.hydrate(
+        "my-env", _make_env_mng_mock_not_running(), remote_name="test-ftp"
+    )
 
     mng.configMng.add_or_set_environment.assert_called_once()  # type: ignore[union-attr]
     saved = mng.configMng.add_or_set_environment.call_args[0][1]  # type: ignore[union-attr]
@@ -1146,7 +1133,9 @@ def test_hydrate_raises_for_unknown_env(
     mng = _make_pull_mng(fake, envs_path, existing_env_cfg=None)
 
     with pytest.raises(click.UsageError, match="not found"):
-        mng.hydrate("my-env", remote_name="test-ftp")
+        mng.hydrate(
+            "my-env", _make_env_mng_mock_not_running(), remote_name="test-ftp"
+        )
 
 
 @pytest.mark.remote
@@ -1160,7 +1149,9 @@ def test_hydrate_raises_for_non_dehydrated_env(
     mng = _make_pull_mng(fake, envs_path, existing_env_cfg=active_cfg)
 
     with pytest.raises(click.UsageError, match="not dehydrated"):
-        mng.hydrate("my-env", remote_name="test-ftp")
+        mng.hydrate(
+            "my-env", _make_env_mng_mock_not_running(), remote_name="test-ftp"
+        )
 
 
 @pytest.mark.remote
@@ -1174,7 +1165,12 @@ def test_hydrate_raises_for_nonexistent_snapshot_id(
     mng = _make_pull_mng(fake, envs_path, existing_env_cfg=dehydrated_cfg)
 
     with pytest.raises(click.UsageError, match="not found"):
-        mng.hydrate("my-env", remote_name="test-ftp", snapshot_id="deadbeef")
+        mng.hydrate(
+            "my-env",
+            _make_env_mng_mock_not_running(),
+            remote_name="test-ftp",
+            snapshot_id="deadbeef",
+        )
 
 
 @pytest.mark.remote
@@ -1206,11 +1202,36 @@ def test_dehydrate_hydrate_roundtrip(
     # 4. Hydrate from the same backend.
     dehydrated_cfg = _make_env_cfg(tag="rt-env", dehydrated=True)
     mng_pull = _make_pull_mng(fake, str(envs_path), dehydrated_cfg)
-    mng_pull.hydrate("rt-env", remote_name="test-ftp")
+    mng_pull.hydrate(
+        "rt-env", _make_env_mng_mock_not_running(), remote_name="test-ftp"
+    )
 
     # The env dir should exist again (untar lands in envs_path/rt-env).
     restored_dir = envs_path / "rt-env"
     assert restored_dir.exists()
+
+
+@pytest.mark.remote
+def test_hydrate_delegates_volume_restoration(
+    tmp_path: pathlib.Path,
+) -> None:
+    """hydrate calls restore_local_volumes on the backend after chunk extraction."""
+    content = b"data" * 512
+    fake = FakeRemoteBackend()
+    _seed_fake_backend(fake, "my-env", content)
+
+    envs_path = str(tmp_path / "envs")
+    dehydrated_cfg = _make_env_cfg(dehydrated=True)
+    mng = _make_pull_mng(fake, envs_path, existing_env_cfg=dehydrated_cfg)
+
+    env_mock = MagicMock()
+    env_mock.is_running.return_value = False
+    env_mng_mock = MagicMock()
+    env_mng_mock.get_environment_from_cfg.return_value = env_mock
+
+    mng.hydrate("my-env", env_mng_mock, remote_name="test-ftp")
+
+    env_mock.restore_local_volumes.assert_called_once()
 
 
 @pytest.mark.remote

--- a/src/util/util.py
+++ b/src/util/util.py
@@ -636,6 +636,24 @@ class Util:
         )
 
     @staticmethod
+    def delete_dir(path: str) -> None:
+        """Delete *path* recursively; retry under sudo on PermissionError."""
+        try:
+            shutil.rmtree(path)
+        except FileNotFoundError:
+            pass
+        except PermissionError:
+            if os.name != "posix" or not shutil.which("sudo"):
+                raise
+            uid = os.getuid()
+            gid = os.getgid()
+            subprocess.run(
+                ["sudo", "chown", "-R", f"{uid}:{gid}", path],
+                check=True,
+            )
+            shutil.rmtree(path)
+
+    @staticmethod
     def fmt_bytes(n: int) -> str:
         """Return a human-readable byte count (e.g. ``1.2 MiB``)."""
         for unit, threshold in (


### PR DESCRIPTION
Remove Docker-specific bind-mount detection from RemoteMng.dehydrate() and make the dehydrate -> hydrate cycle symmetric for all volume types.

- Add Util.delete_dir: sudo-aware recursive delete extracted from the private RemoteMng._delete_dir, now reusable by backend modules.
- Add remove_local_volumes / restore_local_volumes hook pair to the Environment base class with no-op defaults.
- Override both hooks in DockerComposeEnv: · remove_local_volumes_impl — deletes bind-mount device dirs via Util.delete_dir; runs `docker volume rm --force` for named and external volumes. · restore_local_volumes_impl — creates each Docker named volume and populates it from the volumes/<tag>/ subtree already extracted into the env directory by the hydrate tar pass, using a busybox container.
- Extract _is_bind_mount(vol) module-level helper to eliminate the duplicated four-condition check repeated across ensure_resources_impl, volumes_need_elevated_permissions, get_volume_tar_streams, and the new remove_local_volumes_impl.
- RemoteMng.dehydrate: replace inline Docker loop with a single call to env.remove_local_volumes().
- RemoteMng.hydrate: add environment_mng parameter (matching push and dehydrate) and call env.restore_local_volumes() after chunk extraction.
- Update all call sites (shepctl.py, test_remote_mng.py, test_remote_integration.py).

Fixes: #244

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
to change)
- [ ] Change or update to the documentation (with no functional changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Contributor License Agreement
<!--- All contributors must sign the CLA before this PR can be merged. -->
<!--- The CLA Assistant bot will post instructions if you have not yet signed. -->
- [ ] I have signed the [Contributor License Agreement](../CLA.md)
      (or I will follow the CLA Assistant bot instructions posted in this PR).
