### PR TITLE
docs: adopt agent-instructions pattern

### DIFF
--- a/.claude/skills/codex-task-routing/SKILL.md
+++ b/.claude/skills/codex-task-routing/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: codex-task-routing
+description: Compatibility wrapper for the repository's agent-neutral codex-task-routing workflow.
+---
+
+# codex-task-routing
+
+Read and follow [`docs/agent-workflows/codex-task-routing.md`](../../../docs/agent-workflows/codex-task-routing.md).
+That document is authoritative for every agent.

--- a/.claude/skills/local-dev-testing/SKILL.md
+++ b/.claude/skills/local-dev-testing/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: local-dev-testing
+description: Compatibility wrapper for the repository's agent-neutral local-dev-testing workflow.
+---
+
+# local-dev-testing
+
+Read and follow [`docs/agent-workflows/local-dev-testing.md`](../../../docs/agent-workflows/local-dev-testing.md).
+That document is authoritative for every agent.

--- a/.claude/skills/plugin-authoring/SKILL.md
+++ b/.claude/skills/plugin-authoring/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: plugin-authoring
+description: Compatibility wrapper for the repository's agent-neutral plugin-authoring workflow.
+---
+
+# plugin-authoring
+
+Read and follow [`docs/agent-workflows/plugin-authoring.md`](../../../docs/agent-workflows/plugin-authoring.md).
+That document is authoritative for every agent.

--- a/.claude/skills/pr-prep/SKILL.md
+++ b/.claude/skills/pr-prep/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: pr-prep
+description: Compatibility wrapper for the repository's agent-neutral pr-prep workflow.
+---
+
+# pr-prep
+
+Read and follow [`docs/agent-workflows/pr-prep.md`](../../../docs/agent-workflows/pr-prep.md).
+That document is authoritative for every agent.

--- a/.claude/skills/release-process/SKILL.md
+++ b/.claude/skills/release-process/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: release-process
+description: Compatibility wrapper for the repository's agent-neutral release-process workflow.
+---
+
+# release-process
+
+Read and follow [`docs/agent-workflows/release-process.md`](../../../docs/agent-workflows/release-process.md).
+That document is authoritative for every agent.

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,8 @@ convert.sh
 wiki
 shepctl.spec
 build
-AGENTS.md
-CLAUDE.md
-.claude
 vhs
+
+# Claude Code local settings (developer-specific, not shared)
+.claude/settings.local.json
+.claude/scheduled_tasks.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,123 @@
+# AGENTS.md
+
+This file provides guidance to people and AI agents working with code in
+this repository.
+
+## Project description
+
+Shepherd is a CLI tool (`shepctl`) for provisioning and managing
+reproducible development environments. It orchestrates services via
+Docker Compose, with a plugin system for extensibility (CLI commands,
+completions, environment/service templates, and remote storage
+backends).
+
+Shepherd Core Stack is dual-licensed under the
+[GNU AGPL v3](LICENSE) and a
+[proprietary commercial license](LICENSE-COMMERCIAL); every
+contribution requires a signed CLA (see the `pr-prep` workflow).
+
+## Design reference — read this first
+
+- **`docs/decisions/CURRENT.md`** — snapshot of the currently-active
+  decisions, organized by area. Start here; it saves reading the full
+  ADR corpus end to end.
+- `docs/decisions/README.md` — index and instructions for adding a new
+  ADR (MADR format). Check for a relevant decision record before
+  making significant design changes.
+
+## Agent workflows
+
+The agent-neutral workflows in
+[`docs/agent-workflows/`](docs/agent-workflows/README.md) are mandatory
+task guidance. Read the matching workflow before acting:
+
+| Work | Workflow |
+| --- | --- |
+| Cut a release, bump version, publish a build | `release-process` |
+| Build or modify a shepherd plugin | `plugin-authoring` |
+| Commit, push, or open a pull request | `pr-prep` |
+| Set up the dev environment, run tests/lint locally | `local-dev-testing` |
+| Decide Claude Code vs Codex MCP routing for a task | `codex-task-routing` |
+
+Claude wrappers under `.claude/` exist only for compatibility; the
+documents above are authoritative.
+
+## Tech stack
+
+Python 3.12+, Click (CLI), Docker Compose (orchestration backend).
+
+## Project structure & module organization
+
+Core code lives in `src/`:
+
+- CLI entrypoint: `src/shepctl.py` — a `ShepherdMng` composition root
+  wires all managers together; `PluginRootGroup`/`PluginScopeGroup` are
+  custom Click groups that inject plugin commands at runtime.
+- `src/config/` — loads `~/.shpd.conf` (user preferences) and
+  `shpd.yaml` (environment/service definitions); supports `${VAR}`
+  substitution and `#{REF}` cross-config references.
+- `src/environment/` — abstract `Environment` base class;
+  `DockerComposeEnv` (in `src/docker/`) is the concrete implementation.
+  Handles lifecycle (up/halt/reload), status rendering, probe-based
+  health checks.
+- `src/service/` — abstract `Service` base class; `DockerComposeSvc`
+  (in `src/docker/`) is the concrete implementation. Handles container
+  naming, logs, exec, status.
+- `src/docker/` — generates and executes Docker Compose files, wraps
+  compose command output.
+- `src/plugin/` — `PluginMng` (discovery/install), `PluginRuntimeMng`
+  (runtime loading via `importlib`, registry management). See the
+  `plugin-authoring` workflow.
+- `src/factory/` — `ShpdEnvironmentFactory`/`ShpdServiceFactory`
+  dispatch to the correct backend (built-in or plugin-provided).
+- `src/completion/` — `CompletionMng` delegates to per-domain providers
+  (envs, services, plugins, probes).
+- `src/installer/` — installer logic.
+- `src/util/` — shared utilities.
+- `src/tests/` — tests and fixtures.
+
+Documentation lives in `docs/`. Helper and release scripts are in
+`scripts/`. Runtime example configs are `shpd.yaml` and
+`shpd.public-test.yaml`. Reference plugin examples are in
+`examples/plugins/`.
+
+## Common commands
+
+```sh
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r src/requirements.txt -r src/requirements-dev.txt
+pre-commit install
+python3 src/shepctl.py --help  # verify entrypoint
+```
+
+```sh
+pre-commit run --all-files
+black src
+isort src
+cd src && pyright .
+cd src && pytest
+```
+
+Full command reference, targeted test invocations, and the build
+helper: `local-dev-testing` workflow.
+
+## Tests
+
+- pytest, run from `src/` (pythonpath/coverage config lives in
+  `src/pyproject.toml`).
+- Test files: `src/tests/test_*.py`; fixtures in `src/tests/fixtures/`.
+- Markers: `env`, `svc`, `cfg`, `shpd`, `compl`, `docker`.
+
+## Coding style & naming conventions
+
+- Black + isort, 80-char line length (`src/pyproject.toml`).
+- Pyright strict mode.
+- `snake_case` functions/modules, `PascalCase` classes,
+  `UPPER_SNAKE_CASE` constants.
+- Follow existing package boundaries under `src/` rather than adding
+  cross-cutting utilities ad hoc.
+
+## Commits and PRs
+
+Conventional Commits, `<type>/<short-kebab-description>` branch
+naming, CLA sign-off gate on every PR. Full ritual: `pr-prep` workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+@AGENTS.md

--- a/docs/agent-workflows/README.md
+++ b/docs/agent-workflows/README.md
@@ -1,0 +1,14 @@
+# Agent workflows
+
+These documents are the repository's agent-neutral operational guidance.
+They apply to people and every coding agent. Claude-specific wrappers in
+`.claude/` preserve Claude discovery only and must not diverge from these
+documents.
+
+| Workflow | Use when |
+| --- | --- |
+| [release-process](release-process.md) | Cut a release, bump version, publish a build |
+| [plugin-authoring](plugin-authoring.md) | Build or modify a shepherd plugin |
+| [pr-prep](pr-prep.md) | Commit, push, or open a pull request |
+| [local-dev-testing](local-dev-testing.md) | Set up the dev environment, run tests/lint locally |
+| [codex-task-routing](codex-task-routing.md) | Decide whether a task should run in Claude Code or route to Codex MCP |

--- a/docs/agent-workflows/codex-task-routing.md
+++ b/docs/agent-workflows/codex-task-routing.md
@@ -1,0 +1,94 @@
+Codex task routing
+===================
+
+Why this exists
+----------------
+
+Two kinds of work show up in an agent session: figuring out *what* to
+do (exploration, design, planning) and actually *doing* it (editing
+files, running commands that change state). This project routes those
+two kinds of work to different tools so that implementation work goes
+through Codex CLI rather than staying in the same Claude Code session
+that planned it.
+
+The rule
+--------
+
+- **Exploratory / design tasks** (reading code, understanding a bug,
+  drafting an approach, writing a plan) → stay in Claude Code.
+- **Execution / implementation tasks** (editing files, running
+  migrations, anything that changes repo state) → route to Codex CLI
+  via the `mcp__codex__codex` MCP tool.
+- **If unsure**, start with `/plan` in Codex; escalate back to Claude
+  Code if more reasoning is needed before implementation can start.
+- **Small-fix override**: trivial, one-line/typo-scale changes
+  (renaming a variable, fixing an obvious string, adjusting a comment)
+  may be made directly in the Claude Code session without routing to
+  Codex. If a change grows past that scope mid-edit, stop and route
+  the rest to Codex instead of continuing inline.
+
+Trigger point
+--------------
+
+In a Claude Code session, the routing decision is made **immediately
+after a plan is approved** (i.e. right after `ExitPlanMode` is
+accepted) for anything implementation-shaped. At that point, hand the
+approved plan to Codex via `mcp__codex__codex` using the Implementation
+Plan Format below, instead of continuing to call `Edit` / `Write` /
+`NotebookEdit` directly in the same session.
+
+Implementation Plan Format
+---------------------------
+
+Example format:
+
+```text
+### Step 1: [scope] — [action]
+
+**Files to change:** src/config/config.py, src/plugin/api.py
+**What to do:** [precise instruction]
+**Verify:** Run `appropriate test tool` — should pass
+
+### Step 2: [...]
+```
+
+Sandbox mode: use `danger-full-access` for now
+------------------------------------------------
+
+`mcp__codex__codex` accepts a `sandbox` parameter. The expected/default
+value, `workspace-write`, currently **fails on this host** because
+Codex CLI's bubblewrap (bwrap) sandbox cannot bring up the loopback
+interface inside its network namespace when nested under Claude Code's
+own sandbox, combined with Ubuntu 24.04's
+`kernel.apparmor_restrict_unprivileged_userns=1` default. Every
+`workspace-write` call fails before the underlying command even runs.
+Symptoms look like:
+
+```text
+bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted
+```
+
+```text
+Failed to write file <path>
+```
+
+**Until this is fixed**, pass `sandbox: "danger-full-access"` when
+invoking `mcp__codex__codex` / `mcp__codex__codex-reply`:
+
+```text
+mcp__codex__codex(
+  prompt: "<implementation plan, in the format above>",
+  cwd: "<repo root>",
+  sandbox: "danger-full-access",
+  approval-policy: "never"
+)
+```
+
+`danger-full-access` removes filesystem and network sandboxing for
+whatever Codex decides to run. This is an accepted tradeoff for
+routing already-planned, trusted, local work in this repo — it is
+**not** a substitute for fixing the underlying bwrap/userns issue, and
+must not be used to run arbitrary or untrusted prompts. This is a
+host-level sandbox limitation, not specific to this repo. Revisit this
+section once the underlying bwrap/userns issue is fixed upstream, and
+default back to `workspace-write`.

--- a/docs/agent-workflows/local-dev-testing.md
+++ b/docs/agent-workflows/local-dev-testing.md
@@ -1,0 +1,71 @@
+Local development and testing
+==============================
+
+Setup
+-----
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r src/requirements.txt -r src/requirements-dev.txt
+pre-commit install
+python3 src/shepctl.py --help   # verify entrypoint
+```
+
+Daily commands
+--------------
+
+Run from the repo root unless noted:
+
+```sh
+pre-commit run --all-files
+black src
+isort src
+```
+
+Run `pyright` and `pytest` from `src/` — that is where
+`src/pyproject.toml`'s configuration (pythonpath, coverage, strict
+type-checking) lives:
+
+```sh
+cd src
+pyright .
+pytest
+```
+
+Targeted test runs:
+
+```sh
+cd src
+pytest -k <pattern>                          # by keyword
+pytest tests/test_config.py                  # single file
+pytest tests/test_config.py::test_load_config  # single test
+pytest -m cfg                                 # by marker
+```
+
+Markers: `cfg`, `env`, `svc`, `shpd`, `compl`, `docker`.
+
+Build the binary
+-----------------
+
+```sh
+python3 src/build.py [--clean|--debug|--git|--version]
+```
+
+Style
+-----
+
+- Black + isort, 80-char line length, configured in `src/pyproject.toml`.
+- Pyright strict mode.
+- `snake_case` functions/modules, `PascalCase` classes,
+  `UPPER_SNAKE_CASE` constants.
+- Follow existing package boundaries under `src/` rather than adding
+  cross-cutting utilities ad hoc.
+
+See also
+--------
+
+`docs/development.md` covers the same ground with more prose and links
+to `docs/install.md` and `docs/release-process.md`; this document is
+the terse, command-first version for agents.

--- a/docs/agent-workflows/plugin-authoring.md
+++ b/docs/agent-workflows/plugin-authoring.md
@@ -1,0 +1,196 @@
+Plugin authoring
+=================
+
+Use this when building or modifying a shepherd plugin. `docs/plugins.md`
+is the full spec (759 lines); this is the actionable step-by-step
+companion — read `docs/plugins.md` for exact schema field lists, this
+document for how to actually get a plugin installed and working.
+
+Reference examples
+--------------------
+
+- `examples/plugins/hello-plugin/` — minimal reference exercising all
+  four extension points (commands, completion, service factory, env
+  factory). Copy its shape.
+- `examples/plugins/fragment-demo/` — two cooperating plugins showing
+  `env_template_fragments` and `depends_on`.
+
+Layout
+-------
+
+```text
+my-plugin/
+  plugin.yaml
+  my_plugin/
+    __init__.py
+    main.py         # ShepherdPlugin subclass, wires everything below
+    commands.py      # click.Command per verb
+    completion.py     # completion provider functions
+    factories.py       # env/svc factory classes
+  README.md
+```
+
+`plugin.yaml` essentials
+--------------------------
+
+Required: `id`, `name`, `version`, `plugin_api_version` (currently `1`),
+`entrypoint.module`, `entrypoint.class`. Optional: `description`,
+`capabilities` (booleans: `templates`, `commands`, `completion`,
+`env_factories`, `svc_factories`, `remote_backends` — must be real YAML
+booleans, not strings), `default_config`, `depends_on`,
+`env_template_fragments`, `env_templates`, `service_templates`.
+
+Declared `capabilities` must match what the plugin class's getters
+actually return, or validation fails at load time.
+
+Entrypoint class
+------------------
+
+Subclass `ShepherdPlugin`, override the getters for whatever
+capabilities you declared:
+
+```python
+class MyPlugin(ShepherdPlugin):
+    def get_commands(self) -> Sequence[PluginCommandSpec]: ...
+    def get_completion_providers(self) -> Sequence[PluginCompletionSpec]: ...
+    def get_env_factories(self) -> Sequence[PluginEnvFactorySpec]: ...
+    def get_service_factories(self) -> Sequence[PluginSvcFactorySpec]: ...
+```
+
+`self.context: PluginContext` is available in every getter and in any
+command closures built from `get_commands()`. It exposes `.config`
+(read-only query of environments/templates/plugin config),
+`.environment`/`.service`/`.remote` (lifecycle operations, `None` only
+during tab-completion resolution).
+
+Commands that need `self.context` must be built as closures — a
+free-standing `click.Command` (like hello-plugin's simple `greet`) has
+no access to it. Pattern:
+
+```python
+def make_my_command(context: PluginContext) -> click.Command:
+    @click.command(name="my-verb")
+    def my_command() -> None:
+        ...  # use context here
+    return my_command
+```
+
+then in `get_commands()`:
+
+```python
+return [PluginCommandSpec(scope="my-plugin", verb="my-verb",
+                          command=make_my_command(self.context))]
+```
+
+Env/service factories
+------------------------
+
+If the target stack is docker-compose based (the common case), don't
+write custom `Environment`/`Service` subclasses — delegate to the
+built-in `DockerComposeEnv`/`DockerComposeSvc`, exactly like
+hello-plugin's `factories.py` does:
+
+```python
+class MyServiceFactory(ServiceFactory):
+    @classmethod
+    def get_name_impl(cls) -> str:
+        return "my-plugin-svc"
+
+    def new_service_from_cfg_impl(self, envCfg, svcCfg, cli_flags=None):
+        return DockerComposeSvc(self.config, envCfg, svcCfg, cli_flags=cli_flags)
+
+
+class MyEnvironmentFactory(EnvironmentFactory):
+    def __init__(self, configMng, svcFactory, cli_flags=None):
+        self.configMng = configMng
+        self.svcFactory = svcFactory
+        self.cli_flags = cli_flags or {}
+
+    def new_environment_impl(self, env_tmpl_cfg, env_tag):
+        return DockerComposeEnv(
+            self.configMng, self.svcFactory,
+            self.configMng.env_cfg_from_tag(env_tmpl_cfg, env_tag),
+            cli_flags=self.cli_flags,
+        )
+```
+
+Known gap: `ContainerCfg` has no `healthcheck` field — only script-based
+`ProbeCfg`, which attaches to env/service templates, not a container
+directly. A compose `healthcheck:` block has no 1:1 declarative
+translation; write a probe script instead
+([MoonyFringers/shepherd#260](https://github.com/MoonyFringers/shepherd/issues/260)).
+
+Known gap: no docker-compose `profiles:` equivalent. An optional,
+opt-in service within an environment (like a profile-gated crawler)
+must become its own standalone env template instead of a flag on the
+main one
+([MoonyFringers/shepherd#261](https://github.com/MoonyFringers/shepherd/issues/261)).
+
+Install / enable / test loop
+-------------------------------
+
+`plugin install` requires a **tar archive**, not a bare directory —
+despite what hello-plugin's own README currently says
+([MoonyFringers/shepherd#262](https://github.com/MoonyFringers/shepherd/issues/262)).
+Build one explicitly listing contents, **not** `tar czf x.tar.gz .` —
+a `.` top-level entry is rejected by the extraction path check
+([MoonyFringers/shepherd#263](https://github.com/MoonyFringers/shepherd/issues/263)):
+
+```sh
+cd my-plugin
+tar czf /tmp/my-plugin.tar.gz plugin.yaml my_plugin README.md
+```
+
+Then:
+
+```sh
+python3 src/shepctl.py plugin install /tmp/my-plugin.tar.gz --force
+python3 src/shepctl.py plugin enable my-plugin
+python3 src/shepctl.py plugin get my-plugin   # confirm descriptor validated
+```
+
+There is no `env template list` / `svc template list` command
+([MoonyFringers/shepherd#264](https://github.com/MoonyFringers/shepherd/issues/264)).
+Validate templates registered by adding an environment from one
+directly:
+
+```sh
+python3 src/shepctl.py env add my-plugin/<template-tag> <env-tag>
+python3 src/shepctl.py env checkout <env-tag>
+python3 src/shepctl.py env up      # no positional tag; uses checked-out env
+python3 src/shepctl.py env halt
+python3 src/shepctl.py env delete <env-tag>
+```
+
+`env up`/`env halt` take no positional tag despite `env add`'s
+two-positional-arg form
+([MoonyFringers/shepherd#265](https://github.com/MoonyFringers/shepherd/issues/265))
+— check out the env first.
+
+Lifecycle commands
+---------------------
+
+```sh
+shepctl plugin list
+shepctl plugin get <plugin-id>
+shepctl plugin install <archive> [--force]
+shepctl plugin enable <plugin-id>
+shepctl plugin disable <plugin-id>
+shepctl plugin remove <plugin-id>
+```
+
+Filing gaps
+------------
+
+Building a real plugin against a real stack routinely surfaces gaps in
+this API (the six above were all found and filed the same way). File
+them as issues on `MoonyFringers/shepherd`, don't just work around them
+silently — this project's plugin system has so far only been exercised
+by toy examples, and gap reports are how it gets better.
+
+See also
+--------
+
+`docs/plugins.md` for the full descriptor schema, plugin inventory
+config format, and `env_template_fragments`/`depends_on` details not
+repeated here.

--- a/docs/agent-workflows/pr-prep.md
+++ b/docs/agent-workflows/pr-prep.md
@@ -1,0 +1,87 @@
+Commit and PR preparation
+==========================
+
+Fork workflow
+--------------
+
+`MoonyFringers/shepherd` uses a fork-per-developer model: clone your
+personal fork, add the org repo as `upstream`.
+
+```sh
+git clone git@github.com:<you>/shepherd.git
+git remote add upstream git@github.com:MoonyFringers/shepherd.git
+```
+
+Note: in this local checkout, `origin` and `upstream` are inverted from
+that convention — `origin` points at `MoonyFringers/shepherd` and a
+separate named remote (`giubacc`) points at the personal fork. Check
+`git remote -v` before assuming which remote is which; don't rely on
+the name alone.
+
+Branch naming
+--------------
+
+`<type>/<short-kebab-description>`, where `<type>` is one of:
+
+| Type       | Description                                      |
+| ---------- | ------------------------------------------------ |
+| `feature`  | New functionality or enhancements                |
+| `bug`      | Bug fixes and corrections                        |
+| `docs`     | Documentation updates                            |
+| `test`     | Adding or updating tests                         |
+| `refactor` | Code restructuring without functionality changes |
+
+Example: `feature/probe-timeout`.
+
+Commit format
+--------------
+
+- Conventional Commits: `feat(env): ...`, `fix(plugin): ...`,
+  `docs: ...`. Scope is optional but encouraged when the change is
+  domain-specific.
+- Subject line concise and imperative, ~50 characters.
+- Reference the related issue with `Fixes #N` / `Closes #N` /
+  `Resolves #N` in the commit body or PR description — GitHub then
+  auto-closes the issue on merge.
+- A commit-message template is available at `docs/commit-template`; copy
+  it to `~/.commit-template` and set `git config init.templateDir
+  ~/.commit-template` to use it by default.
+
+Before every commit
+---------------------
+
+```sh
+pre-commit run --all-files
+cd src && pytest
+```
+
+All hooks and tests must pass; fix source, not tests, on a mismatch.
+
+CLA gate
+---------
+
+Shepherd is dual-licensed (AGPL-3.0-only + proprietary commercial,
+[ADR-0005](../decisions/0005-dual-license-model.md)). Every PR is
+gated by the CLA Assistant bot: it comments on the PR if the author
+hasn't signed yet. To sign, read `CLA.md` and reply to the bot comment
+with the exact phrase:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your GitHub username is then recorded in `.github/cla_signatures.json`.
+This is a one-time gate per contributor, not per PR — merges are
+blocked until it's satisfied.
+
+PR body
+--------
+
+Clear summary, linked issue (`Fixes #N`), and note any docs/tests
+updated. Target `MoonyFringers/shepherd:main`. Merge only once CI and
+the CLA check both pass.
+
+See also
+--------
+
+`CONTRIBUTION_GUIDELINES.md` is the fuller human-onboarding version of
+this document (fork setup walkthrough, Code of Conduct pointer,
+contribution tips); this workflow is the agent-actionable distillation.

--- a/docs/agent-workflows/release-process.md
+++ b/docs/agent-workflows/release-process.md
@@ -1,0 +1,69 @@
+Release process
+================
+
+Prerequisites
+--------------
+
+- **git-cliff**, for changelog generation: binary download (recommended,
+  see the [GitHub Releases page](https://github.com/orhun/git-cliff/releases)),
+  `pip install git-cliff`, `cargo install git-cliff`, or
+  `npm install -g git-cliff`.
+- Write access to `MoonyFringers/shepherd` to push tags.
+
+Automated path
+---------------
+
+From the repo root:
+
+```sh
+./scripts/release.sh <version>   # e.g. ./scripts/release.sh 1.2.0
+```
+
+This updates `src/version`, regenerates `CHANGELOG.md` via `git-cliff`
+(config: `cliff.toml`), commits
+`chore(release): prepare release <version>`, and tags `<version>`.
+
+Verify before pushing:
+
+```sh
+git show HEAD
+```
+
+Check `src/version` has the right number and `CHANGELOG.md`'s new
+section looks correct.
+
+Publish:
+
+```sh
+git push origin main --tags
+```
+
+Pushing the tag triggers `.github/workflows/release.yaml`.
+
+Manual fallback
+-----------------
+
+If the script fails:
+
+```sh
+# 1. Edit src/version by hand to the new version string.
+
+# 2. Generate the changelog entry.
+git cliff --tag <version> --output CHANGELOG.md
+
+# 3. Commit.
+git add src/version CHANGELOG.md
+git commit -m "chore(release): prepare release <version>"
+
+# 4. Tag.
+git tag -a <version> -m "Release <version>"
+
+# 5. Push.
+git push origin main --tags
+```
+
+See also
+--------
+
+`docs/release-process.md` is the fuller reference this workflow
+distills; keep both in sync if the script or CI trigger changes.

--- a/docs/decisions/CURRENT.md
+++ b/docs/decisions/CURRENT.md
@@ -1,0 +1,70 @@
+# Current architecture snapshot
+
+Net result of all decision records in this directory, organized by
+area. Read this before the full corpus for a quick orientation.
+
+**Maintenance rule**: every PR that adds or supersedes a decision
+record must update this file in the same change.
+
+## Decision-record format (ADR-0000)
+
+MADR (Markdown Any Decision Records) 4.0.0, hosted in
+`MoonyFringers/shepherd`, reviewed via the normal GitHub PR workflow.
+New records: copy `adr-template.md` to `NNNN-title-with-dashes.md`.
+
+## Licensing and CLA (ADR-0001, ADR-0005)
+
+Shepherd Core Stack moved from MIT to AGPL-3.0 (ADR-0001, accepted
+2025-03-31), then to a **dual-license model**: AGPL-3.0-only for open
+source use, plus a proprietary commercial license, enabled by a
+Contributor License Agreement (ADR-0005, accepted 2026-03-30). Every
+contribution requires a signed CLA before merge — enforced
+automatically by the CLA Assistant bot, tracked in
+`.github/cla_signatures.json`. See the `pr-prep` workflow for the
+signing mechanics.
+
+## Plugin architecture (ADR-0002 superseded, ADR-0004 accepted)
+
+ADR-0002 (2025-09-09) first defined what a plugin is; it is
+**superseded by ADR-0004** (accepted 2026-03-21), which locked the
+actual target architecture and a phased rollout plan:
+
+- CLI model refactored to `scope verb [args] [opts]` (e.g.
+  `shepctl env get`), replacing the older `verb scope` shape, to give
+  plugins a clear command tree with low collision risk.
+- Plugins own their contributions via **plugin-owned runtime
+  registries** (templates, factories, commands, completion) rather
+  than copying plugin templates into the main config — keeps plugins
+  self-contained across install/enable/disable/upgrade/remove.
+- Plugin installation is Shepherd-controlled (managed
+  `~/.shpd/plugins/<id>/` root), not arbitrary paths.
+- Delivered as 7 incremental PRs (CLI shape refactor → plugin domain
+  model → lifecycle commands → runtime loader/registries → completion
+  extensibility → factory/template refactor → core contribution
+  alignment) — all landed; this is the architecture live today.
+
+Full spec and authoring guide: `docs/plugins.md` and the
+`plugin-authoring` workflow, which also tracks live gaps found while
+building real plugins against this API
+(MoonyFringers/shepherd#260–#265).
+
+## Changelog tooling (ADR-0003 — proposed, not decided)
+
+**Status: proposed, unresolved.** ADR-0003 (2025-12-30) opened the
+question of which automatic changelog-generation tool to standardize
+on (must integrate with GitHub Actions, support Conventional Commits).
+`docs/release-process.md` and the `release-process` workflow already
+describe git-cliff in active use (`cliff.toml`, `scripts/release.sh`),
+so the de facto answer is git-cliff — but ADR-0003 itself has not been
+formally accepted. Don't treat this as settled; if the tooling changes,
+ADR-0003 needs to move to accepted (or be superseded) in the same PR.
+
+## Remote storage deduplication (ADR-0006)
+
+Accepted 2026-04-12. Environments include backing-service state
+(Postgres dumps, Redis snapshots, etc.) alongside service definitions.
+Naive one-`.tar.gz`-per-backup retransmits unchanged data on every
+push. ADR-0006 defines client-side, remote-agnostic deduplication (the
+remote stays a passive store — FTP/S3/similar, read/write/list only,
+no server-side compute) so repeated backups only transfer changed
+chunks.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -2,6 +2,9 @@
 
 This directory contains decision records for **shepherd**.
 
+Shortcut: read [`CURRENT.md`](CURRENT.md) for the net-result snapshot
+of all active decisions before reading the full corpus below.
+
 ## New ADR
 
 - Copy `adr-template.md` to `NNNN-title-with-dashes.md`


### PR DESCRIPTION
## Summary
- Consolidate `AGENTS.md` + `CLAUDE.md` into one canonical `AGENTS.md`; `CLAUDE.md` becomes a one-line `@AGENTS.md` import
- Add `docs/agent-workflows/` (`release-process`, `plugin-authoring`, `pr-prep`, `local-dev-testing`, `codex-task-routing`) with `.claude/skills/` compatibility wrappers pointing at them
- Add `docs/decisions/CURRENT.md` — a living snapshot condensing all 7 decision records by area, flagging ADR-0002 as superseded and ADR-0003 as still proposed/undecided rather than presenting either as settled
- Fix `.gitignore`: `AGENTS.md`, `CLAUDE.md`, and `.claude/` were excluded entirely (zero commit history before this PR) — narrowed to just `.claude/settings.local.json` and `.claude/scheduled_tasks.lock` (personal, not shared)

The old `docs/release-process.md`, `docs/plugins.md`, `docs/development.md`, and `CONTRIBUTION_GUIDELINES.md` are kept as-is; the new workflows are terse, agent-actionable companions, not replacements.

`plugin-authoring.md` also documents 6 real gaps found while building a plugin against this API, filed as #260–#265, so future plugin work — and future gap reports — has a home.

## Test plan
- [x] `pre-commit run --all-files` — all hooks pass (markdownlint-cli2, codespell, whitespace, etc.)
- [x] Manual: verified no content lost in the AGENTS.md/CLAUDE.md merge (checked every section from both source files against the new file)
- [x] Manual: spot-checked `docs/decisions/CURRENT.md` covers all 7 ADRs with correct status per record

Fixes #266