### PR TITLE
fix(util): send error output to stderr, not stdout

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -17,16 +17,21 @@ pytest_plugins = ["fixtures.fake_remote"]
 
 @pytest.fixture(autouse=True)
 def _no_rich_color(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Replace Util.console with a plain, no-color Console for every test.
+    """Replace Util.console/err_console with plain, no-color Consoles for
+    every test.
 
-    ``Util.console`` is a class-level attribute initialized at import time.
-    If pytest runs in a colour-capable terminal the Rich Console caches
-    colour support and emits ANSI escape codes even when CliRunner captures
-    stdout, making plain-string assertions fail.  Patching it here ensures
-    consistent, colour-free output across all environments.
+    ``Util.console``/``Util.err_console`` are class-level attributes
+    initialized at import time. If pytest runs in a colour-capable
+    terminal the Rich Console caches colour support and emits ANSI escape
+    codes even when CliRunner captures stdout/stderr, making plain-string
+    assertions fail. Patching them here ensures consistent, colour-free
+    output across all environments.
     """
     from util.util import Util
 
     monkeypatch.setattr(
         Util, "console", Console(force_terminal=False, no_color=True)
+    )
+    monkeypatch.setattr(
+        Util, "err_console", Console(force_terminal=False, no_color=True)
     )

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -5,6 +5,7 @@
 # Open-source: see LICENSE (AGPL-3.0-only).
 # Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -26,14 +27,68 @@ def read_fixture(*parts: str) -> str:
 def test_print_error_and_die_uses_minimal_error_prefix(
     mocker: MockerFixture,
 ):
-    console = mocker.Mock()
-    mocker.patch.object(Util, "console", console)
+    err_console = mocker.Mock()
+    mocker.patch.object(Util, "err_console", err_console)
 
     with pytest.raises(SystemExit) as excinfo:
         Util.print_error_and_die("test failure")
 
     assert excinfo.value.code == 1
-    console.print.assert_called_once_with(
+    err_console.print.assert_called_once_with(
         "[red]Error:[/red] test failure",
         highlight=False,
     )
+
+
+def test_print_error_and_die_does_not_use_stdout_console(
+    mocker: MockerFixture,
+):
+    """Regression test for #270: error output must not corrupt stdout,
+    since shell completion (`shepctl __complete ...`) requires stdout to
+    contain only completion candidates."""
+    console = mocker.Mock()
+    err_console = mocker.Mock()
+    mocker.patch.object(Util, "console", console)
+    mocker.patch.object(Util, "err_console", err_console)
+
+    with pytest.raises(SystemExit):
+        Util.print_error_and_die("test failure")
+
+    console.print.assert_not_called()
+    err_console.print.assert_called_once()
+
+
+def test_run_command_failure_prints_to_err_console(mocker: MockerFixture):
+    """Regression test for #270: run_command's failure path must also go
+    to err_console, not the stdout console."""
+    console = mocker.Mock()
+    err_console = mocker.Mock()
+    mocker.patch.object(Util, "console", console)
+    mocker.patch.object(Util, "err_console", err_console)
+    mocker.patch(
+        "util.util.subprocess.run",
+        side_effect=subprocess.CalledProcessError(1, ["false"]),
+    )
+
+    with pytest.raises(SystemExit):
+        Util.run_command(["false"], check=True)
+
+    console.print.assert_not_called()
+    err_console.print.assert_called_once()
+
+
+def test_run_command_failure_no_check_returns_error(mocker: MockerFixture):
+    """When check=False, a failed command returns the error instead of
+    exiting, but still reports via err_console, not stdout."""
+    console = mocker.Mock()
+    err_console = mocker.Mock()
+    mocker.patch.object(Util, "console", console)
+    mocker.patch.object(Util, "err_console", err_console)
+    error = subprocess.CalledProcessError(1, ["false"])
+    mocker.patch("util.util.subprocess.run", side_effect=error)
+
+    result = Util.run_command(["false"], check=False)
+
+    assert result is error
+    console.print.assert_not_called()
+    err_console.print.assert_called_once()

--- a/src/util/util.py
+++ b/src/util/util.py
@@ -43,6 +43,12 @@ log_format=%(asctime)s - %(levelname)s - %(message)s
 
 class Util:
     console = Console()
+    # Dedicated stderr console for error output. Shell completion
+    # (`shepctl __complete ...`) requires stdout to contain only
+    # completion candidates — an error printed via the main `console`
+    # (which defaults to stdout) would corrupt the candidate list any
+    # error path hit during completion resolution.
+    err_console = Console(stderr=True)
 
     @dataclass
     class OsInfo:
@@ -122,7 +128,7 @@ class Util:
 
     @staticmethod
     def print_error_and_die(message: str):
-        Util.console.print(f"[red]Error:[/red] {message}", highlight=False)
+        Util.err_console.print(f"[red]Error:[/red] {message}", highlight=False)
         sys.exit(1)
 
     @staticmethod
@@ -475,7 +481,7 @@ class Util:
             )
             return result
         except subprocess.CalledProcessError as e:
-            Util.console.print(f"Command failed: {e}", style="red")
+            Util.err_console.print(f"Command failed: {e}", style="red")
             if check:
                 sys.exit(1)
             return e


### PR DESCRIPTION
## Summary
- `Util.print_error_and_die` and `run_command`'s `CalledProcessError` path both printed via `Util.console`, a plain `rich.Console()` that defaults to stdout.
- Shell completion (`shepctl __complete ...`) requires stdout to contain only completion candidates — an error hit during completion resolution (e.g. a malformed `.shpd.conf`) would corrupt the candidate list.
- Adds a dedicated `Util.err_console` (`Console(stderr=True)`), routes both error paths through it. `Util.console` is untouched everywhere else (tables, yaml/json output, interactive prompts) — that's real stdout data, not error text.
- Updates the `_no_rich_color` autouse test fixture to patch `err_console` too, so error-path tests stay ANSI-free the same way stdout ones already were.

Follow-up to #88 (closed) — that issue's original "missing config" scenario is already fixed elsewhere, but investigating it surfaced this narrower, still-live risk for *other* config errors during completion.

## Test plan
- [x] `cd src && pytest` — 595 passed (3 new regression tests: error goes to `err_console` not `console`, same for `run_command`'s failure path with `check=True` and `check=False`)
- [x] `cd src && pyright .` — 0 errors
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Manual: with a deliberately malformed `~/.shpd.conf`, `shepctl __complete env` now prints nothing to stdout (verified via separate stdout/stderr redirection) and the error correctly appears on stderr. Original config restored after testing.

Fixes #270