### PR TITLE
chore(config): remove volumes_path and staging_area

### DIFF
--- a/examples/configurations/env-basic/shpd.yaml
+++ b/examples/configurations/env-basic/shpd.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 env_templates: []
 service_templates: []
 envs:

--- a/examples/configurations/env-with-probes/shpd.yaml
+++ b/examples/configurations/env-with-probes/shpd.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 env_templates: []
 service_templates: []
 envs:

--- a/examples/configurations/fragment-demo/shpd.yaml
+++ b/examples/configurations/fragment-demo/shpd.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 
 # ---------------------------------------------------------------------------
 # Plugins

--- a/examples/configurations/minimal/shpd.yaml
+++ b/examples/configurations/minimal/shpd.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 env_templates: []
 service_templates: []
 envs: []

--- a/examples/configurations/svc-basic/shpd.yaml
+++ b/examples/configurations/svc-basic/shpd.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 env_templates: []
 service_templates:
   - tag: nginx

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -798,16 +798,6 @@ class EnvironmentCfg(Resolvable):
 
 
 @dataclass
-class StagingAreaCfg(Resolvable):
-    """
-    Represents the configuration for the staging area.
-    """
-
-    volumes_path: str
-    images_path: str
-
-
-@dataclass
 class PluginCfg(Resolvable):
     """Represents one installed plugin entry in the main config."""
 
@@ -910,8 +900,6 @@ class Config(Resolvable):
 
     templates_path: str
     envs_path: str
-    volumes_path: str
-    staging_area: StagingAreaCfg
     env_templates: Optional[list[EnvironmentTemplateCfg]] = None
     service_templates: Optional[list[ServiceTemplateCfg]] = None
     env_template_fragments: Optional[list[EnvTemplateFragmentCfg]] = None
@@ -1157,13 +1145,6 @@ def _parse_service(item: Any) -> ServiceCfg:
     )
 
 
-def _parse_staging_area(item: Any) -> StagingAreaCfg:
-    return StagingAreaCfg(
-        volumes_path=item["volumes_path"],
-        images_path=item["images_path"],
-    )
-
-
 def _parse_plugin(item: Any) -> PluginCfg:
     enabled_value = item.get("enabled", True)
     return PluginCfg(
@@ -1382,8 +1363,6 @@ def parse_config(yaml_str: str) -> Config:
         ),
         templates_path=data["templates_path"],
         envs_path=data["envs_path"],
-        volumes_path=data["volumes_path"],
-        staging_area=_parse_staging_area(data["staging_area"]),
         plugins=(
             [_parse_plugin(plugin) for plugin in data.get("plugins", [])]
             if data.get("plugins") is not None
@@ -1445,9 +1424,6 @@ class ConfigMng:
                 self.config.templates_path, Constants.SVC_TEMPLATES_DIR
             ),
             "ENVS": self.config.envs_path,
-            "VOLUMES": self.config.volumes_path,
-            "VOLUMES_SA": self.config.staging_area.volumes_path,
-            "IMAGES_SA": self.config.staging_area.images_path,
         }
 
         for template in self.config.env_templates or []:

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -24,7 +24,7 @@ import yaml
 
 from config import ConfigMng, EnvironmentCfg, EnvironmentTemplateCfg
 from service import Service, ServiceFactory
-from util import Constants, Util
+from util import Util
 from util.constants import DEFAULT_COMPOSE_COMMAND_LOG_LIMIT
 
 from .render import (
@@ -1213,7 +1213,7 @@ class EnvironmentMng:
         self,
         env_tag: Optional[str],
         svc_tag: str,
-        svc_template: Optional[str],
+        svc_template: str,
         svc_class: Optional[str],
     ):
         """Add a service to an environment."""
@@ -1226,9 +1226,7 @@ class EnvironmentMng:
                     f"Service: '{svc_tag}' already "
                     f"defined in environment: '{envCfg.tag}'."
                 )
-            svc_type_cfg = self.configMng.get_service_template(
-                svc_template if svc_template else Constants.SVC_TEMPLATE_DEFAULT
-            )
+            svc_type_cfg = self.configMng.get_service_template(svc_template)
 
             if svc_type_cfg:
                 svcCfg = self.configMng.svc_cfg_from_service_template(
@@ -1236,11 +1234,7 @@ class EnvironmentMng:
                 )
             else:
                 svcCfg = self.configMng.svc_cfg_from_tag(
-                    (
-                        svc_template
-                        if svc_template
-                        else Constants.SVC_TEMPLATE_DEFAULT
-                    ),
+                    svc_template,
                     svc_tag,
                     svc_class,
                 )

--- a/src/plugin/context.py
+++ b/src/plugin/context.py
@@ -99,7 +99,7 @@ class PluginEnvironmentView(Protocol):
         self,
         env_tag: Optional[str],
         svc_tag: str,
-        svc_template: Optional[str],
+        svc_template: str,
         svc_class: Optional[str],
     ) -> None:
         """Add *svc_tag* to the environment identified by *env_tag*."""

--- a/src/resources/shpd.conf
+++ b/src/resources/shpd.conf
@@ -2,9 +2,6 @@
 shpd_path=~/shpd
 templates_path=${shpd_path}/templates
 envs_path=${shpd_path}/envs
-volumes_path=${shpd_path}/volumes
-staging_area_volumes_path=${shpd_path}/sa_volumes
-staging_area_images_path=${shpd_path}/sa_images
 
 # Shepherd default environment type
 default_env_type=docker-compose

--- a/src/tests/fixtures/cfg/shpd.yaml
+++ b/src/tests/fixtures/cfg/shpd.yaml
@@ -59,7 +59,7 @@ env_templates:
         driver_opts:
           type: none
           o: bind
-          device: ${envs_path}/srv/data
+          device: /srv/data
         labels:
           env: production
 service_templates:

--- a/src/tests/fixtures/cfg/shpd.yaml
+++ b/src/tests/fixtures/cfg/shpd.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 plugins:
   - id: acme
     enabled: true
@@ -63,7 +59,7 @@ env_templates:
         driver_opts:
           type: none
           o: bind
-          device: ${volumes_path}/srv/data
+          device: ${envs_path}/srv/data
         labels:
           env: production
 service_templates:

--- a/src/tests/fixtures/cfg/shpd_lifecycle.yaml
+++ b/src/tests/fixtures/cfg/shpd_lifecycle.yaml
@@ -67,7 +67,7 @@ env_templates:
         driver_opts:
           type: none
           o: bind
-          device: ${envs_path}/srv/data
+          device: /srv/data
         labels:
           env: production
 service_templates:

--- a/src/tests/fixtures/cfg/shpd_lifecycle.yaml
+++ b/src/tests/fixtures/cfg/shpd_lifecycle.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 env_templates:
   - tag: default
     factory: docker-compose
@@ -71,7 +67,7 @@ env_templates:
         driver_opts:
           type: none
           o: bind
-          device: ${volumes_path}/srv/data
+          device: ${envs_path}/srv/data
         labels:
           env: production
 service_templates:

--- a/src/tests/fixtures/cfg/shpd_with_fragments.yaml
+++ b/src/tests/fixtures/cfg/shpd_with_fragments.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 
 service_templates:
   - tag: worker

--- a/src/tests/fixtures/cfg/shpd_with_refs.yaml
+++ b/src/tests/fixtures/cfg/shpd_with_refs.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 env_templates:
   - tag: nginx-postgres
     factory: docker-compose
@@ -30,7 +26,7 @@ env_templates:
         driver_opts:
           type: none
           o: bind
-          device: "#{cfg.volumes_path}/#{env.tag}/#{vol.tag}"
+          device: "#{cfg.envs_path}/#{env.tag}/#{vol.tag}"
         labels:
           env: production
       - tag: postgres
@@ -40,7 +36,7 @@ env_templates:
         driver_opts:
           type: none
           o: bind
-          device: "#{cfg.volumes_path}/#{env.tag}/#{vol.tag}"
+          device: "#{cfg.envs_path}/#{env.tag}/#{vol.tag}"
         labels:
           env: production
 service_templates:
@@ -173,7 +169,7 @@ envs:
         driver_opts:
           type: none
           o: bind
-          device: "#{cfg.volumes_path}/#{env.tag}/#{vol.tag}"
+          device: "#{cfg.envs_path}/#{env.tag}/#{vol.tag}"
         labels:
           env: production
       - tag: postgres
@@ -183,7 +179,7 @@ envs:
         driver_opts:
           type: none
           o: bind
-          device: "#{cfg.volumes_path}/#{env.tag}/#{vol.tag}"
+          device: "#{cfg.envs_path}/#{env.tag}/#{vol.tag}"
         labels:
           env: production
     status:

--- a/src/tests/fixtures/cfg/shpd_with_refs.yaml
+++ b/src/tests/fixtures/cfg/shpd_with_refs.yaml
@@ -26,7 +26,7 @@ env_templates:
         driver_opts:
           type: none
           o: bind
-          device: "#{cfg.envs_path}/#{env.tag}/#{vol.tag}"
+          device: "#{cfg.templates_path}/#{env.tag}/#{vol.tag}"
         labels:
           env: production
       - tag: postgres
@@ -36,7 +36,7 @@ env_templates:
         driver_opts:
           type: none
           o: bind
-          device: "#{cfg.envs_path}/#{env.tag}/#{vol.tag}"
+          device: "#{cfg.templates_path}/#{env.tag}/#{vol.tag}"
         labels:
           env: production
 service_templates:
@@ -169,7 +169,7 @@ envs:
         driver_opts:
           type: none
           o: bind
-          device: "#{cfg.envs_path}/#{env.tag}/#{vol.tag}"
+          device: "#{cfg.templates_path}/#{env.tag}/#{vol.tag}"
         labels:
           env: production
       - tag: postgres
@@ -179,7 +179,7 @@ envs:
         driver_opts:
           type: none
           o: bind
-          device: "#{cfg.envs_path}/#{env.tag}/#{vol.tag}"
+          device: "#{cfg.templates_path}/#{env.tag}/#{vol.tag}"
         labels:
           env: production
     status:

--- a/src/tests/fixtures/cfg/values.conf
+++ b/src/tests/fixtures/cfg/values.conf
@@ -18,9 +18,6 @@
   shpd_path=${test_path}
   templates_path=${shpd_path}/templates
   envs_path=${shpd_path}/envs
-  volumes_path=${shpd_path}/volumes
-  staging_area_volumes_path=${shpd_path}/sa_volumes
-  staging_area_images_path=${shpd_path}/sa_images
 
   # Database Default Configuration
   db_sys_usr=sys

--- a/src/tests/fixtures/completion/shpd.yaml
+++ b/src/tests/fixtures/completion/shpd.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 env_templates:
   - tag: default
     factory: docker-compose

--- a/src/tests/fixtures/completion/values.conf
+++ b/src/tests/fixtures/completion/values.conf
@@ -18,9 +18,6 @@
   shpd_path=${test_path}
   templates_path=${shpd_path}/templates
   envs_path=${shpd_path}/envs
-  volumes_path=${shpd_path}/volumes
-  staging_area_volumes_path=${shpd_path}/sa_volumes
-  staging_area_images_path=${shpd_path}/sa_images
 
   # Database Default Configuration
   db_sys_usr=sys

--- a/src/tests/fixtures/env/shpd.yaml
+++ b/src/tests/fixtures/env/shpd.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 env_templates:
   - tag: default
     factory: docker-compose

--- a/src/tests/fixtures/env/shpd_bootstrap.yaml
+++ b/src/tests/fixtures/env/shpd_bootstrap.yaml
@@ -1,0 +1,25 @@
+templates_path: ${templates_path}
+envs_path: ${envs_path}
+env_templates:
+  - tag: default
+    factory: docker-compose
+    service_templates:
+      - template: default
+        tag: service-default
+    networks:
+      - tag: shpdnet
+        name: envnet
+        external: true
+service_templates:
+  - tag: default
+    factory: docker
+    containers:
+      - image: ""
+        tag: container-1
+        ports: []
+        environment: []
+        inits: null
+    properties: {}
+plugins: []
+remotes: []
+envs: []

--- a/src/tests/fixtures/env/values.conf
+++ b/src/tests/fixtures/env/values.conf
@@ -18,9 +18,6 @@
   shpd_path=${test_path}
   templates_path=${shpd_path}/templates
   envs_path=${shpd_path}/envs
-  volumes_path=${shpd_path}/volumes
-  staging_area_volumes_path=${shpd_path}/sa_volumes
-  staging_area_images_path=${shpd_path}/sa_images
 
   # Database Default Configuration
   db_sys_usr=sys

--- a/src/tests/fixtures/env_docker/shpd.yaml
+++ b/src/tests/fixtures/env_docker/shpd.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 envs:
   - template: default
     factory: docker-compose

--- a/src/tests/fixtures/env_docker/values.conf
+++ b/src/tests/fixtures/env_docker/values.conf
@@ -18,9 +18,6 @@
   shpd_path=${test_path}
   templates_path=${shpd_path}/templates
   envs_path=${shpd_path}/envs
-  volumes_path=${shpd_path}/volumes
-  staging_area_volumes_path=${shpd_path}/sa_volumes
-  staging_area_images_path=${shpd_path}/sa_images
 
   # Database Default Configuration
   db_sys_usr=sys

--- a/src/tests/fixtures/shpd/shpd.yaml
+++ b/src/tests/fixtures/shpd/shpd.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 env_templates:
   - tag: default
     factory: docker-compose

--- a/src/tests/fixtures/shpd/values.conf
+++ b/src/tests/fixtures/shpd/values.conf
@@ -18,9 +18,6 @@
   shpd_path=${test_path}
   templates_path=${shpd_path}/templates
   envs_path=${shpd_path}/envs
-  volumes_path=${shpd_path}/volumes
-  staging_area_volumes_path=${shpd_path}/sa_volumes
-  staging_area_images_path=${shpd_path}/sa_images
 
   # Database Default Configuration
   db_sys_usr=sys

--- a/src/tests/fixtures/svc/shpd.yaml
+++ b/src/tests/fixtures/svc/shpd.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 env_templates:
   - tag: default
     factory: docker-compose

--- a/src/tests/fixtures/svc/values.conf
+++ b/src/tests/fixtures/svc/values.conf
@@ -18,9 +18,6 @@
   shpd_path=${test_path}
   templates_path=${shpd_path}/templates
   envs_path=${shpd_path}/envs
-  volumes_path=${shpd_path}/volumes
-  staging_area_volumes_path=${shpd_path}/sa_volumes
-  staging_area_images_path=${shpd_path}/sa_images
 
   # Database Default Configuration
   db_sys_usr=sys

--- a/src/tests/fixtures/svc_docker/shpd.yaml
+++ b/src/tests/fixtures/svc_docker/shpd.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 envs:
   - template: default
     factory: docker-compose

--- a/src/tests/fixtures/svc_docker/values.conf
+++ b/src/tests/fixtures/svc_docker/values.conf
@@ -18,9 +18,6 @@
   shpd_path=${test_path}
   templates_path=${shpd_path}/templates
   envs_path=${shpd_path}/envs
-  volumes_path=${shpd_path}/volumes
-  staging_area_volumes_path=${shpd_path}/sa_volumes
-  staging_area_images_path=${shpd_path}/sa_images
 
   # Database Default Configuration
   db_sys_usr=sys

--- a/src/tests/integration/fixtures/basic/shpd.yaml
+++ b/src/tests/integration/fixtures/basic/shpd.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 env_templates: []
 service_templates: []
 envs:

--- a/src/tests/integration/fixtures/basic/values.conf
+++ b/src/tests/integration/fixtures/basic/values.conf
@@ -1,9 +1,6 @@
 shpd_path=${test_path}
 templates_path=${shpd_path}/templates
 envs_path=${shpd_path}/envs
-volumes_path=${shpd_path}/volumes
-staging_area_volumes_path=${shpd_path}/sa_volumes
-staging_area_images_path=${shpd_path}/sa_images
 log_file=${shpd_path}/logs/shepctl.log
 log_level=WARNING
 log_stdout=false

--- a/src/tests/integration/fixtures/gated/shpd.yaml
+++ b/src/tests/integration/fixtures/gated/shpd.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 env_templates: []
 service_templates: []
 envs:

--- a/src/tests/integration/fixtures/gated/values.conf
+++ b/src/tests/integration/fixtures/gated/values.conf
@@ -1,9 +1,6 @@
 shpd_path=${test_path}
 templates_path=${shpd_path}/templates
 envs_path=${shpd_path}/envs
-volumes_path=${shpd_path}/volumes
-staging_area_volumes_path=${shpd_path}/sa_volumes
-staging_area_images_path=${shpd_path}/sa_images
 log_file=${shpd_path}/logs/shepctl.log
 log_level=WARNING
 log_stdout=false

--- a/src/tests/integration/fixtures/gated_redis/shpd.yaml
+++ b/src/tests/integration/fixtures/gated_redis/shpd.yaml
@@ -1,9 +1,5 @@
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 env_templates: []
 service_templates: []
 envs:

--- a/src/tests/integration/fixtures/gated_redis/values.conf
+++ b/src/tests/integration/fixtures/gated_redis/values.conf
@@ -1,9 +1,6 @@
 shpd_path=${test_path}
 templates_path=${shpd_path}/templates
 envs_path=${shpd_path}/envs
-volumes_path=${shpd_path}/volumes
-staging_area_volumes_path=${shpd_path}/sa_volumes
-staging_area_images_path=${shpd_path}/sa_images
 log_file=${shpd_path}/logs/shepctl.log
 log_level=WARNING
 log_stdout=false

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -153,7 +153,7 @@ def test_load_config(mocker: MockerFixture):
     assert service_templates[1].properties["sys_psw"] == "sys"
     assert service_templates[1].properties["user"] == "docker"
     assert service_templates[1].properties["psw"] == "docker"
-    assert config.envs[0].template == Constants.ENV_TEMPLATE_DEFAULT
+    assert config.envs[0].template == "default"
     assert config.envs[0].factory == Constants.ENV_FACTORY_DEFAULT
     assert config.envs[0].tag == "sample-1"
     services = config.envs[0].services

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -92,10 +92,7 @@ def test_load_config(mocker: MockerFixture):
     assert env_templates[0].volumes[0].driver == "local"
     assert not env_templates[0].volumes[0].is_external()
     assert env_templates[0].volumes[0].driver_opts
-    assert (
-        env_templates[0].volumes[0].driver_opts["device"]
-        == "${test_path}/envs/srv/data"
-    )
+    assert env_templates[0].volumes[0].driver_opts["device"] == "/srv/data"
 
     service_templates = config.service_templates
     assert service_templates and service_templates[0].tag == "oracle"
@@ -627,11 +624,15 @@ def test_load_config_with_refs(mocker: MockerFixture):
     assert config.envs[0].volumes
     assert config.envs[0].volumes[0].tag == "nginx"
     assert config.envs[0].volumes[0].driver_opts
-    assert config.envs[0].volumes[0].driver_opts["device"] == "./envs/foo/nginx"
+    assert (
+        config.envs[0].volumes[0].driver_opts["device"]
+        == "./templates/foo/nginx"
+    )
     assert config.envs[0].volumes[1].tag == "postgres"
     assert config.envs[0].volumes[1].driver_opts
     assert (
-        config.envs[0].volumes[1].driver_opts["device"] == "./envs/foo/postgres"
+        config.envs[0].volumes[1].driver_opts["device"]
+        == "./templates/foo/postgres"
     )
     assert config.envs[0].networks
     assert config.envs[0].networks[0].tag == "foo"

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -94,7 +94,7 @@ def test_load_config(mocker: MockerFixture):
     assert env_templates[0].volumes[0].driver_opts
     assert (
         env_templates[0].volumes[0].driver_opts["device"]
-        == "${test_path}/volumes/srv/data"
+        == "${test_path}/envs/srv/data"
     )
 
     service_templates = config.service_templates
@@ -213,9 +213,6 @@ def test_load_config(mocker: MockerFixture):
     assert ports and ports[0] == "3000:3000"
     assert config.templates_path == "${test_path}/templates"
     assert config.envs_path == "${test_path}/envs"
-    assert config.volumes_path == "${test_path}/volumes"
-    assert config.staging_area.volumes_path == "${test_path}/sa_volumes"
-    assert config.staging_area.images_path == "${test_path}/sa_images"
     assert config.plugins is not None
     assert config.plugins[0].id == "acme"
     assert config.plugins[0].enabled == "true"
@@ -541,10 +538,6 @@ def test_parse_plugin_enabled_supports_bool_and_placeholder():
     config_yaml = """
 templates_path: ${templates_path}
 envs_path: ${envs_path}
-volumes_path: ${volumes_path}
-staging_area:
-  volumes_path: ${staging_area_volumes_path}
-  images_path: ${staging_area_images_path}
 plugins:
   - id: acme
     enabled: false
@@ -634,14 +627,11 @@ def test_load_config_with_refs(mocker: MockerFixture):
     assert config.envs[0].volumes
     assert config.envs[0].volumes[0].tag == "nginx"
     assert config.envs[0].volumes[0].driver_opts
-    assert (
-        config.envs[0].volumes[0].driver_opts["device"] == "./volumes/foo/nginx"
-    )
+    assert config.envs[0].volumes[0].driver_opts["device"] == "./envs/foo/nginx"
     assert config.envs[0].volumes[1].tag == "postgres"
     assert config.envs[0].volumes[1].driver_opts
     assert (
-        config.envs[0].volumes[1].driver_opts["device"]
-        == "./volumes/foo/postgres"
+        config.envs[0].volumes[1].driver_opts["device"] == "./envs/foo/postgres"
     )
     assert config.envs[0].networks
     assert config.envs[0].networks[0].tag == "foo"
@@ -891,10 +881,6 @@ def test_parse_fragment_ref_string_shorthand():
     config_yaml = """
 templates_path: /tmp
 envs_path: /tmp
-volumes_path: /tmp
-staging_area:
-  volumes_path: /tmp
-  images_path: /tmp
 env_templates:
   - tag: demo
     factory: docker-compose
@@ -923,10 +909,6 @@ def test_parse_fragment_ref_with_values():
     config_yaml = """
 templates_path: /tmp
 envs_path: /tmp
-volumes_path: /tmp
-staging_area:
-  volumes_path: /tmp
-  images_path: /tmp
 env_templates:
   - tag: demo
     factory: docker-compose
@@ -1251,10 +1233,6 @@ def test_load_config_remote_chunk_defaults():
     config_yaml = """
 templates_path: /tmp
 envs_path: /tmp
-volumes_path: /tmp
-staging_area:
-  volumes_path: /tmp
-  images_path: /tmp
 remotes:
   - name: minimal
     type: ftp

--- a/src/tests/test_environment.py
+++ b/src/tests/test_environment.py
@@ -32,7 +32,7 @@ def shpd_conf(tmp_path: Path, mocker: MockerFixture) -> tuple[Path, Path]:
     config_file.write_text(values.replace("${test_path}", str(temp_home)))
 
     shpd_yaml = temp_home / ".shpd.yaml"
-    shpd_yaml.write_text(read_fixture("svc", "shpd.yaml"))
+    shpd_yaml.write_text(read_fixture("env", "shpd_bootstrap.yaml"))
 
     os.environ["SHPD_CONF"] = str(config_file)
     return temp_home, config_file

--- a/src/tests/test_environment.py
+++ b/src/tests/test_environment.py
@@ -31,6 +31,9 @@ def shpd_conf(tmp_path: Path, mocker: MockerFixture) -> tuple[Path, Path]:
     values = read_fixture("env", "values.conf")
     config_file.write_text(values.replace("${test_path}", str(temp_home)))
 
+    shpd_yaml = temp_home / ".shpd.yaml"
+    shpd_yaml.write_text(read_fixture("svc", "shpd.yaml"))
+
     os.environ["SHPD_CONF"] = str(config_file)
     return temp_home, config_file
 

--- a/src/tests/test_service.py
+++ b/src/tests/test_service.py
@@ -35,6 +35,9 @@ def shpd_conf(tmp_path: Path, mocker: MockerFixture) -> tuple[Path, Path]:
     values = read_fixture("svc", "values.conf")
     config_file.write_text(values.replace("${test_path}", str(temp_home)))
 
+    shpd_yaml = temp_home / ".shpd.yaml"
+    shpd_yaml.write_text(read_fixture("svc", "shpd.yaml"))
+
     os.environ["SHPD_CONF"] = str(config_file)
     return temp_home, config_file
 

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -55,10 +55,7 @@ def test_shepherdmng_creates_dirs(
         sm.configMng.config.templates_path + "/" + Constants.ENV_TEMPLATES_DIR,
         sm.configMng.config.templates_path + "/" + Constants.SVC_TEMPLATES_DIR,
         sm.configMng.config.envs_path,
-        sm.configMng.constants.SHPD_CERTS_DIR,
         sm.configMng.constants.SHPD_PLUGINS_DIR,
-        sm.configMng.constants.SHPD_SSH_DIR,
-        sm.configMng.constants.SHPD_SSHD_DIR,
     ]
 
     for template in sm.configMng.get_environment_templates() or []:

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -55,13 +55,10 @@ def test_shepherdmng_creates_dirs(
         sm.configMng.config.templates_path + "/" + Constants.ENV_TEMPLATES_DIR,
         sm.configMng.config.templates_path + "/" + Constants.SVC_TEMPLATES_DIR,
         sm.configMng.config.envs_path,
-        sm.configMng.config.volumes_path,
         sm.configMng.constants.SHPD_CERTS_DIR,
         sm.configMng.constants.SHPD_PLUGINS_DIR,
         sm.configMng.constants.SHPD_SSH_DIR,
         sm.configMng.constants.SHPD_SSHD_DIR,
-        sm.configMng.config.staging_area.volumes_path,
-        sm.configMng.config.staging_area.images_path,
     ]
 
     for template in sm.configMng.get_environment_templates() or []:

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -70,7 +70,6 @@ class Constants:
     # Service templates:
 
     SVC_TEMPLATES_DIR: str = "svcs"
-    SVC_TAG_DEFAULT: str = "service-default"
 
     # Service factories:
 

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -156,11 +156,6 @@ class Constants:
             ],
             "templates_path": "${templates_path}",
             "envs_path": "${envs_path}",
-            "volumes_path": "${volumes_path}",
-            "staging_area": {
-                "volumes_path": "${staging_area_volumes_path}",
-                "images_path": "${staging_area_images_path}",
-            },
             "plugins": [],
             "remotes": [],
             "envs": [],

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -56,7 +56,6 @@ class Constants:
     # Environment templates:
 
     ENV_TEMPLATES_DIR: str = "envs"
-    ENV_TEMPLATE_DEFAULT: str = "default"
 
     # Environment types
 
@@ -71,7 +70,6 @@ class Constants:
     # Service templates:
 
     SVC_TEMPLATES_DIR: str = "svcs"
-    SVC_TEMPLATE_DEFAULT: str = "default"
     SVC_TAG_DEFAULT: str = "service-default"
 
     # Service factories:
@@ -102,46 +100,8 @@ class Constants:
         config loading/resolution flows.
         """
         return {
-            "env_templates": [
-                {
-                    "tag": self.ENV_TEMPLATE_DEFAULT,
-                    "factory": self.ENV_FACTORY_DEFAULT,
-                    "service_templates": [
-                        {
-                            "template": self.SVC_TEMPLATE_DEFAULT,
-                            "tag": self.SVC_TAG_DEFAULT,
-                        }
-                    ],
-                    "networks": [
-                        {
-                            "tag": self.NET_KEY_DEFAULT,
-                            "name": self.NET_NAME_DEFAULT,
-                            "external": "true",
-                        }
-                    ],
-                }
-            ],
-            "service_templates": [
-                {
-                    "tag": self.SVC_TEMPLATE_DEFAULT,
-                    "factory": self.SVC_FACTORY_DEFAULT,
-                    "labels": [],
-                    "properties": {},
-                    "containers": [
-                        {
-                            "image": "",
-                            "hostname": None,
-                            "container_name": None,
-                            "workdir": None,
-                            "volumes": [],
-                            "environment": [],
-                            "ports": [],
-                            "networks": [],
-                            "extra_hosts": [],
-                        }
-                    ],
-                },
-            ],
+            "env_templates": [],
+            "service_templates": [],
             "templates_path": "${templates_path}",
             "envs_path": "${envs_path}",
             "plugins": [],

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -27,18 +27,6 @@ class Constants:
         return os.path.join(self.SHPD_PATH, ".shpd.yaml")
 
     @property
-    def SHPD_CERTS_DIR(self) -> str:
-        return os.path.join(self.SHPD_PATH, ".certs")
-
-    @property
-    def SHPD_SSH_DIR(self) -> str:
-        return os.path.join(self.SHPD_PATH, ".ssh")
-
-    @property
-    def SHPD_SSHD_DIR(self) -> str:
-        return os.path.join(self.SHPD_PATH, ".sshd")
-
-    @property
     def SHPD_PLUGINS_DIR(self) -> str:
         return os.path.join(self.SHPD_PATH, "plugins")
 

--- a/src/util/util.py
+++ b/src/util/util.py
@@ -29,9 +29,6 @@ DEFAULT_SHPD_VALUES_TEMPLATE = """# Shepherd workspace directory
 shpd_path=~/shpd
 templates_path=${shpd_path}/templates
 envs_path=${shpd_path}/envs
-volumes_path=${shpd_path}/volumes
-staging_area_volumes_path=${shpd_path}/sa_volumes
-staging_area_images_path=${shpd_path}/sa_images
 
 # Shepherd default environment type
 default_env_type=docker-compose

--- a/src/util/util.py
+++ b/src/util/util.py
@@ -367,9 +367,6 @@ class Util:
     @staticmethod
     def ensure_shpd_dirs(constants: Constants):
         dirs = {
-            "SHPD_CERTS_DIR": constants.SHPD_CERTS_DIR,
-            "SHPD_SSH_DIR": constants.SHPD_SSH_DIR,
-            "SHPD_SSHD_DIR": constants.SHPD_SSHD_DIR,
             "SHPD_PLUGINS_DIR": constants.SHPD_PLUGINS_DIR,
         }
 


### PR DESCRIPTION
## Summary

Removes three sets of configuration constructs that became dead weight
after ADR 0006 replaced the local image-snapshot mechanism with remote
object storage. None of these were used by any active feature code.

- **`volumes_path` and `staging_area`** — `StagingAreaCfg` dataclass,
  `_parse_staging_area()` parser, `Config` fields, `ensure_dirs()`
  bootstrap entries, default-value vars, all fixture YAMLs and examples
- **`SHPD_CERTS_DIR` / `SHPD_SSH_DIR` / `SHPD_SSHD_DIR`** — `Constants`
  properties and their `ensure_shpd_dirs()` entries; directories were
  created at startup but never consumed
- **`ENV_TEMPLATE_DEFAULT` / `SVC_TEMPLATE_DEFAULT`** — `Constants`
  fields, pre-populated blocks in `DEFAULT_CONFIG` (now ships empty
  lists), fallback in `EnvironmentMng.add_service()`; `svc_template`
  parameter tightened from `Optional[str]` to `str` in the manager
  and plugin context protocol

## Test plan

- [x] `cd src && pytest` — 584 passed
- [x] `black src && isort src` — clean
- [x] `pyright src/` — no new errors
- [x] `grep -r 'volumes_path\|staging_area\|SHPD_CERTS_DIR\|SHPD_SSH_DIR\|SHPD_SSHD_DIR\|ENV_TEMPLATE_DEFAULT\|SVC_TEMPLATE_DEFAULT' src/ examples/` — zero results

Fixes: #256