### PR TITLE
fix(remote): prevent corrupt chunks from interrupted uploads

### DIFF
--- a/src/remote/backend.py
+++ b/src/remote/backend.py
@@ -44,6 +44,14 @@ class RemoteBackend(ABC):
         return f"chunks/{chunk_hash[:2]}/{chunk_hash}"
 
     @staticmethod
+    def chunk_tmp_path(chunk_hash: str) -> str:
+        """Return the in-flight temp path for *chunk_hash* during upload.
+
+        Example: ``ab3f1c9d...`` → ``chunks/ab/ab3f1c9d....tmp``
+        """
+        return f"chunks/{chunk_hash[:2]}/{chunk_hash}.tmp"
+
+    @staticmethod
     def snapshots_prefix(env_name: str) -> str:
         """Return the remote path prefix for all snapshots of *env_name*.
 
@@ -93,6 +101,14 @@ class RemoteBackend(ABC):
     @abstractmethod
     def delete(self, path: str) -> None:
         """Delete *path* from the remote."""
+
+    @abstractmethod
+    def rename(self, src_path: str, dst_path: str) -> None:
+        """Atomically rename *src_path* to *dst_path* on the remote.
+
+        Both paths are always in the same shard directory.  Implementations
+        map to ``RNFR``/``RNTO`` (FTP) or ``sftp.rename()`` (SFTP).
+        """
 
     @abstractmethod
     def close(self) -> None:

--- a/src/remote/ftp_backend.py
+++ b/src/remote/ftp_backend.py
@@ -77,6 +77,10 @@ class FTPBackend(RemoteBackend):
         self._mkdirs(posixpath.dirname(abs_path))
         self._ftp.storbinary(f"STOR {abs_path}", io.BytesIO(data))
         # Keep shard cache consistent after a new chunk is written.
+        # When uploading via the write-then-rename pattern the caller first
+        # uploads to a .tmp path (added here) and then calls rename(), which
+        # swaps the .tmp entry for the final hash.  The end state is correct
+        # as long as both calls are made in sequence on the same instance.
         parts = path.split("/")
         if len(parts) == 3 and parts[0] == "chunks":
             shard = parts[1]
@@ -104,6 +108,21 @@ class FTPBackend(RemoteBackend):
             self._ftp.delete(self._abs(path))
         except ftplib.error_perm:
             pass
+
+    def rename(self, src_path: str, dst_path: str) -> None:
+        self._ftp.rename(self._abs(src_path), self._abs(dst_path))
+        src_parts = src_path.split("/")
+        dst_parts = dst_path.split("/")
+        if (
+            len(src_parts) == 3
+            and src_parts[0] == "chunks"
+            and len(dst_parts) == 3
+            and dst_parts[0] == "chunks"
+        ):
+            shard = dst_parts[1]
+            if shard in self._shard_cache:
+                self._shard_cache[shard].discard(src_parts[2])
+                self._shard_cache[shard].add(dst_parts[2])
 
     def close(self) -> None:
         try:
@@ -137,4 +156,8 @@ class FTPBackend(RemoteBackend):
             )
         except ftplib.error_perm:
             pass
-        self._shard_cache[shard] = {posixpath.basename(n) for n in names}
+        self._shard_cache[shard] = {
+            posixpath.basename(n)
+            for n in names
+            if not posixpath.basename(n).endswith(".tmp")
+        }

--- a/src/remote/remote_mng.py
+++ b/src/remote/remote_mng.py
@@ -352,16 +352,21 @@ class RemoteMng:
                 for chunk in chunker.chunk_stream(stream):
                     shard = chunk.hash[:2]
                     if shard not in shard_cache:
-                        shard_cache[shard] = set(
-                            backend.list_prefix(f"chunks/{shard}")
-                        )
+                        shard_cache[shard] = {
+                            name
+                            for name in backend.list_prefix(f"chunks/{shard}")
+                            if not name.endswith(".tmp")
+                        }
                     chunk_hashes.append(chunk.hash)
                     total_raw += chunk.raw_size
                     total_stored += len(chunk.data)
                     if chunk.hash not in shard_cache[shard]:
-                        backend.upload(
-                            RemoteBackend.chunk_path(chunk.hash), chunk.data
+                        tmp_path = RemoteBackend.chunk_tmp_path(chunk.hash)
+                        backend.upload(tmp_path, chunk.data)
+                        backend.rename(
+                            tmp_path, RemoteBackend.chunk_path(chunk.hash)
                         )
+                        shard_cache[shard].add(chunk.hash)
                         uploaded += 1
 
             now = _utcnow()
@@ -725,23 +730,32 @@ class RemoteMng:
 
             # Enumerate every stored chunk across all 256 hex shards.
             orphans: list[str] = []
+            tmp_files: list[str] = []
             total = 0
             for shard in (f"{i:02x}" for i in range(256)):
-                for chunk_hash in backend.list_prefix(f"chunks/{shard}"):
-                    total += 1
-                    if chunk_hash not in referenced:
-                        orphans.append(chunk_hash)
+                for name in backend.list_prefix(f"chunks/{shard}"):
+                    if name.endswith(".tmp"):
+                        tmp_files.append(f"chunks/{shard}/{name}")
+                    else:
+                        total += 1
+                        if name not in referenced:
+                            orphans.append(name)
 
-            # Delete (or dry-run report) orphaned chunks.
+            # Delete (or dry-run report) orphaned chunks and stranded temp
+            # files left by interrupted uploads.
             if not dry_run:
                 for chunk_hash in orphans:
                     backend.delete(RemoteBackend.chunk_path(chunk_hash))
+                for tmp_path in tmp_files:
+                    backend.delete(tmp_path)
 
         action = "would be deleted" if dry_run else "deleted"
+        tmp_action = "would be cleaned" if dry_run else "cleaned"
         Util.print(
             f"Prune '{remote_cfg.name}': "
             f"{total} chunk(s) scanned, "
-            f"{len(orphans)} orphan(s) {action}."
+            f"{len(orphans)} orphan(s) {action}, "
+            f"{len(tmp_files)} incomplete upload(s) {tmp_action}."
         )
 
     def _delete_dir(self, path: str) -> None:

--- a/src/remote/sftp_backend.py
+++ b/src/remote/sftp_backend.py
@@ -104,6 +104,11 @@ class SFTPBackend(RemoteBackend):
         except FileNotFoundError:
             pass
 
+    def rename(self, src_path: str, dst_path: str) -> None:
+        # Errors propagate intentionally: a failed rename must abort the push
+        # rather than leave a .tmp file silently treated as a valid chunk.
+        self._sftp.rename(self._abs(src_path), self._abs(dst_path))
+
     def close(self) -> None:
         try:
             self._sftp.close()

--- a/src/tests/fixtures/fake_remote.py
+++ b/src/tests/fixtures/fake_remote.py
@@ -56,6 +56,13 @@ class FakeRemoteBackend(RemoteBackend):
     def delete(self, path: str) -> None:
         self._store.pop(path, None)
 
+    def rename(self, src_path: str, dst_path: str) -> None:
+        if src_path not in self._store:
+            raise FileNotFoundError(
+                f"FakeRemoteBackend: cannot rename missing path: {src_path}"
+            )
+        self._store[dst_path] = self._store.pop(src_path)
+
     def close(self) -> None:
         pass
 

--- a/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py
+++ b/src/tests/fixtures/plugins/runtime_plugin/fixture_plugin/main.py
@@ -43,6 +43,9 @@ class FakeRemoteBackend(RemoteBackend):
     def delete(self, path: str) -> None:
         pass
 
+    def rename(self, src_path: str, dst_path: str) -> None:
+        pass
+
     def close(self) -> None:
         pass
 

--- a/src/tests/test_remote_backends.py
+++ b/src/tests/test_remote_backends.py
@@ -269,3 +269,113 @@ def test_sftp_close_closes_transport() -> None:
     with pytest.raises(RuntimeError):
         backend.close()
     mock_transport.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# chunk_tmp_path helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_chunk_tmp_path_format() -> None:
+    """chunk_tmp_path returns {shard}/{hash}.tmp, differing from chunk_path by .tmp."""
+    from remote.backend import RemoteBackend
+
+    h = _CHUNK_HASH
+    assert RemoteBackend.chunk_tmp_path(h) == f"chunks/ab/{h}.tmp"
+    assert (
+        RemoteBackend.chunk_tmp_path(h) == RemoteBackend.chunk_path(h) + ".tmp"
+    )
+
+
+# ---------------------------------------------------------------------------
+# FTPBackend — rename
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_ftp_rename_calls_ftp_rename() -> None:
+    """rename issues ftp.rename() at the correct absolute paths."""
+    mock_ftp = MagicMock()
+    backend = _make_ftp_backend(mock_ftp)
+    src = f"chunks/ab/{_CHUNK_HASH}.tmp"
+    dst = _CHUNK_PATH
+    backend.rename(src, dst)
+    mock_ftp.rename.assert_called_once_with(f"{_ROOT}/{src}", f"{_ROOT}/{dst}")
+
+
+@pytest.mark.remote
+def test_ftp_rename_updates_shard_cache() -> None:
+    """rename removes the .tmp name and inserts the final name in the shard cache."""
+    mock_ftp = MagicMock()
+
+    def retrlines_side_effect(cmd: str, callback: object) -> None:
+        if "NLST" in cmd:
+            callback(f"{_CHUNK_HASH}.tmp")  # type: ignore[operator]
+
+    mock_ftp.retrlines.side_effect = retrlines_side_effect
+    backend = _make_ftp_backend(mock_ftp)
+
+    # Warm the shard cache.
+    backend.exists(f"chunks/ab/{_CHUNK_HASH}.tmp")
+
+    backend.rename(f"chunks/ab/{_CHUNK_HASH}.tmp", _CHUNK_PATH)
+
+    shard = backend._shard_cache.get("ab", set())
+    assert f"{_CHUNK_HASH}.tmp" not in shard
+    assert _CHUNK_HASH in shard
+
+
+@pytest.mark.remote
+def test_ftp_rename_cold_cache_does_not_raise() -> None:
+    """rename succeeds and leaves the cache untouched when the shard is not warmed."""
+    mock_ftp = MagicMock()
+    backend = _make_ftp_backend(mock_ftp)
+
+    # Shard "ab" is deliberately NOT warmed before the rename.
+    assert "ab" not in backend._shard_cache
+
+    backend.rename(f"chunks/ab/{_CHUNK_HASH}.tmp", _CHUNK_PATH)
+
+    mock_ftp.rename.assert_called_once()
+    # Cache must remain absent — not populated with stale data.
+    assert "ab" not in backend._shard_cache
+
+
+@pytest.mark.remote
+def test_ftp_warm_shard_excludes_tmp_files() -> None:
+    """_warm_shard must not add .tmp file names to the shard cache."""
+    mock_ftp = MagicMock()
+    tmp_name = f"{_CHUNK_HASH}.tmp"
+
+    def retrlines_side_effect(cmd: str, callback: object) -> None:
+        if "NLST" in cmd:
+            callback(tmp_name)  # type: ignore[operator]
+            callback(_CHUNK_HASH)  # type: ignore[operator]
+
+    mock_ftp.retrlines.side_effect = retrlines_side_effect
+    backend = _make_ftp_backend(mock_ftp)
+
+    # Trigger shard warming.
+    backend.exists(_CHUNK_PATH)
+
+    shard = backend._shard_cache.get("ab", set())
+    assert tmp_name not in shard
+    assert _CHUNK_HASH in shard
+
+
+# ---------------------------------------------------------------------------
+# SFTPBackend — rename
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_sftp_rename_calls_sftp_rename() -> None:
+    """rename delegates to sftp.rename() at the correct absolute paths."""
+    mock_sftp = MagicMock()
+    mock_transport = MagicMock()
+    backend = _make_sftp_backend(mock_sftp, mock_transport)
+    src = f"chunks/ab/{_CHUNK_HASH}.tmp"
+    dst = _CHUNK_PATH
+    backend.rename(src, dst)
+    mock_sftp.rename.assert_called_once_with(f"{_ROOT}/{src}", f"{_ROOT}/{dst}")

--- a/src/tests/test_remote_mng.py
+++ b/src/tests/test_remote_mng.py
@@ -1476,16 +1476,153 @@ def test_prune_empty_remote() -> None:
 
 @pytest.mark.remote
 def test_prune_prints_summary(capsys: pytest.CaptureFixture[str]) -> None:
-    """prune prints a summary line with scanned and orphaned counts."""
+    """prune prints a summary line with scanned, orphaned, and tmp counts."""
     fake = FakeRemoteBackend()
     _seed_prune_backend(fake, "my-env", [_HASH_A], [_HASH_B])
     mng = _make_prune_mng(fake)
 
     mng.prune(remote_name="test-ftp")
 
-    out = capsys.readouterr().out
+    out = " ".join(capsys.readouterr().out.split())
     assert "2 chunk(s) scanned" in out
     assert "1 orphan(s) deleted" in out
+    assert "0 incomplete upload(s) cleaned" in out
+
+
+@pytest.mark.remote
+def test_prune_deletes_stranded_tmp_files() -> None:
+    """prune removes .tmp files left by interrupted uploads."""
+    fake = FakeRemoteBackend()
+    _seed_prune_backend(fake, "my-env", [_HASH_A], [])
+
+    stranded = f"chunks/aa/{_HASH_A}.tmp"
+    fake._store[stranded] = b"partial"
+
+    mng = _make_prune_mng(fake)
+    mng.prune(remote_name="test-ftp")
+
+    assert stranded not in fake._store
+    assert RemoteBackend.chunk_path(_HASH_A) in fake._store
+
+
+@pytest.mark.remote
+def test_prune_dry_run_preserves_tmp_files() -> None:
+    """prune --dry-run leaves .tmp files intact."""
+    fake = FakeRemoteBackend()
+    _seed_prune_backend(fake, "my-env", [_HASH_A], [])
+
+    stranded = f"chunks/aa/{_HASH_A}.tmp"
+    fake._store[stranded] = b"partial"
+
+    mng = _make_prune_mng(fake)
+    mng.prune(remote_name="test-ftp", dry_run=True)
+
+    assert stranded in fake._store
+
+
+@pytest.mark.remote
+def test_push_chunks_stored_without_tmp_suffix(
+    tmp_path: pathlib.Path,
+) -> None:
+    """All chunk paths in the backend after push use the final hash name, not .tmp."""
+    env_dir = tmp_path / "my-env"
+    env_dir.mkdir()
+    (env_dir / "data.txt").write_bytes(b"hello" * 1024)
+
+    fake = FakeRemoteBackend()
+    mng, env_mng = _make_push_mng(fake, _make_env_cfg(), str(env_dir))
+    mng.push("my-env", env_mng, remote_name="test-ftp")
+
+    chunk_paths = [k for k in fake._store if k.startswith("chunks/")]
+    assert chunk_paths, "Expected at least one chunk to be uploaded"
+    for path in chunk_paths:
+        assert not path.endswith(
+            ".tmp"
+        ), f"Chunk path {path!r} still has .tmp suffix after push"
+
+
+@pytest.mark.remote
+def test_push_issues_rename_after_upload(
+    tmp_path: pathlib.Path,
+) -> None:
+    """push uploads each chunk to a .tmp path then renames to the final path."""
+    env_dir = tmp_path / "my-env"
+    env_dir.mkdir()
+    (env_dir / "data.txt").write_bytes(b"hello" * 1024)
+
+    fake = FakeRemoteBackend()
+    upload_calls: list[str] = []
+    rename_calls: list[tuple[str, str]] = []
+
+    original_upload = fake.upload
+    original_rename = fake.rename
+
+    def _spy_upload(path: str, data: bytes) -> None:
+        upload_calls.append(path)
+        original_upload(path, data)
+
+    def _spy_rename(src: str, dst: str) -> None:
+        rename_calls.append((src, dst))
+        original_rename(src, dst)
+
+    fake.upload = _spy_upload  # type: ignore[method-assign]
+    fake.rename = _spy_rename  # type: ignore[method-assign]
+
+    mng, env_mng = _make_push_mng(fake, _make_env_cfg(), str(env_dir))
+    mng.push("my-env", env_mng, remote_name="test-ftp")
+
+    chunk_uploads = [p for p in upload_calls if p.startswith("chunks/")]
+    assert chunk_uploads, "Expected at least one chunk upload"
+    for path in chunk_uploads:
+        assert path.endswith(
+            ".tmp"
+        ), f"Chunk uploaded to non-.tmp path: {path!r}"
+
+    assert len(rename_calls) == len(chunk_uploads)
+    for tmp_path_val, final_path in rename_calls:
+        assert tmp_path_val.endswith(".tmp")
+        assert final_path == tmp_path_val[: -len(".tmp")]
+
+
+@pytest.mark.remote
+def test_push_shard_cache_ignores_stranded_tmp(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A stranded .tmp file must not suppress re-upload of its chunk."""
+    env_dir = tmp_path / "my-env"
+    env_dir.mkdir()
+    (env_dir / "data.txt").write_bytes(b"hello" * 1024)
+
+    fake = FakeRemoteBackend()
+
+    # First push to discover which hashes are produced.
+    mng, env_mng = _make_push_mng(fake, _make_env_cfg(), str(env_dir))
+    mng.push("my-env", env_mng, remote_name="test-ftp")
+    chunk_paths = [k for k in fake._store if k.startswith("chunks/")]
+    assert chunk_paths
+
+    # Simulate a crash: replace final chunk files with partial .tmp files.
+    for final_path in chunk_paths:
+        parts = final_path.split("/")  # ["chunks", shard, hash]
+        fake._store.pop(final_path)
+        fake._store[f"chunks/{parts[1]}/{parts[2]}.tmp"] = b"partial"
+
+    # Second push must re-upload the chunks, not skip them.
+    mng2, env_mng2 = _make_push_mng(fake, _make_env_cfg(), str(env_dir))
+    uploaded_on_second: list[str] = []
+    original_upload = fake.upload
+
+    def _spy(path: str, data: bytes) -> None:
+        if path.startswith("chunks/") and path.endswith(".tmp"):
+            uploaded_on_second.append(path)
+        original_upload(path, data)
+
+    fake.upload = _spy  # type: ignore[method-assign]
+    mng2.push("my-env", env_mng2, remote_name="test-ftp")
+
+    assert (
+        uploaded_on_second
+    ), "Chunks must be re-uploaded when only .tmp files exist"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Upload each chunk to a temp path (`{hash}.tmp`) and rename to the
  final hash path only after the upload completes, making the on-remote
  write effectively atomic
- Shard cache (orchestrator-level and `FTPBackend` in-memory) now
  filters `.tmp` names so a stranded partial file never suppresses
  re-upload on the next push attempt
- `prune` collects and deletes `.tmp` leftovers unconditionally and
  reports them separately in its summary line

## Motivation

Before this change, a crash mid-upload (network drop, SIGKILL) left a
partial file on the remote under its correct hash name.  On the next
push the shard dedup check found that name and skipped the chunk,
leaving a permanently corrupt entry.  A subsequent pull would silently
receive bad data or fail entirely.

## Testing

```
cd src
pytest -q                  # 556 passed
pyright                    # 0 errors
black src && isort src     # no changes
```

Fixes: #252