### PR TITLE
feat(remote): live progress display for push/pull/hydrate/dehydrate

### DIFF
--- a/src/remote/remote_mng.py
+++ b/src/remote/remote_mng.py
@@ -41,6 +41,7 @@ from .sftp_backend import SFTPBackend
 if TYPE_CHECKING:
     from environment.environment import Environment, EnvironmentMng
     from plugin.runtime import PluginRuntimeMng
+    from remote.remote_progress import DehydrateHooks, PushHooks, RestoreHooks
 
 
 def _utcnow() -> str:
@@ -80,6 +81,10 @@ class RemoteMng:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def resolve_remote_name(self, name: Optional[str]) -> str:
+        """Return the display name of the resolved remote."""
+        return self._resolve_remote(name).name
 
     def _resolve_remote(self, name: Optional[str]) -> RemoteCfg:
         """Return the named remote, the default, or raise
@@ -269,6 +274,7 @@ class RemoteMng:
         remote_name: Optional[str] = None,
         set_tracking: bool = False,
         labels: Optional[list[str]] = None,
+        push_hooks: Optional[PushHooks] = None,
     ) -> None:
         """Create a new remote snapshot for *env_name*.
 
@@ -348,6 +354,8 @@ class RemoteMng:
             # OS pipe buffer and then blocks on write — natural backpressure
             # with no deadlock risk.
             shard_cache: dict[str, set[str]] = {}
+            if push_hooks and push_hooks.on_start:
+                push_hooks.on_start()
             with producer.stream() as stream:
                 for chunk in chunker.chunk_stream(stream):
                     shard = chunk.hash[:2]
@@ -360,7 +368,12 @@ class RemoteMng:
                     chunk_hashes.append(chunk.hash)
                     total_raw += chunk.raw_size
                     total_stored += len(chunk.data)
-                    if chunk.hash not in shard_cache[shard]:
+                    is_new = chunk.hash not in shard_cache[shard]
+                    if push_hooks:
+                        push_hooks.on_chunk(
+                            chunk.raw_size, len(chunk.data), is_new
+                        )
+                    if is_new:
                         tmp_path = RemoteBackend.chunk_tmp_path(chunk.hash)
                         backend.upload(tmp_path, chunk.data)
                         backend.rename(
@@ -414,15 +427,25 @@ class RemoteMng:
             self.configMng.add_or_set_environment(env_name, env_cfg)
 
         skipped = len(chunk_hashes) - uploaded
-        Util.print(
-            f"Pushed '{env_name}' → '{remote_cfg.name}' "
-            f"[{snapshot_id}]: "
-            f"{uploaded} chunk(s) uploaded, "
-            f"{skipped} already present, "
-            f"{Util.fmt_bytes(total_stored)} stored."
-        )
+        if push_hooks:
+            push_hooks.on_complete(
+                snapshot_id, uploaded, skipped, total_raw, total_stored
+            )
+        else:
+            Util.print(
+                f"Pushed '{env_name}' → '{remote_cfg.name}' "
+                f"[{snapshot_id}]: "
+                f"{uploaded} chunk(s) uploaded, "
+                f"{skipped} already present, "
+                f"{Util.fmt_bytes(total_stored)} stored."
+            )
 
-    def dehydrate(self, env_name: str, environment_mng: EnvironmentMng) -> None:
+    def dehydrate(
+        self,
+        env_name: str,
+        environment_mng: EnvironmentMng,
+        dehydrate_hooks: Optional[DehydrateHooks] = None,
+    ) -> None:
         """Strip local data for *env_name* while preserving its config entry.
 
         Removes all backend-managed volumes, then the environment directory.
@@ -448,7 +471,11 @@ class RemoteMng:
         env: Environment = environment_mng.get_environment_from_cfg(env_cfg)
         self._stop_if_running(env, environment_mng)
 
+        if dehydrate_hooks:
+            dehydrate_hooks.on_phase("Removing volumes")
         env.remove_local_volumes()
+        if dehydrate_hooks:
+            dehydrate_hooks.on_phase("Deleting local data")
         env_dir = os.path.join(self.configMng.config.envs_path, env_name)
         self._delete_dir(env_dir)
 
@@ -511,6 +538,7 @@ class RemoteMng:
         manifest: SnapshotManifest,
         dest_dir: str,
         cache: LocalChunkCache | NullLocalChunkCache,
+        restore_hooks: Optional[RestoreHooks] = None,
     ) -> tuple[int, int]:
         """Download, decompress, and untar all chunks into *dest_dir*.
 
@@ -540,12 +568,16 @@ class RemoteMng:
                         if (cached := cache.get(chunk_hash)) is not None:
                             compressed = cached
                             counters[1] += 1
+                            from_cache = True
                         else:
                             compressed = backend.download(
                                 RemoteBackend.chunk_path(chunk_hash)
                             )
                             cache.put(chunk_hash, compressed)
                             counters[0] += 1
+                            from_cache = False
+                        if restore_hooks:
+                            restore_hooks.on_chunk(from_cache)
                         wf.write(dctx.decompress(compressed))
             except BrokenPipeError:
                 # The read end was closed early (e.g. tarfile raised an error
@@ -574,6 +606,7 @@ class RemoteMng:
         env_name: str,
         remote_name: Optional[str] = None,
         snapshot_id: Optional[str] = None,
+        restore_hooks: Optional[RestoreHooks] = None,
     ) -> None:
         """Create a local environment entry from a remote snapshot.
 
@@ -600,8 +633,12 @@ class RemoteMng:
 
         with self._build_backend(remote_cfg) as backend:
             manifest = self._resolve_manifest(backend, env_name, snapshot_id)
+            if restore_hooks:
+                restore_hooks.on_manifest(
+                    manifest.chunk_count, manifest.snapshot_id
+                )
             downloaded, from_cache = self._restore_chunks(
-                backend, manifest, dest_dir, cache
+                backend, manifest, dest_dir, cache, restore_hooks
             )
 
         env_cfg = EnvironmentCfg(
@@ -617,13 +654,21 @@ class RemoteMng:
         )
         self.configMng.add_or_set_environment(env_name, env_cfg)
 
-        Util.print(
-            f"Pulled '{env_name}' ← '{remote_cfg.name}' "
-            f"[{manifest.snapshot_id}]: "
-            f"{downloaded} chunk(s) downloaded, "
-            f"{from_cache} from cache, "
-            f"{Util.fmt_bytes(manifest.stored_size_bytes)} stored."
-        )
+        if restore_hooks:
+            restore_hooks.on_complete(
+                manifest.snapshot_id,
+                downloaded,
+                from_cache,
+                manifest.stored_size_bytes,
+            )
+        else:
+            Util.print(
+                f"Pulled '{env_name}' ← '{remote_cfg.name}' "
+                f"[{manifest.snapshot_id}]: "
+                f"{downloaded} chunk(s) downloaded, "
+                f"{from_cache} from cache, "
+                f"{Util.fmt_bytes(manifest.stored_size_bytes)} stored."
+            )
 
     def hydrate(
         self,
@@ -631,6 +676,7 @@ class RemoteMng:
         environment_mng: Optional["EnvironmentMng"] = None,
         remote_name: Optional[str] = None,
         snapshot_id: Optional[str] = None,
+        restore_hooks: Optional[RestoreHooks] = None,
     ) -> None:
         """Restore local data for a dehydrated environment.
 
@@ -664,8 +710,12 @@ class RemoteMng:
 
         with self._build_backend(remote_cfg) as backend:
             manifest = self._resolve_manifest(backend, env_name, snapshot_id)
+            if restore_hooks:
+                restore_hooks.on_manifest(
+                    manifest.chunk_count, manifest.snapshot_id
+                )
             downloaded, from_cache = self._restore_chunks(
-                backend, manifest, dest_dir, cache
+                backend, manifest, dest_dir, cache, restore_hooks
             )
 
         if environment_mng is not None:
@@ -677,13 +727,21 @@ class RemoteMng:
         env_cfg.dehydrated = False
         self.configMng.add_or_set_environment(env_name, env_cfg)
 
-        Util.print(
-            f"Hydrated '{env_name}' ← '{remote_cfg.name}' "
-            f"[{manifest.snapshot_id}]: "
-            f"{downloaded} chunk(s) downloaded, "
-            f"{from_cache} from cache, "
-            f"{Util.fmt_bytes(manifest.stored_size_bytes)} stored."
-        )
+        if restore_hooks:
+            restore_hooks.on_complete(
+                manifest.snapshot_id,
+                downloaded,
+                from_cache,
+                manifest.stored_size_bytes,
+            )
+        else:
+            Util.print(
+                f"Hydrated '{env_name}' ← '{remote_cfg.name}' "
+                f"[{manifest.snapshot_id}]: "
+                f"{downloaded} chunk(s) downloaded, "
+                f"{from_cache} from cache, "
+                f"{Util.fmt_bytes(manifest.stored_size_bytes)} stored."
+            )
 
     # ------------------------------------------------------------------
     # Prune

--- a/src/remote/remote_progress.py
+++ b/src/remote/remote_progress.py
@@ -1,0 +1,361 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Orchestration layer for remote operation progress display.
+
+Hook dataclasses are defined here and passed as optional parameters into
+``RemoteMng`` methods.  All Rich rendering is isolated in ``remote_render``;
+``remote_mng`` itself has no Rich dependency.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+from rich.live import Live
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+)
+
+from util import Util
+
+from .remote_render import build_push_renderable, build_restore_header
+
+if TYPE_CHECKING:
+    from remote.remote_mng import RemoteMng
+
+_UI_HZ = 8
+_UI_TICK = 1.0 / _UI_HZ
+
+
+# ------------------------------------------------------------------
+# Hook dataclasses — imported by remote_mng under TYPE_CHECKING
+# ------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PushHooks:
+    """Callbacks injected into ``RemoteMng.push``."""
+
+    on_chunk: Callable[[int, int, bool], None]
+    on_complete: Callable[[str, int, int, int, int], None]
+    on_start: Optional[Callable[[], None]] = None
+
+
+@dataclass(frozen=True)
+class RestoreHooks:
+    """Callbacks injected into ``RemoteMng.pull`` / ``RemoteMng.hydrate``."""
+
+    on_manifest: Callable[[int, str], None]
+    on_chunk: Callable[[bool], None]
+    on_complete: Callable[[str, int, int, int], None]
+
+
+@dataclass(frozen=True)
+class DehydrateHooks:
+    """Callbacks injected into ``RemoteMng.dehydrate``."""
+
+    on_phase: Callable[[str], None]
+
+
+# ------------------------------------------------------------------
+# Internal helpers
+# ------------------------------------------------------------------
+
+
+def _remote_display_name(mng: RemoteMng, remote_name: Optional[str]) -> str:
+    return mng.resolve_remote_name(remote_name)
+
+
+def _make_restore_progress() -> Progress:
+    return Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        MofNCompleteColumn(),
+        TextColumn("[dim]·  {task.fields[from_cache]} from cache[/dim]"),
+        console=Util.console,
+        transient=True,
+    )
+
+
+def _run_restore_with_progress(
+    mng: RemoteMng,
+    env_name: str,
+    remote_display: str,
+    call_restore: Callable[[RestoreHooks], None],
+    summary_verb: str,
+) -> None:
+    task_holder: list[Any] = []
+    from_cache_count = [0]
+    complete: list[tuple[str, int, int, int]] = []
+
+    progress = _make_restore_progress()
+
+    def on_manifest(total_chunks: int, snap_id: str) -> None:
+        progress.console.print(
+            build_restore_header(env_name, remote_display, snap_id)
+        )
+        task_id = progress.add_task(
+            f"Downloading {total_chunks} chunk(s)",
+            total=total_chunks,
+            from_cache=0,
+        )
+        task_holder.append(task_id)
+
+    def on_chunk(from_cache: bool) -> None:
+        if not task_holder:
+            return
+        progress.advance(task_holder[0])
+        if from_cache:
+            from_cache_count[0] += 1
+            progress.update(task_holder[0], from_cache=from_cache_count[0])
+
+    def on_complete(
+        snap_id: str, downloaded: int, from_cache: int, stored_bytes: int
+    ) -> None:
+        complete.append((snap_id, downloaded, from_cache, stored_bytes))
+
+    hooks = RestoreHooks(
+        on_manifest=on_manifest, on_chunk=on_chunk, on_complete=on_complete
+    )
+
+    with progress:
+        call_restore(hooks)
+
+    if complete:
+        snap_id, downloaded, from_cache, stored_bytes = complete[0]
+        Util.print(
+            f"{summary_verb} '{env_name}' ← '{remote_display}' "
+            f"[{snap_id}]: "
+            f"{downloaded} chunk(s) downloaded, "
+            f"{from_cache} from cache, "
+            f"{Util.fmt_bytes(stored_bytes)} stored."
+        )
+
+
+# ------------------------------------------------------------------
+# run_push_with_progress
+# ------------------------------------------------------------------
+
+
+def run_push_with_progress(
+    mng: RemoteMng,
+    env_name: str,
+    environment_mng: Any,
+    remote_name: Optional[str] = None,
+    set_tracking: bool = False,
+    labels: Optional[list[str]] = None,
+) -> None:
+    if not Util.console.is_terminal:
+        mng.push(
+            env_name=env_name,
+            environment_mng=environment_mng,
+            remote_name=remote_name,
+            set_tracking=set_tracking,
+            labels=labels,
+        )
+        return
+
+    remote_display = _remote_display_name(mng, remote_name)
+
+    lock = threading.Lock()
+    total = [0]
+    uploaded = [0]
+    skipped = [0]
+    raw = [0]
+    stored = [0]
+    complete: list[tuple[str, int, int, int, int]] = []
+
+    def on_chunk(raw_size: int, stored_size: int, is_new: bool) -> None:
+        with lock:
+            total[0] += 1
+            raw[0] += raw_size
+            stored[0] += stored_size
+            if is_new:
+                uploaded[0] += 1
+            else:
+                skipped[0] += 1
+
+    def on_complete(
+        snapshot_id: str,
+        n_uploaded: int,
+        n_skipped: int,
+        n_raw: int,
+        n_stored: int,
+    ) -> None:
+        complete.append((snapshot_id, n_uploaded, n_skipped, n_raw, n_stored))
+
+    stop_tick = threading.Event()
+    tick = [0]
+    live = Live(
+        refresh_per_second=_UI_HZ,
+        console=Util.console,
+        transient=True,
+    )
+    live_started = [False]
+    tick_thread_holder: list[threading.Thread] = []
+
+    def on_start() -> None:
+        live.__enter__()
+        live_started[0] = True
+
+        def _tick_loop() -> None:
+            while not stop_tick.is_set():
+                with lock:
+                    t = total[0]
+                    u = uploaded[0]
+                    s = skipped[0]
+                    r = raw[0]
+                    st = stored[0]
+                live.update(
+                    build_push_renderable(
+                        env_name, remote_display, t, u, s, r, st, tick=tick[0]
+                    )
+                )
+                tick[0] += 1
+                time.sleep(_UI_TICK)
+
+        t = threading.Thread(target=_tick_loop, daemon=True)
+        t.start()
+        tick_thread_holder.append(t)
+
+    hooks = PushHooks(
+        on_chunk=on_chunk, on_complete=on_complete, on_start=on_start
+    )
+
+    try:
+        mng.push(
+            env_name=env_name,
+            environment_mng=environment_mng,
+            remote_name=remote_name,
+            set_tracking=set_tracking,
+            labels=labels,
+            push_hooks=hooks,
+        )
+    finally:
+        stop_tick.set()
+        if tick_thread_holder:
+            tick_thread_holder[0].join()
+        if live_started[0]:
+            live.__exit__(None, None, None)
+
+    if complete:
+        snapshot_id, n_up, n_sk, _, n_st = complete[0]
+        Util.print(
+            f"Pushed '{env_name}' → '{remote_display}' "
+            f"[{snapshot_id}]: "
+            f"{n_up} chunk(s) uploaded, "
+            f"{n_sk} already present, "
+            f"{Util.fmt_bytes(n_st)} stored."
+        )
+
+
+# ------------------------------------------------------------------
+# run_pull_with_progress
+# ------------------------------------------------------------------
+
+
+def run_pull_with_progress(
+    mng: RemoteMng,
+    env_name: str,
+    remote_name: Optional[str] = None,
+    snapshot_id: Optional[str] = None,
+) -> None:
+    if not Util.console.is_terminal:
+        mng.pull(
+            env_name=env_name,
+            remote_name=remote_name,
+            snapshot_id=snapshot_id,
+        )
+        return
+
+    remote_display = _remote_display_name(mng, remote_name)
+    _run_restore_with_progress(
+        mng,
+        env_name,
+        remote_display,
+        lambda hooks: mng.pull(
+            env_name=env_name,
+            remote_name=remote_name,
+            snapshot_id=snapshot_id,
+            restore_hooks=hooks,
+        ),
+        "Pulled",
+    )
+
+
+# ------------------------------------------------------------------
+# run_hydrate_with_progress
+# ------------------------------------------------------------------
+
+
+def run_hydrate_with_progress(
+    mng: RemoteMng,
+    env_name: str,
+    environment_mng: Any,
+    remote_name: Optional[str] = None,
+    snapshot_id: Optional[str] = None,
+) -> None:
+    if not Util.console.is_terminal:
+        mng.hydrate(
+            env_name=env_name,
+            environment_mng=environment_mng,
+            remote_name=remote_name,
+            snapshot_id=snapshot_id,
+        )
+        return
+
+    remote_display = _remote_display_name(mng, remote_name)
+    _run_restore_with_progress(
+        mng,
+        env_name,
+        remote_display,
+        lambda hooks: mng.hydrate(
+            env_name=env_name,
+            environment_mng=environment_mng,
+            remote_name=remote_name,
+            snapshot_id=snapshot_id,
+            restore_hooks=hooks,
+        ),
+        "Hydrated",
+    )
+
+
+# ------------------------------------------------------------------
+# run_dehydrate_with_progress
+# ------------------------------------------------------------------
+
+
+def run_dehydrate_with_progress(
+    mng: RemoteMng,
+    env_name: str,
+    environment_mng: Any,
+) -> None:
+    if not Util.console.is_terminal:
+        mng.dehydrate(
+            env_name=env_name,
+            environment_mng=environment_mng,
+        )
+        return
+
+    def on_phase(label: str) -> None:
+        Util.print(f"  [dim]→[/dim] {label}...")
+
+    mng.dehydrate(
+        env_name=env_name,
+        environment_mng=environment_mng,
+        dehydrate_hooks=DehydrateHooks(on_phase=on_phase),
+    )

--- a/src/remote/remote_render.py
+++ b/src/remote/remote_render.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Pure Rich renderables for remote operation progress displays."""
+
+from __future__ import annotations
+
+from rich.console import Group
+from rich.text import Text
+from rich.tree import Tree
+
+from environment.status_wait import render_moving_shadow_text
+from util import Util
+
+
+def build_push_renderable(
+    env_name: str,
+    remote_name: str,
+    total: int,
+    uploaded: int,
+    skipped: int,
+    raw_bytes: int,
+    stored_bytes: int,
+    *,
+    tick: int,
+) -> Group:
+    """Live push display: animated spinner tree + running counters."""
+    tree = Tree(
+        f"[bold white]{env_name}[/bold white]"
+        f" [dim]→[/dim] [cyan]{remote_name}[/cyan]",
+        guide_style="dim",
+    )
+    tree.add(render_moving_shadow_text("Uploading", tick))
+    counters = Text.from_markup(
+        f"[dim]Chunks[/dim]   {total} processed"
+        f"  ·  [green]{uploaded} new[/green]"
+        f"  ·  [dim]{skipped} skipped[/dim]\n"
+        f"[dim]Data[/dim]     {Util.fmt_bytes(raw_bytes)} raw"
+        f"  ·  {Util.fmt_bytes(stored_bytes)} stored"
+    )
+    return Group(tree, counters)
+
+
+def build_restore_header(
+    env_name: str,
+    remote_name: str,
+    snapshot_id: str,
+    *,
+    direction: str = "←",
+) -> Text:
+    """Static header printed above the pull/hydrate progress bar."""
+    short_id = snapshot_id[:12] if len(snapshot_id) > 12 else snapshot_id
+    return Text.from_markup(
+        f"[bold white]{env_name}[/bold white]"
+        f" [dim]{direction}[/dim] [cyan]{remote_name}[/cyan]"
+        f"  [dim][{short_id}][/dim]"
+    )

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -22,6 +22,12 @@ from environment import EnvironmentMng
 from factory import ShpdEnvironmentFactory, ShpdServiceFactory
 from plugin import PluginMng, PluginRuntimeMng
 from remote import RemoteMng
+from remote.remote_progress import (
+    run_dehydrate_with_progress,
+    run_hydrate_with_progress,
+    run_pull_with_progress,
+    run_push_with_progress,
+)
 from service import ServiceMng
 from util import Util, setup_logging
 from util.constants import DEFAULT_COMPOSE_COMMAND_LOG_LIMIT
@@ -620,7 +626,8 @@ def push_env(
             "Restore local data with 'env hydrate' first."
         )
     label_list = [lbl.strip() for lbl in labels.split(",")] if labels else []
-    shepherd.remoteMng.push(
+    run_push_with_progress(
+        shepherd.remoteMng,
         env_name=env_tag,
         environment_mng=shepherd.environmentMng,
         remote_name=remote_name,
@@ -635,7 +642,11 @@ def push_env(
 def dehydrate_env(shepherd: ShepherdMng, env_tag: Optional[str]) -> None:
     """Strip local data for ENV_TAG (or the checked-out env)."""
     env_tag = _resolve_env_tag(shepherd, env_tag)
-    shepherd.remoteMng.dehydrate(env_tag, shepherd.environmentMng)
+    run_dehydrate_with_progress(
+        shepherd.remoteMng,
+        env_name=env_tag,
+        environment_mng=shepherd.environmentMng,
+    )
 
 
 @env.command(name="pull")
@@ -666,7 +677,8 @@ def pull_env(
             f"Environment '{env_tag}' is dehydrated. "
             "Restore local data with 'env hydrate' instead."
         )
-    shepherd.remoteMng.pull(
+    run_pull_with_progress(
+        shepherd.remoteMng,
         env_name=env_tag,
         remote_name=remote_name,
         snapshot_id=snapshot_id,
@@ -695,7 +707,8 @@ def hydrate_env(
 ) -> None:
     """Restore local data for ENV_TAG (or the checked-out env) from a remote."""
     env_tag = _resolve_env_tag(shepherd, env_tag)
-    shepherd.remoteMng.hydrate(
+    run_hydrate_with_progress(
+        shepherd.remoteMng,
         env_name=env_tag,
         environment_mng=shepherd.environmentMng,
         remote_name=remote_name,

--- a/src/tests/test_remote_mng.py
+++ b/src/tests/test_remote_mng.py
@@ -1626,6 +1626,194 @@ def test_push_shard_cache_ignores_stranded_tmp(
 
 
 # ---------------------------------------------------------------------------
+# Push hooks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_push_hooks_on_start_and_on_chunk_and_on_complete(
+    tmp_path: pathlib.Path,
+) -> None:
+    """push invokes on_start once, on_chunk per chunk, on_complete once."""
+    env_dir = tmp_path / "my-env"
+    env_dir.mkdir()
+    (env_dir / "data.txt").write_bytes(b"abc" * 1024)
+
+    fake = FakeRemoteBackend()
+    mng, env_mng = _make_push_mng(fake, _make_env_cfg(), str(env_dir))
+
+    starts: list[None] = []
+    chunks: list[tuple[int, int, bool]] = []
+    completes: list[tuple[str, int, int, int, int]] = []
+
+    from remote.remote_progress import PushHooks
+
+    hooks = PushHooks(
+        on_start=lambda: starts.append(None),
+        on_chunk=lambda raw, stored, is_new: chunks.append(
+            (raw, stored, is_new)
+        ),
+        on_complete=lambda snap, up, sk, raw, st: completes.append(
+            (snap, up, sk, raw, st)
+        ),
+    )
+
+    mng.push("my-env", env_mng, remote_name="test-ftp", push_hooks=hooks)
+
+    assert len(starts) == 1
+    assert len(chunks) >= 1
+    assert len(completes) == 1
+    snap_id, uploaded, skipped, total_raw, total_stored = completes[0]
+    assert uploaded + skipped == len(chunks)
+    assert total_raw > 0
+    assert total_stored > 0
+
+
+@pytest.mark.remote
+def test_push_hooks_on_chunk_totals_match(tmp_path: pathlib.Path) -> None:
+    """Sum of raw_size and stored_size across on_chunk calls matches
+    the n_raw / n_stored forwarded to on_complete."""
+    env_dir = tmp_path / "my-env"
+    env_dir.mkdir()
+    (env_dir / "data.txt").write_bytes(b"x" * 2048)
+
+    fake = FakeRemoteBackend()
+    mng, env_mng = _make_push_mng(fake, _make_env_cfg(), str(env_dir))
+
+    accumulated_raw = [0]
+    accumulated_stored = [0]
+    complete_raw = [0]
+    complete_stored = [0]
+
+    from remote.remote_progress import PushHooks
+
+    def on_chunk(raw: int, stored: int, is_new: bool) -> None:
+        accumulated_raw[0] += raw
+        accumulated_stored[0] += stored
+
+    def on_complete(snap: str, up: int, sk: int, raw: int, st: int) -> None:
+        complete_raw[0] = raw
+        complete_stored[0] = st
+
+    hooks = PushHooks(on_chunk=on_chunk, on_complete=on_complete)
+    mng.push("my-env", env_mng, remote_name="test-ftp", push_hooks=hooks)
+
+    assert accumulated_raw[0] == complete_raw[0]
+    assert accumulated_stored[0] == complete_stored[0]
+
+
+# ---------------------------------------------------------------------------
+# Restore hooks (pull / hydrate)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_pull_restore_hooks_are_invoked(tmp_path: pathlib.Path) -> None:
+    """pull invokes on_manifest, on_chunk per chunk, and on_complete once."""
+    content = b"pull me" * 512
+    fake = FakeRemoteBackend()
+    manifest = _seed_fake_backend(fake, "my-env", content)
+
+    envs_path = str(tmp_path / "envs")
+    mng = _make_pull_mng(fake, envs_path)
+
+    from remote.remote_progress import RestoreHooks
+
+    manifests_seen: list[tuple[int, str]] = []
+    chunks_seen: list[bool] = []
+    completes: list[tuple[str, int, int, int]] = []
+
+    hooks = RestoreHooks(
+        on_manifest=lambda total, snap: manifests_seen.append((total, snap)),
+        on_chunk=lambda from_cache: chunks_seen.append(from_cache),
+        on_complete=lambda snap, dl, fc, sb: completes.append(
+            (snap, dl, fc, sb)
+        ),
+    )
+
+    mng.pull("my-env", remote_name="test-ftp", restore_hooks=hooks)
+
+    assert len(manifests_seen) == 1
+    total_chunks, snap_id = manifests_seen[0]
+    assert total_chunks == manifest.chunk_count
+    assert snap_id == manifest.snapshot_id
+    assert len(chunks_seen) == manifest.chunk_count
+    assert len(completes) == 1
+    assert completes[0][0] == manifest.snapshot_id
+
+
+@pytest.mark.remote
+def test_hydrate_restore_hooks_are_invoked(tmp_path: pathlib.Path) -> None:
+    """hydrate invokes on_manifest, on_chunk per chunk, and on_complete once."""
+    content = b"hydrate me" * 512
+    fake = FakeRemoteBackend()
+    manifest = _seed_fake_backend(fake, "my-env", content)
+
+    envs_path = str(tmp_path / "envs")
+    dehydrated_cfg = _make_env_cfg(dehydrated=True)
+    mng = _make_pull_mng(fake, envs_path, existing_env_cfg=dehydrated_cfg)
+
+    from remote.remote_progress import RestoreHooks
+
+    manifests_seen: list[tuple[int, str]] = []
+    chunks_seen: list[bool] = []
+    completes: list[tuple[str, int, int, int]] = []
+
+    hooks = RestoreHooks(
+        on_manifest=lambda total, snap: manifests_seen.append((total, snap)),
+        on_chunk=lambda from_cache: chunks_seen.append(from_cache),
+        on_complete=lambda snap, dl, fc, sb: completes.append(
+            (snap, dl, fc, sb)
+        ),
+    )
+
+    mng.hydrate(
+        "my-env",
+        _make_env_mng_mock_not_running(),
+        remote_name="test-ftp",
+        restore_hooks=hooks,
+    )
+
+    assert len(manifests_seen) == 1
+    assert manifests_seen[0][0] == manifest.chunk_count
+    assert len(chunks_seen) == manifest.chunk_count
+    assert len(completes) == 1
+    assert completes[0][0] == manifest.snapshot_id
+
+
+# ---------------------------------------------------------------------------
+# Dehydrate hooks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_dehydrate_hooks_on_phase_called_twice(
+    tmp_path: pathlib.Path,
+) -> None:
+    """dehydrate calls on_phase exactly twice: once for volumes, once for data."""
+    env_dir = tmp_path / "envs" / "my-env"
+    env_dir.mkdir(parents=True)
+
+    env_cfg = _make_env_cfg()
+    configMng = MagicMock()
+    configMng.get_environment.return_value = env_cfg
+    configMng.config.envs_path = str(tmp_path / "envs")
+    mng = RemoteMng(configMng)
+
+    phases: list[str] = []
+
+    from remote.remote_progress import DehydrateHooks
+
+    hooks = DehydrateHooks(on_phase=lambda label: phases.append(label))
+
+    mng.dehydrate(
+        "my-env", _make_env_mng_mock_not_running(), dehydrate_hooks=hooks
+    )
+
+    assert phases == ["Removing volumes", "Deleting local data"]
+
+
+# ---------------------------------------------------------------------------
 # Plugin backend dispatch
 # ---------------------------------------------------------------------------
 

--- a/src/tests/test_remote_progress.py
+++ b/src/tests/test_remote_progress.py
@@ -1,0 +1,537 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Unit tests for :mod:`remote.remote_progress`.
+
+Non-terminal paths are exercised with the conftest's ``force_terminal=False``
+console (already the default).  Terminal paths patch ``Util.console`` with a
+mock whose ``is_terminal`` attribute is ``True`` and stub out the Rich Live /
+Progress objects to avoid actual TTY rendering.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from remote.remote_progress import (
+    DehydrateHooks,
+    PushHooks,
+    RestoreHooks,
+    _make_restore_progress,
+    _remote_display_name,
+    run_dehydrate_with_progress,
+    run_hydrate_with_progress,
+    run_pull_with_progress,
+    run_push_with_progress,
+)
+from util.util import Util
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mng_mock(remote_display: str = "prod") -> MagicMock:
+    mng = MagicMock()
+    mng.resolve_remote_name.return_value = remote_display
+    return mng
+
+
+def _terminal_console() -> MagicMock:
+    console = MagicMock()
+    console.is_terminal = True
+    return console
+
+
+# ---------------------------------------------------------------------------
+# _remote_display_name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_remote_display_name_delegates_to_mng() -> None:
+    """_remote_display_name calls mng.resolve_remote_name and returns result."""
+    mng = _make_mng_mock("my-remote")
+    assert _remote_display_name(mng, "my-remote") == "my-remote"
+    mng.resolve_remote_name.assert_called_once_with("my-remote")
+
+
+# ---------------------------------------------------------------------------
+# _make_restore_progress
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_make_restore_progress_returns_progress_object() -> None:
+    """_make_restore_progress constructs a Rich Progress without raising."""
+    from rich.progress import Progress
+
+    p = _make_restore_progress()
+    assert isinstance(p, Progress)
+
+
+# ---------------------------------------------------------------------------
+# run_push_with_progress — non-terminal path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_run_push_non_terminal_delegates_to_mng_push() -> None:
+    """Non-terminal: delegates straight to mng.push with correct keyword args."""
+    mng = _make_mng_mock()
+    env_mng = MagicMock()
+
+    run_push_with_progress(
+        mng,
+        "my-env",
+        env_mng,
+        remote_name="prod",
+        set_tracking=True,
+        labels=["k=v"],
+    )
+
+    mng.push.assert_called_once_with(
+        env_name="my-env",
+        environment_mng=env_mng,
+        remote_name="prod",
+        set_tracking=True,
+        labels=["k=v"],
+    )
+
+
+@pytest.mark.remote
+def test_run_push_non_terminal_no_live_started() -> None:
+    """Non-terminal: the Live context manager is never entered."""
+    mng = _make_mng_mock()
+    with pytest.MonkeyPatch.context() as mp:
+        mock_live = MagicMock()
+        mp.setattr(
+            "remote.remote_progress.Live", MagicMock(return_value=mock_live)
+        )
+        run_push_with_progress(mng, "my-env", MagicMock())
+
+    mock_live.__enter__.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# run_pull_with_progress — non-terminal path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_run_pull_non_terminal_delegates_to_mng_pull() -> None:
+    """Non-terminal: delegates to mng.pull with correct keyword args."""
+    mng = _make_mng_mock()
+
+    run_pull_with_progress(
+        mng, "my-env", remote_name="prod", snapshot_id="snap-1"
+    )
+
+    mng.pull.assert_called_once_with(
+        env_name="my-env",
+        remote_name="prod",
+        snapshot_id="snap-1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_hydrate_with_progress — non-terminal path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_run_hydrate_non_terminal_delegates_to_mng_hydrate() -> None:
+    """Non-terminal: delegates to mng.hydrate with correct keyword args."""
+    mng = _make_mng_mock()
+    env_mng = MagicMock()
+
+    run_hydrate_with_progress(
+        mng, "my-env", env_mng, remote_name="prod", snapshot_id="snap-1"
+    )
+
+    mng.hydrate.assert_called_once_with(
+        env_name="my-env",
+        environment_mng=env_mng,
+        remote_name="prod",
+        snapshot_id="snap-1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_dehydrate_with_progress — non-terminal path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_run_dehydrate_non_terminal_delegates_to_mng_dehydrate() -> None:
+    """Non-terminal: delegates to mng.dehydrate without any hooks."""
+    mng = _make_mng_mock()
+    env_mng = MagicMock()
+
+    run_dehydrate_with_progress(mng, "my-env", env_mng)
+
+    mng.dehydrate.assert_called_once_with(
+        env_name="my-env",
+        environment_mng=env_mng,
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_push_with_progress — terminal path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_run_push_terminal_invokes_hooks_and_prints_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Terminal: push hooks are wired up; summary is printed after completion."""
+    monkeypatch.setattr(Util, "console", _terminal_console())
+
+    mock_live = MagicMock()
+    monkeypatch.setattr(
+        "remote.remote_progress.Live", MagicMock(return_value=mock_live)
+    )
+
+    mng = _make_mng_mock("prod")
+
+    def fake_push(
+        env_name: str,
+        environment_mng: Any,
+        remote_name: str | None = None,
+        set_tracking: bool = False,
+        labels: list[str] | None = None,
+        push_hooks: PushHooks | None = None,
+    ) -> None:
+        if push_hooks:
+            push_hooks.on_start()
+            push_hooks.on_chunk(1024, 512, True)
+            push_hooks.on_chunk(512, 256, False)
+            push_hooks.on_complete("snap-abc", 1, 1, 1536, 768)
+
+    mng.push.side_effect = fake_push
+
+    printed: list[str] = []
+    monkeypatch.setattr(
+        "remote.remote_progress.Util.print",
+        lambda msg: printed.append(msg),
+    )
+
+    run_push_with_progress(mng, "my-env", MagicMock(), remote_name="prod")
+
+    mng.push.assert_called_once()
+    mock_live.__enter__.assert_called_once()
+    mock_live.__exit__.assert_called_once()
+    assert any("snap-abc" in m for m in printed)
+
+
+@pytest.mark.remote
+def test_run_push_terminal_no_complete_no_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Terminal: if on_complete is never fired no summary is printed."""
+    monkeypatch.setattr(Util, "console", _terminal_console())
+    monkeypatch.setattr(
+        "remote.remote_progress.Live",
+        MagicMock(return_value=MagicMock()),
+    )
+
+    mng = _make_mng_mock()
+
+    def fake_push(
+        env_name: str,
+        environment_mng: Any,
+        remote_name: str | None = None,
+        set_tracking: bool = False,
+        labels: list[str] | None = None,
+        push_hooks: PushHooks | None = None,
+    ) -> None:
+        if push_hooks:
+            push_hooks.on_start()
+
+    mng.push.side_effect = fake_push
+
+    printed: list[str] = []
+    monkeypatch.setattr(
+        "remote.remote_progress.Util.print",
+        lambda msg: printed.append(msg),
+    )
+
+    run_push_with_progress(mng, "my-env", MagicMock())
+
+    assert printed == []
+
+
+@pytest.mark.remote
+def test_run_push_terminal_exception_stops_tick_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Terminal: the tick thread is stopped and live is exited even on error."""
+    monkeypatch.setattr(Util, "console", _terminal_console())
+    monkeypatch.setattr(
+        "remote.remote_progress.Live",
+        MagicMock(return_value=MagicMock()),
+    )
+
+    mng = _make_mng_mock()
+
+    def fake_push(
+        env_name: str,
+        environment_mng: Any,
+        remote_name: str | None = None,
+        set_tracking: bool = False,
+        labels: list[str] | None = None,
+        push_hooks: PushHooks | None = None,
+    ) -> None:
+        if push_hooks:
+            push_hooks.on_start()
+        raise RuntimeError("upload failed")
+
+    mng.push.side_effect = fake_push
+
+    with pytest.raises(RuntimeError, match="upload failed"):
+        run_push_with_progress(mng, "my-env", MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# run_pull_with_progress — terminal path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_run_pull_terminal_invokes_hooks_and_prints_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Terminal: pull restore hooks fire; summary is printed after completion."""
+    monkeypatch.setattr(Util, "console", _terminal_console())
+
+    mock_progress = MagicMock()
+    mock_progress.__enter__ = MagicMock(return_value=mock_progress)
+    mock_progress.__exit__ = MagicMock(return_value=False)
+    mock_progress.add_task.return_value = 0
+    monkeypatch.setattr(
+        "remote.remote_progress._make_restore_progress",
+        lambda: mock_progress,
+    )
+
+    mng = _make_mng_mock("prod")
+
+    def fake_pull(
+        env_name: str,
+        remote_name: str | None = None,
+        snapshot_id: str | None = None,
+        restore_hooks: RestoreHooks | None = None,
+    ) -> None:
+        if restore_hooks:
+            restore_hooks.on_manifest(3, "snap-xyz")
+            restore_hooks.on_chunk(False)
+            restore_hooks.on_chunk(True)
+            restore_hooks.on_chunk(False)
+            restore_hooks.on_complete("snap-xyz", 2, 1, 20_480)
+
+    mng.pull.side_effect = fake_pull
+
+    printed: list[str] = []
+    monkeypatch.setattr(
+        "remote.remote_progress.Util.print",
+        lambda msg: printed.append(msg),
+    )
+
+    run_pull_with_progress(mng, "my-env", remote_name="prod")
+
+    mng.pull.assert_called_once()
+    mock_progress.__enter__.assert_called_once()
+    assert any("snap-xyz" in m for m in printed)
+    assert any("Pulled" in m for m in printed)
+
+
+@pytest.mark.remote
+def test_run_pull_terminal_on_chunk_before_manifest_is_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """on_chunk fired before on_manifest (no task_holder) must not raise."""
+    monkeypatch.setattr(Util, "console", _terminal_console())
+
+    mock_progress = MagicMock()
+    mock_progress.__enter__ = MagicMock(return_value=mock_progress)
+    mock_progress.__exit__ = MagicMock(return_value=False)
+    monkeypatch.setattr(
+        "remote.remote_progress._make_restore_progress",
+        lambda: mock_progress,
+    )
+
+    mng = _make_mng_mock()
+
+    def fake_pull(
+        env_name: str,
+        remote_name: str | None = None,
+        snapshot_id: str | None = None,
+        restore_hooks: RestoreHooks | None = None,
+    ) -> None:
+        if restore_hooks:
+            # call on_chunk before on_manifest — task_holder is still empty
+            restore_hooks.on_chunk(False)
+
+    mng.pull.side_effect = fake_pull
+    monkeypatch.setattr("remote.remote_progress.Util.print", lambda msg: None)
+
+    run_pull_with_progress(mng, "my-env")  # must not raise
+
+
+@pytest.mark.remote
+def test_run_pull_terminal_no_complete_no_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Terminal: if on_complete is never fired no summary is printed."""
+    monkeypatch.setattr(Util, "console", _terminal_console())
+
+    mock_progress = MagicMock()
+    mock_progress.__enter__ = MagicMock(return_value=mock_progress)
+    mock_progress.__exit__ = MagicMock(return_value=False)
+    monkeypatch.setattr(
+        "remote.remote_progress._make_restore_progress",
+        lambda: mock_progress,
+    )
+
+    mng = _make_mng_mock()
+    mng.pull.return_value = None
+
+    printed: list[str] = []
+    monkeypatch.setattr(
+        "remote.remote_progress.Util.print",
+        lambda msg: printed.append(msg),
+    )
+
+    run_pull_with_progress(mng, "my-env")
+
+    assert printed == []
+
+
+# ---------------------------------------------------------------------------
+# run_hydrate_with_progress — terminal path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_run_hydrate_terminal_invokes_hooks_and_prints_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Terminal: hydrate restore hooks fire; summary says 'Hydrated'."""
+    monkeypatch.setattr(Util, "console", _terminal_console())
+
+    mock_progress = MagicMock()
+    mock_progress.__enter__ = MagicMock(return_value=mock_progress)
+    mock_progress.__exit__ = MagicMock(return_value=False)
+    mock_progress.add_task.return_value = 0
+    monkeypatch.setattr(
+        "remote.remote_progress._make_restore_progress",
+        lambda: mock_progress,
+    )
+
+    mng = _make_mng_mock("prod")
+    env_mng = MagicMock()
+
+    def fake_hydrate(
+        env_name: str,
+        environment_mng: Any,
+        remote_name: str | None = None,
+        snapshot_id: str | None = None,
+        restore_hooks: RestoreHooks | None = None,
+    ) -> None:
+        if restore_hooks:
+            restore_hooks.on_manifest(2, "snap-hyd")
+            restore_hooks.on_chunk(False)
+            restore_hooks.on_chunk(True)
+            restore_hooks.on_complete("snap-hyd", 1, 1, 8_192)
+
+    mng.hydrate.side_effect = fake_hydrate
+
+    printed: list[str] = []
+    monkeypatch.setattr(
+        "remote.remote_progress.Util.print",
+        lambda msg: printed.append(msg),
+    )
+
+    run_hydrate_with_progress(mng, "my-env", env_mng, remote_name="prod")
+
+    mng.hydrate.assert_called_once()
+    assert any("Hydrated" in m for m in printed)
+    assert any("snap-hyd" in m for m in printed)
+
+
+# ---------------------------------------------------------------------------
+# run_dehydrate_with_progress — terminal path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_run_dehydrate_terminal_passes_hooks_to_mng(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Terminal: mng.dehydrate receives a DehydrateHooks with on_phase wired."""
+    monkeypatch.setattr(Util, "console", _terminal_console())
+
+    mng = _make_mng_mock()
+    env_mng = MagicMock()
+
+    received_hooks: list[DehydrateHooks] = []
+
+    def fake_dehydrate(
+        env_name: str,
+        environment_mng: Any,
+        dehydrate_hooks: DehydrateHooks | None = None,
+    ) -> None:
+        if dehydrate_hooks:
+            received_hooks.append(dehydrate_hooks)
+            dehydrate_hooks.on_phase("Removing volumes")
+
+    mng.dehydrate.side_effect = fake_dehydrate
+
+    printed: list[str] = []
+    monkeypatch.setattr(
+        "remote.remote_progress.Util.print",
+        lambda msg: printed.append(msg),
+    )
+
+    run_dehydrate_with_progress(mng, "my-env", env_mng)
+
+    assert len(received_hooks) == 1
+    mng.dehydrate.assert_called_once()
+    assert any("Removing volumes" in m for m in printed)
+
+
+@pytest.mark.remote
+def test_run_dehydrate_terminal_on_phase_prints_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The on_phase callback prints the label via Util.print."""
+    monkeypatch.setattr(Util, "console", _terminal_console())
+
+    mng = _make_mng_mock()
+
+    def fake_dehydrate(
+        env_name: str,
+        environment_mng: Any,
+        dehydrate_hooks: DehydrateHooks | None = None,
+    ) -> None:
+        if dehydrate_hooks:
+            dehydrate_hooks.on_phase("Deleting local data")
+
+    mng.dehydrate.side_effect = fake_dehydrate
+
+    printed: list[str] = []
+    monkeypatch.setattr(
+        "remote.remote_progress.Util.print",
+        lambda msg: printed.append(msg),
+    )
+
+    run_dehydrate_with_progress(mng, "my-env", MagicMock())
+
+    assert any("Deleting local data" in m for m in printed)

--- a/src/tests/test_remote_render.py
+++ b/src/tests/test_remote_render.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Unit tests for :mod:`remote.remote_render`."""
+
+from __future__ import annotations
+
+import pytest
+from rich.console import Group
+from rich.text import Text
+
+from remote.remote_render import build_push_renderable, build_restore_header
+
+
+@pytest.mark.remote
+def test_build_push_renderable_returns_group() -> None:
+    """build_push_renderable returns a Rich Group at any tick value."""
+    result = build_push_renderable(
+        "my-env",
+        "prod",
+        total=10,
+        uploaded=7,
+        skipped=3,
+        raw_bytes=10_240,
+        stored_bytes=5_120,
+        tick=0,
+    )
+    assert isinstance(result, Group)
+
+
+@pytest.mark.remote
+def test_build_push_renderable_advances_tick() -> None:
+    """Two consecutive ticks produce different Group objects (no crash)."""
+    kwargs = dict(
+        env_name="e",
+        remote_name="r",
+        total=1,
+        uploaded=1,
+        skipped=0,
+        raw_bytes=512,
+        stored_bytes=256,
+    )
+    g0 = build_push_renderable(**kwargs, tick=0)
+    g1 = build_push_renderable(**kwargs, tick=5)
+    assert isinstance(g0, Group)
+    assert isinstance(g1, Group)
+
+
+@pytest.mark.remote
+def test_build_restore_header_short_snap_id() -> None:
+    """A snapshot ID shorter than 12 chars is passed through unchanged."""
+    result = build_restore_header("my-env", "prod", "short")
+    assert isinstance(result, Text)
+    # env_name and remote_name always appear as plain text
+    assert "my-env" in result.plain
+    assert "prod" in result.plain
+
+
+@pytest.mark.remote
+def test_build_restore_header_long_snap_id_truncated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A snapshot ID longer than 12 chars is truncated to its first 12 chars."""
+    long_id = "a" * 64
+
+    captured: list[str] = []
+    original = Text.from_markup
+
+    def spy(markup: str, **kw: object) -> Text:
+        captured.append(markup)
+        return original(markup, **kw)
+
+    monkeypatch.setattr(Text, "from_markup", staticmethod(spy))
+
+    build_restore_header("my-env", "prod", long_id)
+
+    assert captured
+    markup = captured[0]
+    assert long_id[:12] in markup
+    assert long_id[12:] not in markup
+
+
+@pytest.mark.remote
+def test_build_restore_header_default_direction() -> None:
+    """Default direction arrow (←) appears in the rendered plain text."""
+    result = build_restore_header("my-env", "prod", "snap1")
+    assert "←" in result.plain
+
+
+@pytest.mark.remote
+def test_build_restore_header_custom_direction() -> None:
+    """Callers can override the direction arrow."""
+    result = build_restore_header("my-env", "prod", "snap1", direction="→")
+    assert "→" in result.plain
+    assert "←" not in result.plain

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -2192,8 +2192,7 @@ def test_cli_env_dehydrate_defaults_to_active_env(
 
     assert result.exit_code == 0, result.output
     mock_dehydrate.assert_called_once()
-    # dehydrate takes env_tag as a positional arg, not keyword
-    assert mock_dehydrate.call_args.args[0] == "test-1"
+    assert mock_dehydrate.call_args.kwargs["env_name"] == "test-1"
 
 
 @pytest.mark.shpd


### PR DESCRIPTION
## Summary

- **push**: Rich `Live` with animated spinner tree + running counters (chunks processed / new / skipped, raw bytes / stored bytes); total is unknown during streaming so no percentage bar
- **pull / hydrate**: `rich.progress.Progress` bar with %, M/N chunk count, and "from cache" counter; total known from the manifest before the download loop, enabling a deterministic bar
- **dehydrate**: phase labels printed inline (`→ Removing volumes... / → Deleting local data...`) via `on_phase` hook

Follows the existing `environment/render.py` + `environment/status_wait.py` decoupling pattern — no Rich code in `remote_mng.py`.

**New modules:**
- `remote/remote_render.py` — pure Rich renderables, no business logic
- `remote/remote_progress.py` — `PushHooks` / `RestoreHooks` / `DehydrateHooks` dataclasses + four `run_X_with_progress` orchestration functions

**Non-TTY / piped output** falls back to the existing silent behaviour (only the final summary line).

## Test plan

- [x] `pyright` — 0 errors
- [x] `pytest` — 557 passed
- [x] `black` / `isort` — no changes
- [x] Pre-commit hooks — all passed
- [ ] Manual: `shepctl env push <env>` — animated spinner + running counters visible
- [ ] Manual: `shepctl env pull <env>` — progress bar with % and from-cache counter
- [ ] Manual: `shepctl env hydrate <env>` — same as pull
- [ ] Manual: `shepctl env dehydrate <env>` — phase labels printed inline
- [ ] Manual: `shepctl env push <env> | cat` — silent, only summary line

Fixes: #254