### PR TITLE
feat(remote): add OCI registry as third built-in remote-storage backend

### DIFF
--- a/docs/decisions/0006-remote-storage-deduplication.md
+++ b/docs/decisions/0006-remote-storage-deduplication.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: "accepted; registry-transport section superseded by ADR-0007 (2026-08-08)"
 date: 2026-04-12
 decision-makers:
   - '@giubacc'
@@ -128,16 +128,33 @@ the existing `_delete_dir_with_sudo` pattern.
 
 ### Built-in Transports
 
-Two transports ship with the core:
+Three transports ship with the core:
 
 - **FTP** — using stdlib `ftplib`. Existence checks use the shard-listing
   strategy (one `NLST` per 2-char prefix per session, resolved from an
   in-memory set).
 - **SFTP** — using `paramiko`. Provides encrypted transfer and SSH key
   authentication, making it the preferred choice for most real deployments.
+- **Registry (OCI)** — added 2026-08-07, using `requests` over the OCI
+  Distribution Spec. Maps the same `RemoteBackend` contract onto a
+  Docker/OCI container registry's native blob store: a chunk's SHA-256
+  hash *is* its OCI blob digest, so existence checks are a single `HEAD`
+  per chunk rather than a shard-listing cache, and the registry does
+  digest verification server-side for free. Each stored path is tagged
+  individually in one repository (registries have no directory listing);
+  `list_prefix` is implemented via the repository's tag-list endpoint.
+  This is a transport addition only — the chunking/dedup algorithm above
+  is unchanged, which is why it is documented here rather than in a new
+  ADR. Full transport-specific notes, including the manifest-uniqueness
+  safeguard needed to make digest-based delete tag-scoped in practice:
+  [docs/remote.md](../remote.md#registry-oci). **This per-path-tag
+  object layout was superseded 2026-08-08 by ADR-0007**, which stops
+  tagging individual chunks and instead assembles a real multi-layer
+  OCI image per snapshot; see ADR-0007 for the current registry
+  object layout.
 
-Both implement the same `RemoteBackend` ABC and are interchangeable from
-the orchestration layer's perspective.
+All three implement the same `RemoteBackend` ABC and are interchangeable
+from the orchestration layer's perspective.
 
 ### Backend Extensibility
 
@@ -160,9 +177,9 @@ See [docs/remote.md](../remote.md) for the full configuration reference,
 built-in transport details, and worked CLI examples.
 
 Remotes are persisted in the main Shepherd config (`~/.shpd.conf`) under a
-top-level `remotes` list. Each entry has a `name`, a `type` (`ftp` or `sftp`
-for built-ins, or a plugin-registered type id), type-specific connection
-fields, and optional chunk tuning and local cache settings.
+top-level `remotes` list. Each entry has a `name`, a `type` (`ftp`, `sftp`,
+or `registry` for built-ins, or a plugin-registered type id), type-specific
+connection fields, and optional chunk tuning and local cache settings.
 
 Remotes are managed via `shepctl remote`:
 

--- a/docs/decisions/0007-registry-backend-snapshot-images.md
+++ b/docs/decisions/0007-registry-backend-snapshot-images.md
@@ -1,0 +1,199 @@
+---
+status: "accepted"
+date: 2026-08-08
+decision-makers:
+  - '@giubacc'
+---
+
+# Registry Backend: Bare Chunk Blobs + Per-Snapshot OCI Images
+
+Supersedes: ADR-0006 (registry-transport section only). ADR-0006's
+chunking algorithm and FTP/SFTP transports remain fully accepted and
+are unaffected by this ADR — ADRs are immutable records, so ADR-0006's
+body is not edited; only its `status` frontmatter now points here.
+
+## Context and Problem Statement
+
+ADR-0006 added an OCI registry transport that maps every path the
+`RemoteBackend` contract stores — every chunk, every snapshot
+manifest, `latest.json`, `index.json` — onto its own single-layer OCI
+artifact, tagged with a translated form of the path. This satisfies
+the contract, but wastes what makes a registry different from a plain
+KV store: one environment push produces thousands of tiny fake
+"images" (one manifest + one tag per chunk), none of which is a real,
+inspectable artifact, and none of which benefits from the registry's
+own image/layer model beyond blob-level content addressing that
+FTP/SFTP-style dedup already provided by construction.
+
+How do we keep the chunk-level dedup that makes repeated backups cheap
+(ADR-0006) while producing a registry-native artifact that is actually
+meaningful to registry tooling — pullable, inspectable, and subject to
+the registry's own layer/image conventions — instead of a pile of
+disposable per-chunk tags?
+
+## Decision Drivers
+
+- Minimize wasted manifest/tag churn: one manifest+tag write per chunk
+  does not scale and adds no value over a bare blob.
+- Produce a real multi-layer OCI image per snapshot, so
+  `docker pull`/`crane manifest`/registry UIs show something
+  meaningful, not thousands of disposable one-layer tags.
+- Preserve the existing dedup granularity: unchanged data between two
+  pushes must not be retransmitted, same as ADR-0006's guarantee for
+  FTP/SFTP.
+- Zero changes to `RemoteMng`, the `RemoteBackend` ABC, or the
+  FTP/SFTP backends — this is a `RegistryBackend`-only change.
+- OCI registries expose no blob-listing API, only a per-repository
+  tag list — removing per-chunk tags removes the only mechanism
+  `list_prefix("chunks/<shard>")` had to enumerate chunks, and
+  `RemoteMng`'s push-time dedup check and `prune`'s orphan scan both
+  depend on it with no fallback.
+
+## Considered Options
+
+- Keep per-chunk tagging (status quo from ADR-0006) — rejected; this
+  ADR exists because that design is the problem being solved.
+- Push one single-layer image per environment, whole tar as one blob —
+  rejected; dedup would only fire when two environments are
+  byte-identical as a whole, regressing ADR-0006's core guarantee that
+  only changed data is retransmitted.
+- Bare content-addressed chunk blobs (no tag) + one multi-layer OCI
+  image per snapshot (layers = chunk blobs, in order) + a per-shard
+  index object to replace tag-list-based chunk enumeration — chosen.
+- Bare chunk blobs with no enumeration support at all, relying on a
+  per-chunk `exists()` instead of batched `list_prefix` — rejected;
+  would require changing `RemoteMng`'s push loop (out of scope) and is
+  far chattier than a shard-index read.
+
+## Decision Outcome
+
+Chosen option: **bare chunk blobs + per-snapshot OCI image + per-shard
+index**, because it eliminates per-chunk tag overhead, produces a real
+pullable artifact per snapshot, and requires no changes outside
+`RegistryBackend`.
+
+### Chunk objects become bare blobs
+
+A chunk's path (`chunks/<shard>/<hash>`) already embeds its SHA-256
+hash, which *is* its OCI blob digest — this invariant holds for every
+real chunk path, since `RemoteMng`/`Chunker` always compute the path
+from the actual content hash before calling `upload`. `exists()` and
+`download()` for chunk paths resolve the digest straight from the
+path, with no manifest lookup. `upload()` for a chunk path stops after
+the blob PUT — no manifest, no tag. `delete()` issues a direct blob
+`DELETE`. `rename()` becomes a no-op on the blob itself (the tmp and
+final paths share the same hash/digest, so there is nothing to move) —
+a significant simplification and performance win over the previous
+download+upload+delete dance.
+
+### Per-shard chunk index
+
+Since chunks are no longer tagged, `list_prefix("chunks/<shard>")` can
+no longer use the tag-list endpoint. A small JSON blob per shard,
+`chunks/<shard>/.index.json`, stored through the ordinary
+tagged-artifact path (it isn't chunk-shaped, so no special-casing is
+needed there), tracks which chunk hashes exist in that shard.
+`RegistryBackend` buffers adds/removes in memory as chunks are
+confirmed (`rename()`, or `upload()` directly to a non-`.tmp` chunk
+path) or removed (`delete()`), and flushes once per touched shard in
+`close()` — the one lifecycle hook `RemoteMng` always invokes via
+`with backend:` for every push/pull/hydrate/prune operation. This
+turns O(new chunks) index writes into O(touched shards).
+
+### Per-snapshot OCI image
+
+Writing a snapshot manifest (`envs/<env>/snapshots/<id>.json`)
+additionally assembles one real multi-layer OCI image: layers are the
+manifest's chunk blobs, in the same order as `SnapshotManifest.chunks`,
+each already present as a bare blob from earlier in the same push.
+This image is pushed under two tags: an immutable per-snapshot tag
+(`images/<env>/<snapshot_id>`, translated) and a mutable
+per-environment tag (`images/<env>/latest`, translated) repointed on
+every push — mirroring `latest.json`'s role, so
+`docker pull <repo>:<env>-latest`-style access just works. The
+synthetic `images/` path namespace cannot collide with any real KV
+path.
+
+The image is a genuine `docker pull`/`crane manifest`-able artifact —
+registry-native layer dedup applies to it directly — but it is **not
+runnable**: layers are opaque zstd-compressed FastCDC chunks, not real
+tar diffs, so `docker run`/`docker save` would not produce a coherent
+filesystem. It exists for registry-native storage/dedup visibility and
+interoperability, not execution.
+
+The existing per-snapshot manifest JSON object
+(`envs/<env>/snapshots/<id>.json`) is unchanged and continues to serve
+as the cheap metadata sidecar for `shepctl remote get`/listing,
+without ever touching the big image.
+
+### Consequences
+
+- Good, because per-push manifest/tag writes drop from O(chunks) to
+  O(touched shards) + O(1) image assembly — the dominant waste in the
+  previous design is gone.
+- Good, because each snapshot now has a real, inspectable,
+  `docker pull`-able artifact instead of thousands of disposable tags.
+- Good, because `rename()` for chunks becomes a no-op instead of a
+  download+upload+delete round trip, and `delete()` for chunks becomes
+  a direct blob delete instead of a manifest-digest lookup first.
+- Good, because `RemoteMng`, the `RemoteBackend` ABC, and FTP/SFTP are
+  completely untouched.
+- Neutral, because assembling a snapshot's image costs one `HEAD` per
+  chunk that was a dedup hit this push (to learn its size for the
+  layer descriptor) — bounded, one-time cost at manifest-upload time.
+- Neutral, because a crash between uploading new chunks and `close()`
+  flushing the shard index leaves those chunks temporarily invisible
+  to `list_prefix`/`prune` within a *single* session. This is
+  self-healing (a later push re-PUTs an idempotent, already-present
+  digest) and non-corrupting for that single-session-crash scenario.
+- Bad, because the OCI distribution spec has no atomic compare-and-swap
+  for manifest tags, so the shard-index flush (`_write_shard_index`) is
+  fundamentally a read-merge-write against shared state. Two backend
+  sessions racing on the *same shard* — e.g. a `push()`'s flush and a
+  concurrent `prune()`'s deletion — can still interleave in a way that
+  resurrects an already-deleted hash if both land within the same
+  narrow window. `_write_shard_index` mitigates this with an
+  optimistic-concurrency recheck immediately before the write (retried
+  up to `_INDEX_WRITE_ATTEMPTS`), which shrinks the race from the whole
+  read-merge-write sequence down to a single HTTP round trip, but does
+  not eliminate it — this is a real, if narrow, gap in the "multiple
+  clients may write concurrently without corrupting data" driver from
+  ADR-0006, specific to the shard-index mechanism this ADR introduces
+  (FTP/SFTP and the chunk/manifest objects themselves have no
+  equivalent derived-state race).
+- Bad, because the per-shard `.index.json` is one more piece of
+  derived state that must stay consistent with actual blob presence;
+  consistency is maintained solely by `delete()`/`rename()`/`upload()`
+  on chunk paths, so any future code path that writes/removes chunk
+  blobs without going through those methods would need to keep it in
+  sync too.
+- Bad (forward-looking gap), because `RemoteMng` has no
+  snapshot-deletion feature today — `prune()` only removes orphan
+  chunks, snapshot manifests are kept forever — so nothing currently
+  deletes a per-snapshot image tag or repoints `:latest` when a
+  snapshot is forgotten. A future `shepctl remote forget <snapshot>`
+  (or similar) would need to also delete the per-snapshot image tag
+  and, if that snapshot was newest, repoint (or remove) the `:latest`
+  tag. Not implemented as part of this change.
+
+### Confirmation
+
+- `shepctl env push` twice in a row against a registry remote uploads
+  zero new chunks on the second push (same guarantee as ADR-0006).
+- A push's per-snapshot image tag (`GET /v2/<repo>/manifests/<tag>`,
+  or `crane manifest`/`docker pull`) returns a valid OCI manifest with
+  one layer per chunk, in the same order as the snapshot manifest's
+  `chunks` list.
+- `shepctl remote prune` against the registry backend removes orphan
+  chunk blobs and leaves referenced ones and their shard indexes
+  consistent.
+- `shepctl env pull`/`hydrate`/`dehydrate` round-trip against the
+  registry backend without data loss, unchanged from before this ADR.
+- Unit tests (`src/tests/test_remote_registry_backend.py`) and the
+  Docker-backed integration suite
+  (`src/tests/integration/test_ftp_sftp_backends.py`, `registry`
+  parametrization) cover the above.
+
+## More Information
+
+Full transport-specific reference: [docs/remote.md](../remote.md#registry-oci).

--- a/docs/decisions/CURRENT.md
+++ b/docs/decisions/CURRENT.md
@@ -59,7 +59,7 @@ so the de facto answer is git-cliff — but ADR-0003 itself has not been
 formally accepted. Don't treat this as settled; if the tooling changes,
 ADR-0003 needs to move to accepted (or be superseded) in the same PR.
 
-## Remote storage deduplication (ADR-0006)
+## Remote storage deduplication (ADR-0006, registry transport ADR-0007)
 
 Accepted 2026-04-12. Environments include backing-service state
 (Postgres dumps, Redis snapshots, etc.) alongside service definitions.
@@ -67,4 +67,15 @@ Naive one-`.tar.gz`-per-backup retransmits unchanged data on every
 push. ADR-0006 defines client-side, remote-agnostic deduplication (the
 remote stays a passive store — FTP/S3/similar, read/write/list only,
 no server-side compute) so repeated backups only transfer changed
-chunks.
+chunks. Three transports ship in core: FTP, SFTP, and an OCI
+container-registry transport (added 2026-08-07). The registry
+transport's object layout was revised 2026-08-08 (ADR-0007, which
+supersedes ADR-0006's original registry section): chunks are stored as
+bare content-addressed blobs (no per-chunk tag — a chunk's SHA-256
+hash *is* its OCI blob digest, resolved straight from its path), and
+each snapshot additionally gets a real multi-layer OCI image
+(immutable per-snapshot tag + mutable per-environment `latest`-style
+tag) assembled from those chunk blobs, so `docker pull`/`crane` see a
+real artifact instead of one tag per chunk. This is a
+transport-internal change only — `RemoteMng` and the chunking
+algorithm itself are unaffected. Details: [docs/remote.md](../remote.md).

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -213,6 +213,99 @@ remotes:
 
 ---
 
+### Registry (OCI)
+
+Stores chunks and manifests in a Docker/OCI container registry instead of a
+file-oriented server. A chunk's SHA-256 hash — already computed for
+deduplication — doubles as its OCI blob digest, so existence checks and
+uploads piggyback directly on the registry's own content-addressed blob
+store instead of a bespoke listing/caching scheme. Each snapshot also gets
+a real, `docker pull`-able multi-layer OCI image assembled from its chunk
+blobs (see [Registry Notes](#registry-notes) below and ADR-0007).
+
+#### CLI (Registry)
+
+```sh
+shepctl remote add my-registry --registry \
+    --host registry.example.com \
+    --user deploy \
+    --password "${REGISTRY_PASSWORD}" \
+    --root-path myorg/shepherd-backups \
+    --set-default
+
+# Local/test registry without TLS (e.g. `docker run -p 5000:5000 registry:2`)
+shepctl remote add local-registry --registry \
+    --host localhost:5000 \
+    --root-path shepherd-test \
+    --insecure
+```
+
+`--host` and `--root-path` are required. `--root-path` is the OCI
+repository name (not a filesystem path) — every object for this remote is
+stored as a distinct tag inside that one repository. `--user`/`--password`
+are optional; when set they are used both for HTTP Basic auth and to
+resolve the registry's Bearer-token auth challenge (the same flow
+`docker login`/`docker push` use). `--insecure` connects over plain HTTP
+instead of HTTPS.
+
+#### Config YAML (Registry)
+
+```yaml
+remotes:
+  - name: my-registry
+    type: registry
+    host: registry.example.com
+    user: deploy
+    password: "${REGISTRY_PASSWORD}"
+    root_path: myorg/shepherd-backups
+    properties:
+      insecure: false   # optional; true for plain-HTTP local/test registries
+    default: true
+```
+
+#### Registry Notes
+
+- Uses [`requests`](https://requests.readthedocs.io/) over the OCI
+  Distribution Spec (`GET`/`HEAD`/`PUT`/`DELETE` on `/v2/<repo>/blobs/...`
+  and `/v2/<repo>/manifests/...`) — the same wire protocol `docker
+  push`/`docker pull` use.
+- **Chunks are bare, untagged blobs.** A chunk's path
+  (`chunks/<shard>/<hash>`) already embeds its SHA-256 hash, which *is*
+  its OCI blob digest, so existence checks and downloads resolve the
+  digest straight from the path — no manifest lookup, no per-chunk tag.
+  Every other object (snapshot manifest, `latest.json`, `index.json`)
+  keeps the original model: a small single-layer OCI artifact tagged
+  with a translated form of the path (`/` and `:` become `_`, since OCI
+  tag names disallow both).
+- **Per-shard chunk index.** Registries expose no blob-listing API, only
+  a repository tag list, so a small JSON object per shard
+  (`chunks/<shard>/.index.json`) tracks which chunk hashes exist in that
+  shard; `shepctl remote get`/`shepctl remote prune` (and push-time
+  dedup checks) read this instead of tag-listing. The index is updated
+  in memory as chunks are confirmed or removed and flushed once per
+  touched shard when the backend connection closes.
+- **Per-snapshot OCI image.** Writing a snapshot's manifest also
+  assembles one real multi-layer OCI image — layers are that snapshot's
+  chunk blobs, in order — under an immutable per-snapshot tag and a
+  mutable per-environment `latest`-style tag repointed on every push.
+  This image is genuinely `docker pull`/`crane manifest`-able and
+  registry-native layer dedup applies to it directly, but it is **not
+  runnable**: layers are opaque zstd-compressed chunks, not real tar
+  diffs, so `docker run`/`docker save` will not produce a coherent
+  filesystem. It exists for registry-native visibility/interoperability,
+  not execution. See [ADR-0007](decisions/0007-registry-backend-snapshot-images.md)
+  for the full design.
+- **Deletion support (`shepctl remote prune`) depends on the registry.**
+  Many registries — notably Docker Hub — disable manifest/blob deletion
+  by default; a local `registry:2` container needs
+  `REGISTRY_STORAGE_DELETE_ENABLED=true` to support it. When deletion is
+  unsupported, `prune` silently skips removal rather than failing
+  (mirroring FTP/SFTP's "best effort" stance on missing paths).
+- Bearer tokens obtained during the auth challenge are cached in memory
+  for the lifetime of the backend connection.
+
+---
+
 ## Advanced: Chunk Tuning
 
 The default FastCDC parameters work well for most environments. Override them

--- a/src/remote/__init__.py
+++ b/src/remote/__init__.py
@@ -9,11 +9,13 @@
 
 from .backend import RemoteBackend
 from .ftp_backend import FTPBackend
+from .registry_backend import RegistryBackend
 from .remote_mng import RemoteMng
 from .sftp_backend import SFTPBackend
 
 __all__ = [
     "FTPBackend",
+    "RegistryBackend",
     "RemoteBackend",
     "RemoteMng",
     "SFTPBackend",

--- a/src/remote/registry_backend.py
+++ b/src/remote/registry_backend.py
@@ -1,0 +1,657 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+"""Built-in OCI registry remote storage backend.
+
+Maps the passive key/value ``RemoteBackend`` contract onto an OCI
+container registry's native content-addressed blob store (the same
+protocol ``docker push``/``docker pull`` use).
+
+Chunk objects (``chunks/<shard>/<hash>``) are stored as **bare blobs**:
+the path already embeds the chunk's SHA-256 hash, which *is* its OCI
+blob digest, so no manifest or tag is created per chunk. Because OCI
+registries expose no blob-listing API, a small per-shard index object
+(``chunks/<shard>/.index.json``) is maintained to support
+``list_prefix`` (used by push-time dedup checks and ``prune``).
+
+Every other path (snapshot manifests, ``latest.json``, ``index.json``,
+the per-shard index itself) keeps the original model: a small
+single-layer OCI artifact tagged with a translated form of the path.
+
+Additionally, whenever a snapshot manifest is written
+(``envs/<env>/snapshots/<id>.json``), this backend assembles and pushes
+one real multi-layer OCI image for that snapshot — layers are the
+snapshot's chunk blobs, in order — under an immutable per-snapshot tag
+and a mutable per-environment ``:latest``-style tag. This is a genuine
+``docker pull``/``crane manifest``-able artifact (registry-native
+dedup applies to its layers directly) but is not runnable: layers are
+opaque zstd-compressed FastCDC chunks, not real tar diffs, so
+``docker run``/``docker save`` would not produce a coherent
+filesystem. It exists for registry-native storage/dedup visibility and
+interoperability, not execution. See ADR-0007.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, Optional, cast
+
+import requests
+
+from storage.snapshot import SnapshotManifest
+
+from .backend import RemoteBackend
+
+_EMPTY_CONFIG_BYTES = b"{}"
+_EMPTY_CONFIG_DIGEST = (
+    f"sha256:{hashlib.sha256(_EMPTY_CONFIG_BYTES).hexdigest()}"
+)
+_CONFIG_MEDIA_TYPE = "application/vnd.shepherd.remote.config.v1+json"
+_LAYER_MEDIA_TYPE = "application/vnd.shepherd.remote.object.v1"
+_MANIFEST_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json"
+
+_CHUNK_PATH_RE = re.compile(r"^chunks/[0-9a-f]{2}/([0-9a-f]{64})(?:\.tmp)?$")
+_CHUNK_SHARD_RE = re.compile(r"^chunks/([0-9a-f]{2})$")
+_SNAPSHOT_MANIFEST_RE = re.compile(r"^envs/[^/]+/snapshots/[^/]+\.json$")
+
+_INDEX_WRITE_ATTEMPTS = 5
+
+
+def _chunk_digest_from_path(path: str) -> Optional[str]:
+    """Return the ``sha256:<hash>`` blob digest encoded in *path*.
+
+    Chunk paths embed their own content hash (see
+    :meth:`RemoteBackend.chunk_path`), so the digest never requires a
+    manifest lookup. Returns ``None`` for non-chunk paths.
+    """
+    m = _CHUNK_PATH_RE.match(path)
+    return f"sha256:{m.group(1)}" if m else None
+
+
+def _chunk_shard_from_prefix(prefix: str) -> Optional[str]:
+    """Return the 2-hex shard if *prefix* is a chunk-shard prefix."""
+    m = _CHUNK_SHARD_RE.match(prefix)
+    return m.group(1) if m else None
+
+
+def _path_to_tag(path: str) -> str:
+    """Translate a backend path into a valid OCI tag.
+
+    OCI tag names are restricted to ``[A-Za-z0-9_][A-Za-z0-9._-]*``. Every
+    path this backend stores uses ``/`` as a directory separator
+    (mirroring the FTP/SFTP layout) and snapshot ids embed an ISO-8601
+    UTC timestamp containing ``:`` (see ``SnapshotManifest.build_id`` in
+    ``storage/snapshot.py``) — both characters are illegal in a tag.
+    Both are replaced with ``_``. This is a one-way mapping (not required
+    to round-trip: tags are looked up by exact translated string, never
+    parsed back into a path), so a real ``_`` in a path and an escaped
+    ``/`` or ``:`` are indistinguishable, which is harmless here.
+    """
+    return path.replace("/", "_").replace(":", "_")
+
+
+class RegistryBackend(RemoteBackend):
+    """OCI registry remote backend.
+
+    Chunk objects are bare, untagged blobs: a chunk's SHA-256 hash
+    (already computed by :class:`~storage.chunker.Chunker` over the
+    compressed bytes) *is* its OCI blob digest and is encoded directly
+    in its path, so ``exists()``/``download()`` for chunk paths resolve
+    the digest without any manifest lookup, and ``upload()`` stops
+    after the blob PUT — no per-chunk manifest or tag is created.
+
+    All other objects (snapshot manifests, pointers, the global index,
+    and the per-shard chunk index described below) keep the original
+    model: a small single-layer OCI artifact tagged with a translated
+    form of its backend path (see :func:`_path_to_tag`).
+
+    ``list_prefix`` has no direct OCI equivalent (registries have no
+    blob- or tag-listing API beyond the repository's flat tag list).
+    For non-chunk prefixes it is implemented via the tag-list endpoint
+    (``GET /v2/<repo>/tags/list``), filtered by the translated prefix —
+    this keeps ``shepctl remote get`` (snapshot enumeration) working
+    exactly as it does against FTP/SFTP. For a chunk-shard prefix
+    (``chunks/<shard>``) it instead reads a small per-shard index blob
+    (``chunks/<shard>/.index.json``, itself stored via the ordinary
+    tagged-artifact path since it isn't chunk-shaped), which this
+    backend keeps in sync as chunks are confirmed (``rename()``) or
+    removed (``delete()``). Index updates are buffered in memory and
+    flushed once per touched shard in :meth:`close`, so a push that
+    touches many chunks in the same shard costs one index write, not
+    one per chunk. The flush uses an optimistic-concurrency recheck
+    (see :meth:`_write_shard_index`) to avoid silently undoing a
+    concurrent session's update to the same shard — the OCI
+    distribution spec has no atomic compare-and-swap for tags, so this
+    narrows but does not fully eliminate that race.
+
+    Writing a snapshot manifest (``envs/<env>/snapshots/<id>.json``)
+    additionally assembles a real multi-layer OCI image for that
+    snapshot (layers = the manifest's chunk blobs, in order) under an
+    immutable per-snapshot tag and a mutable per-environment ``latest``
+    tag. See the module docstring and ADR-0007.
+
+    Parameters
+    ----------
+    host:
+        Registry host, optionally including a port (e.g.
+        ``registry.example.com:5000``).
+    user:
+        Registry username (optional; used for Basic auth and to resolve
+        Bearer token challenges).
+    password:
+        Registry password or access token (optional; supports
+        ``${VAR}`` resolved before construction).
+    root_path:
+        Repository name (OCI ``<name>`` path component) under which all
+        objects for this remote are stored, e.g. ``myorg/shepherd``.
+    insecure:
+        When ``True``, connect over plain HTTP instead of HTTPS (for
+        local/test registries such as ``registry:2`` without TLS).
+    """
+
+    def __init__(
+        self,
+        host: str,
+        user: str = "",
+        password: str = "",
+        root_path: str = "shepherd",
+        insecure: bool = False,
+    ) -> None:
+        self._repo = root_path.strip("/") or "shepherd"
+        scheme = "http" if insecure else "https"
+        self._base = f"{scheme}://{host}/v2/{self._repo}"
+        self._user = user
+        self._password = password
+        self._session = requests.Session()
+        # Cache of Bearer tokens keyed by the (realm, service, scope)
+        # challenge tuple, so repeated requests against the same scope
+        # do not each re-authenticate.
+        self._token_cache: dict[tuple[str, str, str], str] = {}
+        # Sizes of blobs uploaded (or confirmed present) this session,
+        # so assembling a snapshot image doesn't re-HEAD a blob this
+        # same push just wrote.
+        self._known_blob_sizes: dict[str, int] = {}
+        # Per-shard chunk-hash adds/removes not yet flushed to the
+        # shard's .index.json (see _flush_shard_indexes / close()).
+        self._pending_index_adds: dict[str, set[str]] = {}
+        self._pending_index_removes: dict[str, set[str]] = {}
+
+    # ------------------------------------------------------------------
+    # RemoteBackend implementation
+    # ------------------------------------------------------------------
+
+    def exists(self, path: str) -> bool:
+        digest = _chunk_digest_from_path(path) or self._resolve_digest(path)
+        if digest is None:
+            return False
+        resp = self._request("HEAD", f"/blobs/{digest}")
+        return resp.status_code == 200
+
+    def upload(self, path: str, data: bytes) -> None:
+        digest = f"sha256:{hashlib.sha256(data).hexdigest()}"
+        if not self._blob_exists(digest):
+            self._upload_blob(data, digest)
+        self._known_blob_sizes[digest] = len(data)
+
+        if _chunk_digest_from_path(path) is not None:
+            # Bare content-addressed blob only — no manifest, no tag.
+            if not path.endswith(".tmp"):
+                # Final chunk path (not a staging .tmp path, so no
+                # rename() will follow to confirm it) — index it as
+                # enumerable immediately.
+                shard, chunk_hash = self._shard_and_hash(path)
+                self._pending_index_adds.setdefault(shard, set()).add(
+                    chunk_hash
+                )
+                self._pending_index_removes.get(shard, set()).discard(
+                    chunk_hash
+                )
+            return
+
+        if not self._blob_exists(_EMPTY_CONFIG_DIGEST):
+            self._upload_blob(_EMPTY_CONFIG_BYTES, _EMPTY_CONFIG_DIGEST)
+        tag = _path_to_tag(path)
+        self._put_manifest(
+            tag,
+            json.dumps(self._build_manifest(digest, len(data), tag)).encode(),
+        )
+
+        if _SNAPSHOT_MANIFEST_RE.match(path):
+            self._push_snapshot_image(data)
+
+    def download(self, path: str) -> bytes:
+        digest = _chunk_digest_from_path(path) or self._resolve_digest(path)
+        if digest is None:
+            raise FileNotFoundError(path)
+        resp = self._request("GET", f"/blobs/{digest}")
+        resp.raise_for_status()
+        return resp.content
+
+    def list_prefix(self, prefix: str) -> list[str]:
+        shard = _chunk_shard_from_prefix(prefix)
+        if shard is not None:
+            return self._effective_shard_index(shard)
+        tag_prefix = _path_to_tag(prefix)
+        if tag_prefix and not tag_prefix.endswith("_"):
+            tag_prefix = f"{tag_prefix}_"
+        names: list[str] = []
+        url: Optional[str] = f"{self._base}/tags/list?n=1000"
+        while url is not None:
+            resp = self._request_absolute("GET", url)
+            if resp.status_code == 404:
+                break
+            resp.raise_for_status()
+            body: dict[str, Any] = resp.json()
+            tags = cast("list[str]", body.get("tags") or [])
+            for tag in tags:
+                if tag.startswith(tag_prefix):
+                    names.append(tag[len(tag_prefix) :])
+            url = self._next_page_url(resp)
+        return names
+
+    def delete(self, path: str) -> None:
+        chunk_digest = _chunk_digest_from_path(path)
+        if chunk_digest is not None:
+            resp = self._request("DELETE", f"/blobs/{chunk_digest}")
+            if resp.status_code not in (200, 202, 404, 405):
+                resp.raise_for_status()
+            shard, chunk_hash = self._shard_and_hash(path)
+            self._pending_index_removes.setdefault(shard, set()).add(chunk_hash)
+            self._pending_index_adds.get(shard, set()).discard(chunk_hash)
+            return
+
+        tag = _path_to_tag(path)
+        digest = self._manifest_digest(tag)
+        if digest is None:
+            return
+        resp = self._request("DELETE", f"/manifests/{digest}")
+        # Many registries (notably Docker Hub) disable manifest/blob
+        # deletion entirely without a separate GC pass. Mirror the
+        # FTP/SFTP backends' "best effort, ignore missing" stance for
+        # anything short of an unexpected server error.
+        if resp.status_code not in (200, 202, 404, 405):
+            resp.raise_for_status()
+
+    def rename(self, src_path: str, dst_path: str) -> None:
+        if _chunk_digest_from_path(src_path) is not None:
+            # Content-addressed: upload(tmp_path, data) already wrote
+            # the blob at its permanent digest (tmp and final paths
+            # share the same hash) — there is nothing to move. Record
+            # the chunk as confirmed/enumerable in its shard index.
+            shard, chunk_hash = self._shard_and_hash(dst_path)
+            self._pending_index_adds.setdefault(shard, set()).add(chunk_hash)
+            self._pending_index_removes.get(shard, set()).discard(chunk_hash)
+            return
+
+        # Every other stored path (pointer/manifest) is tagged
+        # individually (see _path_to_tag), so upload(tmp_path, ...)
+        # leaves the content reachable only under the .tmp tag — the
+        # underlying blob upload is atomic, but the *tag* pointing at it
+        # still needs to move. Re-tag by re-pushing the manifest under
+        # the destination tag (registry tag writes are atomic), then
+        # remove the source tag.
+        if self._resolve_digest(src_path) is None:
+            return
+        data = self.download(src_path)
+        self.upload(dst_path, data)
+        self.delete(src_path)
+
+    def close(self) -> None:
+        self._flush_shard_indexes()
+        self._session.close()
+
+    # ------------------------------------------------------------------
+    # Chunk-path helpers
+    # ------------------------------------------------------------------
+
+    def _shard_and_hash(self, chunk_path: str) -> tuple[str, str]:
+        m = _CHUNK_PATH_RE.match(chunk_path)
+        assert m is not None, chunk_path
+        return chunk_path.split("/")[1], m.group(1)
+
+    # ------------------------------------------------------------------
+    # Per-shard chunk index (list_prefix / prune enumeration)
+    # ------------------------------------------------------------------
+
+    def _shard_index_path(self, shard: str) -> str:
+        return f"chunks/{shard}/.index.json"
+
+    def _read_persisted_shard_index(self, shard: str) -> list[str]:
+        path = self._shard_index_path(shard)
+        digest = self._resolve_digest(path)
+        if digest is None:
+            return []
+        resp = self._request("GET", f"/blobs/{digest}")
+        resp.raise_for_status()
+        return cast("list[str]", json.loads(resp.content))
+
+    def _effective_shard_index(self, shard: str) -> list[str]:
+        current = set(self._read_persisted_shard_index(shard))
+        current |= self._pending_index_adds.get(shard, set())
+        current -= self._pending_index_removes.get(shard, set())
+        return sorted(current)
+
+    def _upload_index_blob(self, entries: list[str]) -> tuple[str, bytes]:
+        data = json.dumps(entries).encode()
+        digest = f"sha256:{hashlib.sha256(data).hexdigest()}"
+        if not self._blob_exists(digest):
+            self._upload_blob(data, digest)
+        if not self._blob_exists(_EMPTY_CONFIG_DIGEST):
+            self._upload_blob(_EMPTY_CONFIG_BYTES, _EMPTY_CONFIG_DIGEST)
+        return digest, data
+
+    def _write_shard_index(self, shard: str) -> None:
+        """Write *shard*'s merged index, retrying under contention.
+
+        The OCI distribution spec has no atomic compare-and-swap for
+        manifest tags, so a plain read-merge-write here can silently
+        undo a concurrent session's update to the same shard (e.g. this
+        push's flush racing a concurrent ``prune()`` that just deleted a
+        chunk from this shard). Immediately before writing, re-check
+        that the index tag hasn't moved since we read it; if it has,
+        retry with a fresh read/merge instead of blindly overwriting the
+        concurrent change. This narrows the race to the single HTTP
+        round trip between that recheck and the write, rather than the
+        whole read-merge-write sequence — not a full fix (no CAS
+        primitive is available to close it entirely), but a large
+        reduction in the window during which a lost update can occur.
+        """
+        tag = _path_to_tag(self._shard_index_path(shard))
+        for _ in range(_INDEX_WRITE_ATTEMPTS - 1):
+            base_digest = self._manifest_digest(tag)
+            entries = self._effective_shard_index(shard)
+            digest, data = self._upload_index_blob(entries)
+            if self._manifest_digest(tag) != base_digest:
+                continue  # raced by a concurrent writer — retry
+            self._put_manifest(
+                tag,
+                json.dumps(
+                    self._build_manifest(digest, len(data), tag)
+                ).encode(),
+            )
+            return
+        # Retry budget exhausted under heavy contention: write once more,
+        # unconditionally, rather than silently dropping this session's
+        # update. This risks the same class of lost update the loop
+        # above was narrowing, not a new one — a later flush from any
+        # session reconciles further changes.
+        entries = self._effective_shard_index(shard)
+        digest, data = self._upload_index_blob(entries)
+        self._put_manifest(
+            tag,
+            json.dumps(self._build_manifest(digest, len(data), tag)).encode(),
+        )
+
+    def _flush_shard_indexes(self) -> None:
+        shards = set(self._pending_index_adds) | set(
+            self._pending_index_removes
+        )
+        for shard in shards:
+            self._write_shard_index(shard)
+        self._pending_index_adds.clear()
+        self._pending_index_removes.clear()
+
+    # ------------------------------------------------------------------
+    # Per-snapshot OCI image
+    # ------------------------------------------------------------------
+
+    def _snapshot_image_tag(self, env_name: str, snapshot_id: str) -> str:
+        return _path_to_tag(f"images/{env_name}/{snapshot_id}")
+
+    def _snapshot_latest_image_tag(self, env_name: str) -> str:
+        return _path_to_tag(f"images/{env_name}/latest")
+
+    def _blob_size(self, digest: str) -> int:
+        if digest in self._known_blob_sizes:
+            return self._known_blob_sizes[digest]
+        resp = self._request("HEAD", f"/blobs/{digest}")
+        resp.raise_for_status()
+        size = int(resp.headers.get("Content-Length", "0"))
+        self._known_blob_sizes[digest] = size
+        return size
+
+    def _push_snapshot_image(self, manifest_data: bytes) -> None:
+        """Assemble and push the multi-layer OCI image for a snapshot.
+
+        Called from :meth:`upload` right after a snapshot manifest
+        (``envs/<env>/snapshots/<id>.json``) is written. Layers are the
+        snapshot's chunk blobs, in the same order as
+        ``SnapshotManifest.chunks`` — all already pushed as bare blobs
+        by earlier ``upload()`` calls in the same push.
+        """
+        snapshot = SnapshotManifest.from_dict(json.loads(manifest_data))
+        layers: list[dict[str, Any]] = []
+        for chunk_hash in snapshot.chunks:
+            digest = f"sha256:{chunk_hash}"
+            layers.append(
+                {
+                    "mediaType": _LAYER_MEDIA_TYPE,
+                    "digest": digest,
+                    "size": self._blob_size(digest),
+                }
+            )
+        image_manifest = self._build_snapshot_image_manifest(layers)
+        manifest_bytes = json.dumps(image_manifest).encode()
+        self._put_manifest(
+            self._snapshot_image_tag(
+                snapshot.environment, snapshot.snapshot_id
+            ),
+            manifest_bytes,
+        )
+        self._put_manifest(
+            self._snapshot_latest_image_tag(snapshot.environment),
+            manifest_bytes,
+        )
+
+    def _build_snapshot_image_manifest(
+        self, layers: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        return {
+            "schemaVersion": 2,
+            "mediaType": _MANIFEST_MEDIA_TYPE,
+            "config": {
+                "mediaType": _CONFIG_MEDIA_TYPE,
+                "digest": _EMPTY_CONFIG_DIGEST,
+                "size": len(_EMPTY_CONFIG_BYTES),
+            },
+            "layers": layers,
+        }
+
+    # ------------------------------------------------------------------
+    # OCI manifest helpers
+    # ------------------------------------------------------------------
+
+    def _put_manifest(self, tag: str, manifest_bytes: bytes) -> None:
+        resp = self._request(
+            "PUT",
+            f"/manifests/{tag}",
+            data=manifest_bytes,
+            headers={"Content-Type": _MANIFEST_MEDIA_TYPE},
+        )
+        resp.raise_for_status()
+
+    def _build_manifest(
+        self, digest: str, size: int, tag: str
+    ) -> dict[str, Any]:
+        # The manifest embeds its own tag as an annotation so that two
+        # tags pointing at byte-identical content (e.g. the .tmp and
+        # final tags for the same chunk during push, or two distinct
+        # chunks that happen to compress to the same bytes) never
+        # collide on the same manifest digest. Digest-based delete
+        # (DELETE /manifests/<digest>) removes every tag pointing at
+        # that digest, not just one — a collision here would let
+        # deleting one tag silently take a second, unrelated tag with
+        # it. See delete()/rename() for the corresponding safety notes.
+        return {
+            "schemaVersion": 2,
+            "mediaType": _MANIFEST_MEDIA_TYPE,
+            "config": {
+                "mediaType": _CONFIG_MEDIA_TYPE,
+                "digest": _EMPTY_CONFIG_DIGEST,
+                "size": len(_EMPTY_CONFIG_BYTES),
+            },
+            "layers": [
+                {
+                    "mediaType": _LAYER_MEDIA_TYPE,
+                    "digest": digest,
+                    "size": size,
+                }
+            ],
+            "annotations": {"com.moonyfringers.shepherd.tag": tag},
+        }
+
+    def _resolve_digest(self, path: str) -> Optional[str]:
+        """Return the blob digest referenced by *path*'s tag manifest."""
+        tag = _path_to_tag(path)
+        resp = self._request(
+            "GET",
+            f"/manifests/{tag}",
+            headers={"Accept": _MANIFEST_MEDIA_TYPE},
+        )
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        manifest: dict[str, Any] = resp.json()
+        layers = cast("list[dict[str, Any]]", manifest.get("layers") or [])
+        if not layers:
+            return None
+        return cast(str, layers[0]["digest"])
+
+    def _manifest_digest(self, tag: str) -> Optional[str]:
+        """Return the manifest's own digest (for delete-by-digest)."""
+        resp = self._request(
+            "GET",
+            f"/manifests/{tag}",
+            headers={"Accept": _MANIFEST_MEDIA_TYPE},
+        )
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.headers.get("Docker-Content-Digest")
+
+    def _blob_exists(self, digest: str) -> bool:
+        resp = self._request("HEAD", f"/blobs/{digest}")
+        return resp.status_code == 200
+
+    def _upload_blob(self, data: bytes, digest: str) -> None:
+        # Single monolithic PUT: initiate the upload session, then push
+        # the entire blob in one request with the digest attached.
+        # Chunk sizes here (avg 2 MB, max 8 MB) are comfortably within
+        # what registries accept as a single PUT.
+        start = self._request("POST", "/blobs/uploads/")
+        start.raise_for_status()
+        location = start.headers["Location"]
+        put_url = self._with_query(location, {"digest": digest})
+        resp = self._request_absolute(
+            "PUT",
+            put_url,
+            data=data,
+            headers={"Content-Type": "application/octet-stream"},
+        )
+        resp.raise_for_status()
+
+    def _with_query(self, url: str, params: dict[str, str]) -> str:
+        sep = "&" if "?" in url else "?"
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        return f"{url}{sep}{query}"
+
+    def _next_page_url(self, resp: requests.Response) -> Optional[str]:
+        link = resp.links.get("next")
+        if link is None:
+            return None
+        href = link.get("url")
+        if href is None:
+            return None
+        if href.startswith("http"):
+            return href
+        # Relative Link header (e.g. "/v2/<repo>/tags/list?...").
+        base = self._base.split("/v2/", 1)[0]
+        return f"{base}{href}"
+
+    # ------------------------------------------------------------------
+    # HTTP + auth
+    # ------------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        data: Optional[bytes] = None,
+        headers: Optional[dict[str, str]] = None,
+    ) -> requests.Response:
+        return self._request_absolute(
+            method, f"{self._base}{path}", data=data, headers=headers
+        )
+
+    def _request_absolute(
+        self,
+        method: str,
+        url: str,
+        data: Optional[bytes] = None,
+        headers: Optional[dict[str, str]] = None,
+    ) -> requests.Response:
+        resp = self._session.request(method, url, data=data, headers=headers)
+        if resp.status_code == 401:
+            token = self._authenticate(resp)
+            if token is not None:
+                auth_headers = dict(headers or {})
+                auth_headers["Authorization"] = f"Bearer {token}"
+                resp = self._session.request(
+                    method, url, data=data, headers=auth_headers
+                )
+        return resp
+
+    def _authenticate(self, challenge: requests.Response) -> Optional[str]:
+        """Resolve a ``WWW-Authenticate: Bearer`` challenge into a token.
+
+        Implements the standard Docker Registry v2 token auth flow: the
+        registry's 401 response names a token *realm*, *service*, and
+        *scope*; the client fetches a short-lived Bearer token from the
+        realm (optionally using Basic auth credentials) and retries the
+        original request with it attached.
+        """
+        header = challenge.headers.get("WWW-Authenticate", "")
+        if not header.lower().startswith("bearer "):
+            return None
+        params = self._parse_bearer_challenge(header)
+        realm = params.get("realm")
+        if realm is None:
+            return None
+        service = params.get("service", "")
+        scope = params.get("scope", "")
+        cache_key = (realm, service, scope)
+        if cache_key in self._token_cache:
+            return self._token_cache[cache_key]
+
+        query: dict[str, str] = {}
+        if service:
+            query["service"] = service
+        if scope:
+            query["scope"] = scope
+        auth = (self._user, self._password) if self._user else None
+        resp = self._session.get(realm, params=query, auth=auth)
+        resp.raise_for_status()
+        body: dict[str, Any] = resp.json()
+        token = body.get("token") or body.get("access_token")
+        if token is None:
+            return None
+        self._token_cache[cache_key] = token
+        return token
+
+    @staticmethod
+    def _parse_bearer_challenge(header: str) -> dict[str, str]:
+        """Parse a ``Bearer realm="...",service="...",scope="..."`` header."""
+        raw = header[len("Bearer ") :]
+        params: dict[str, str] = {}
+        for part in raw.split(","):
+            if "=" not in part:
+                continue
+            key, _, value = part.strip().partition("=")
+            params[key.strip()] = value.strip().strip('"')
+        return params

--- a/src/remote/remote_mng.py
+++ b/src/remote/remote_mng.py
@@ -36,6 +36,7 @@ from util import Util
 
 from .backend import RemoteBackend
 from .ftp_backend import FTPBackend
+from .registry_backend import RegistryBackend
 from .sftp_backend import SFTPBackend
 
 if TYPE_CHECKING:
@@ -150,13 +151,26 @@ class RemoteMng:
                 root_path=root_path,
             )
 
+        if cfg.type == "registry":
+            properties = cfg.properties or {}
+            registry_host = host
+            if port is not None:
+                registry_host = f"{host}:{port}"
+            return RegistryBackend(
+                host=registry_host,
+                user=user,
+                password=cfg.password or "",
+                root_path=root_path,
+                insecure=bool(properties.get("insecure", False)),
+            )
+
         if self._plugin_runtime is not None:
             backend = self._plugin_runtime.build_remote_backend(cfg.type, cfg)
             if backend is not None:
                 return backend
         raise click.UsageError(
             f"Unknown remote type '{cfg.type}'. "
-            "Built-in types are 'ftp' and 'sftp'. "
+            "Built-in types are 'ftp', 'sftp', and 'registry'. "
             "Use a plugin to add additional transport backends."
         )
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,3 +7,4 @@ packaging
 fastcdc
 zstandard
 paramiko
+requests

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -1060,6 +1060,12 @@ def remote():
 @click.option(
     "--sftp", "backend_type", flag_value="sftp", help="SFTP transport."
 )
+@click.option(
+    "--registry",
+    "backend_type",
+    flag_value="registry",
+    help="OCI container registry transport.",
+)
 @click.option("--host", required=True, help="Remote server hostname.")
 @click.option("--user", default=None, help="Login username.")
 @click.option(
@@ -1087,7 +1093,14 @@ def remote():
 @click.option(
     "--root-path",
     required=True,
-    help="Root directory on the remote for the chunk store.",
+    help="Root directory on the remote for the chunk store "
+    "(repository name for --registry).",
+)
+@click.option(
+    "--insecure",
+    is_flag=True,
+    default=False,
+    help="Connect over plain HTTP instead of HTTPS (--registry only).",
 )
 @click.option(
     "--set-default",
@@ -1107,13 +1120,18 @@ def add_remote(
     password: Optional[str],
     identity_file: Optional[str],
     root_path: str,
+    insecure: bool,
     set_default: bool,
 ) -> None:
     """Register a new remote storage backend."""
     if not backend_type:
-        raise click.UsageError("Specify a transport with --ftp or --sftp.")
+        raise click.UsageError(
+            "Specify a transport with --ftp, --sftp, or --registry."
+        )
     if anon and backend_type != "ftp":
         raise click.UsageError("--anon is only valid for FTP remotes.")
+    if insecure and backend_type != "registry":
+        raise click.UsageError("--insecure is only valid for --registry.")
     if backend_type == "ftp":
         if anon and (user or password):
             raise click.UsageError(
@@ -1130,6 +1148,9 @@ def add_remote(
         raise click.UsageError(
             "SFTP remotes require --password or --identity-file."
         )
+    properties: Optional[dict[str, Any]] = (
+        {"insecure": True} if insecure else None
+    )
     remote_cfg = RemoteCfg(
         name=name,
         type=backend_type,
@@ -1140,6 +1161,7 @@ def add_remote(
         root_path=root_path,
         identity_file=identity_file,
         default="true" if set_default else "false",
+        properties=properties,
     )
     try:
         shepherd.configMng.add_remote(remote_cfg)
@@ -1185,6 +1207,11 @@ def delete_remote(shepherd: ShepherdMng, name: str) -> None:
 )
 @click.option("--root-path", default=None, help="New root path on remote.")
 @click.option(
+    "--insecure/--no-insecure",
+    default=None,
+    help="Toggle plain-HTTP mode (--registry only).",
+)
+@click.option(
     "--set-default",
     is_flag=True,
     default=False,
@@ -1201,6 +1228,7 @@ def modify_remote(
     anon: bool,
     identity_file: Optional[str],
     root_path: Optional[str],
+    insecure: Optional[bool],
     set_default: bool,
 ) -> None:
     """Modify an existing remote storage backend."""
@@ -1225,6 +1253,13 @@ def modify_remote(
         updates["identity_file"] = identity_file
     if root_path:
         updates["root_path"] = root_path
+    if insecure is not None:
+        existing = shepherd.configMng.get_remote(name)
+        if existing is None:
+            raise click.UsageError(f"Remote '{name}' is not configured.")
+        properties = dict(existing.properties or {})
+        properties["insecure"] = insecure
+        updates["properties"] = properties
     if set_default:
         updates["default"] = "true"
     if not updates:

--- a/src/tests/integration/conftest.py
+++ b/src/tests/integration/conftest.py
@@ -16,6 +16,7 @@ from typing import Generator
 
 import paramiko
 import pytest
+import requests
 from click.testing import CliRunner
 
 from config.config import RemoteCfg, RemoteChunkCfg
@@ -85,6 +86,21 @@ def _wait_sftp_ready(
                 transport.close()
         time.sleep(0.5)
     raise TimeoutError(f"SFTP {host}:{port} not ready after {timeout}s")
+
+
+def _wait_registry_ready(host: str, port: int, timeout: float = 30.0) -> None:
+    """Probe until the registry's base API endpoint responds."""
+    deadline = time.monotonic() + timeout
+    url = f"http://{host}:{port}/v2/"
+    while time.monotonic() < deadline:
+        try:
+            resp = requests.get(url, timeout=2)
+            if resp.status_code == 200:
+                return
+        except Exception:
+            pass
+        time.sleep(0.5)
+    raise TimeoutError(f"Registry {host}:{port} not ready after {timeout}s")
 
 
 def read_fixture(*parts: str) -> str:
@@ -194,6 +210,7 @@ def remote_backends() -> Generator[dict[str, RemoteCfg], None, None]:
     try:
         _wait_ftp_ready("127.0.0.1", 2121, "ftpuser", "ftppass")
         _wait_sftp_ready("127.0.0.1", 2222, "sftpuser", "sftppass")
+        _wait_registry_ready("127.0.0.1", 5500)
         yield {
             "ftp": RemoteCfg(
                 name="ftp",
@@ -216,6 +233,15 @@ def remote_backends() -> Generator[dict[str, RemoteCfg], None, None]:
                 password="sftppass",
                 root_path="/upload",
                 chunk=_CHUNK_CFG,
+            ),
+            "registry": RemoteCfg(
+                name="registry",
+                type="registry",
+                host="127.0.0.1",
+                port=5500,
+                root_path="shepherd-test",
+                chunk=_CHUNK_CFG,
+                properties={"insecure": True},
             ),
         }
     finally:

--- a/src/tests/integration/fixtures/remote/docker-compose.yml
+++ b/src/tests/integration/fixtures/remote/docker-compose.yml
@@ -15,3 +15,10 @@ services:
     command: "sftpuser:sftppass:1001::upload"
     ports:
       - "2222:22"
+
+  registry:
+    image: registry:2
+    environment:
+      REGISTRY_STORAGE_DELETE_ENABLED: "true"
+    ports:
+      - "5500:5000"

--- a/src/tests/integration/test_ftp_sftp_backends.py
+++ b/src/tests/integration/test_ftp_sftp_backends.py
@@ -6,17 +6,20 @@
 # Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 """Integration tests for remote push/pull/dehydrate/hydrate/prune flows
-against real FTP and SFTP backends running in Docker containers.
+against real FTP, SFTP, and OCI registry backends running in Docker
+containers.
 
-Each test receives a ``backend_cfg`` fixture parametrized over ``ftp`` and
-``sftp``, giving 12 test runs total (6 tests × 2 backends).  Docker containers
-are started once per session via the ``remote_backends`` fixture in conftest.py.
+Each test receives a ``backend_cfg`` fixture parametrized over ``ftp``,
+``sftp``, and ``registry``, giving 18 test runs total (6 tests × 3
+backends).  Docker containers are started once per session via the
+``remote_backends`` fixture in conftest.py.
 
 Marker: ``integration`` + ``docker``.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
@@ -28,6 +31,7 @@ import pytest
 
 from config.config import EnvironmentCfg, RemoteCfg
 from remote.backend import RemoteBackend
+from remote.registry_backend import RegistryBackend
 from remote.remote_mng import RemoteMng
 from storage.snapshot import IndexCatalogue, SnapshotManifest
 
@@ -50,7 +54,7 @@ pytestmark = [
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(params=["ftp", "sftp"])
+@pytest.fixture(params=["ftp", "sftp", "registry"])
 def backend_cfg(
     remote_backends: dict[str, RemoteCfg], request: pytest.FixtureRequest
 ) -> RemoteCfg:
@@ -201,6 +205,26 @@ def test_push_first_time(
 
         for chunk_hash in manifest.chunks:
             assert backend.exists(RemoteBackend.chunk_path(chunk_hash))
+
+        if backend_cfg.type == "registry":
+            # Registry-only: the per-snapshot image assembled alongside
+            # the manifest JSON is a real, independently fetchable OCI
+            # artifact with one layer per chunk, in manifest order.
+            assert isinstance(backend, RegistryBackend)
+            tag = backend._snapshot_image_tag(env_name, snapshot_id)
+            resp = backend._request(
+                "GET",
+                f"/manifests/{tag}",
+                headers={
+                    "Accept": ("application/vnd.oci.image.manifest.v1+json")
+                },
+            )
+            resp.raise_for_status()
+            image_manifest = resp.json()
+            assert len(image_manifest["layers"]) == manifest.chunk_count
+            assert [layer["digest"] for layer in image_manifest["layers"]] == [
+                f"sha256:{h}" for h in manifest.chunks
+            ]
 
 
 @pytest.mark.integration
@@ -357,9 +381,15 @@ def test_prune_removes_orphans(
     )
     push_mng.push(env_name, env_mng, remote_name=backend_cfg.name)
 
-    orphan_hash = "aa" * 32
+    # The chunk hash must be the real digest of the uploaded bytes: real
+    # pushes always compute the path's hash from the actual chunk
+    # content (see Chunker/RemoteMng), and the registry backend relies
+    # on that invariant to resolve a chunk's blob digest straight from
+    # its path without a manifest lookup.
+    orphan_data = b"orphan-data"
+    orphan_hash = hashlib.sha256(orphan_data).hexdigest()
     with push_mng._build_backend(backend_cfg) as backend:
-        backend.upload(RemoteBackend.chunk_path(orphan_hash), b"orphan-data")
+        backend.upload(RemoteBackend.chunk_path(orphan_hash), orphan_data)
         assert backend.exists(RemoteBackend.chunk_path(orphan_hash))
 
         manifest_bytes = backend.download(

--- a/src/tests/test_remote_registry_backend.py
+++ b/src/tests/test_remote_registry_backend.py
@@ -1,0 +1,782 @@
+# Copyright (c) 2025 Moony Fringers
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This file is part of Shepherd Core Stack.
+# Open-source: see LICENSE (AGPL-3.0-only).
+# Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from remote.registry_backend import (
+    RegistryBackend,
+    _chunk_digest_from_path,
+    _chunk_shard_from_prefix,
+    _path_to_tag,
+)
+
+_HOST = "registry.example.com"
+_CHUNK_HASH = "ab" + "3f" * 31  # 64-char hex, shard "ab"
+_CHUNK_PATH = f"chunks/ab/{_CHUNK_HASH}"
+_LATEST_PATH = "envs/my-env/latest.json"
+_DATA = b"some compressed chunk bytes"
+
+
+def _resp(
+    status_code: int = 200,
+    json_body: Optional[dict[str, Any]] = None,
+    headers: Optional[dict[str, str]] = None,
+    content: bytes = b"",
+) -> MagicMock:
+    m = MagicMock()
+    m.status_code = status_code
+    m.headers = headers or {}
+    m.links = {}
+    m.content = content
+    m.json.return_value = json_body or {}
+    m.raise_for_status = MagicMock()
+    return m
+
+
+def _make_backend(session: MagicMock, insecure: bool = True) -> RegistryBackend:
+    backend = RegistryBackend(
+        host=_HOST, root_path="shepherd", insecure=insecure
+    )
+    backend._session = session
+    return backend
+
+
+# ---------------------------------------------------------------------------
+# _path_to_tag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_path_to_tag_replaces_slashes() -> None:
+    assert _path_to_tag(_CHUNK_PATH) == f"chunks_ab_{_CHUNK_HASH}"
+    assert _path_to_tag("index/index.json") == "index_index.json"
+
+
+@pytest.mark.remote
+def test_path_to_tag_replaces_colons() -> None:
+    """Snapshot ids embed an ISO-8601 timestamp (e.g. 2026-08-07T21:00:00Z),
+    which contains ':' — illegal in an OCI tag."""
+    path = "envs/my-env/snapshots/2026-08-07T21:00:00Z-6b22b1.json"
+    tag = _path_to_tag(path)
+    assert ":" not in tag
+    assert tag == "envs_my-env_snapshots_2026-08-07T21_00_00Z-6b22b1.json"
+
+
+# ---------------------------------------------------------------------------
+# _chunk_digest_from_path / _chunk_shard_from_prefix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_chunk_digest_from_path_matches_chunk() -> None:
+    assert _chunk_digest_from_path(_CHUNK_PATH) == f"sha256:{_CHUNK_HASH}"
+
+
+@pytest.mark.remote
+def test_chunk_digest_from_path_matches_tmp_variant() -> None:
+    assert (
+        _chunk_digest_from_path(f"{_CHUNK_PATH}.tmp") == f"sha256:{_CHUNK_HASH}"
+    )
+
+
+@pytest.mark.remote
+def test_chunk_digest_from_path_rejects_index_file() -> None:
+    assert _chunk_digest_from_path("chunks/ab/.index.json") is None
+
+
+@pytest.mark.remote
+def test_chunk_digest_from_path_rejects_non_chunk_paths() -> None:
+    assert _chunk_digest_from_path(_LATEST_PATH) is None
+    assert _chunk_digest_from_path("chunks/ab/tooshort") is None
+
+
+@pytest.mark.remote
+def test_chunk_shard_from_prefix() -> None:
+    assert _chunk_shard_from_prefix("chunks/ab") == "ab"
+    assert _chunk_shard_from_prefix("chunks/ab/") is None
+    assert _chunk_shard_from_prefix("envs/my-env/snapshots") is None
+
+
+# ---------------------------------------------------------------------------
+# exists / upload / download
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_exists_chunk_is_single_blob_head() -> None:
+    """Chunk paths encode their own digest — no manifest GET needed."""
+    session = MagicMock()
+    session.request.return_value = _resp(200)  # HEAD blob
+    backend = _make_backend(session)
+    assert backend.exists(_CHUNK_PATH) is True
+    calls = session.request.call_args_list
+    assert len(calls) == 1
+    assert calls[0][0][0] == "HEAD"
+    assert calls[0][0][1].endswith(f"/blobs/sha256:{_CHUNK_HASH}")
+
+
+@pytest.mark.remote
+def test_exists_chunk_false_when_blob_missing() -> None:
+    session = MagicMock()
+    session.request.return_value = _resp(404)
+    backend = _make_backend(session)
+    assert backend.exists(_CHUNK_PATH) is False
+
+
+@pytest.mark.remote
+def test_exists_true_when_manifest_and_blob_present() -> None:
+    session = MagicMock()
+    manifest = {
+        "layers": [{"mediaType": "x", "digest": f"sha256:{_CHUNK_HASH}"}]
+    }
+    session.request.side_effect = [
+        _resp(200, json_body=manifest),  # GET manifest (resolve digest)
+        _resp(200),  # HEAD blob
+    ]
+    backend = _make_backend(session)
+    assert backend.exists(_LATEST_PATH) is True
+
+
+@pytest.mark.remote
+def test_exists_false_when_manifest_missing() -> None:
+    session = MagicMock()
+    session.request.return_value = _resp(404)
+    backend = _make_backend(session)
+    assert backend.exists(_LATEST_PATH) is False
+
+
+@pytest.mark.remote
+def test_upload_chunk_pushes_blob_only_no_manifest() -> None:
+    session = MagicMock()
+    digest = f"sha256:{hashlib.sha256(_DATA).hexdigest()}"
+    session.request.side_effect = [
+        _resp(404),  # HEAD blob -> not present
+        _resp(202, headers={"Location": "/v2/shepherd/blobs/uploads/xyz"}),
+        _resp(201),  # PUT blob
+    ]
+    backend = _make_backend(session)
+    backend.upload(_CHUNK_PATH, _DATA)
+
+    calls = session.request.call_args_list
+    assert len(calls) == 3
+    assert calls[0][0][0] == "HEAD"
+    assert calls[1][0][0] == "POST"
+    put_blob_call = calls[2]
+    assert put_blob_call[0][0] == "PUT"
+    assert digest in put_blob_call[0][1]
+
+
+@pytest.mark.remote
+def test_upload_chunk_skips_blob_when_already_present() -> None:
+    session = MagicMock()
+    session.request.side_effect = [
+        _resp(200),  # HEAD blob -> already present
+    ]
+    backend = _make_backend(session)
+    backend.upload(_CHUNK_PATH, _DATA)
+
+    calls = session.request.call_args_list
+    assert len(calls) == 1
+    assert calls[0][0][0] == "HEAD"
+
+
+@pytest.mark.remote
+def test_upload_non_chunk_pushes_blob_then_manifest() -> None:
+    session = MagicMock()
+    digest = f"sha256:{hashlib.sha256(_DATA).hexdigest()}"
+    session.request.side_effect = [
+        _resp(404),  # HEAD blob -> not present
+        _resp(202, headers={"Location": "/v2/shepherd/blobs/uploads/xyz"}),
+        _resp(201),  # PUT blob
+        _resp(404),  # HEAD empty-config blob -> not present
+        _resp(202, headers={"Location": "/v2/shepherd/blobs/uploads/abc"}),
+        _resp(201),  # PUT empty-config blob
+        _resp(201),  # PUT manifest
+    ]
+    backend = _make_backend(session)
+    backend.upload(_LATEST_PATH, _DATA)
+
+    calls = session.request.call_args_list
+    assert calls[0][0][0] == "HEAD"
+    assert calls[1][0][0] == "POST"
+    put_blob_call = calls[2]
+    assert put_blob_call[0][0] == "PUT"
+    assert digest in put_blob_call[0][1]
+    put_manifest_call = calls[-1]
+    assert put_manifest_call[0][0] == "PUT"
+    assert put_manifest_call[0][1].endswith(
+        f"/manifests/{_path_to_tag(_LATEST_PATH)}"
+    )
+
+
+@pytest.mark.remote
+def test_upload_non_chunk_skips_blob_when_already_present() -> None:
+    session = MagicMock()
+    session.request.side_effect = [
+        _resp(200),  # HEAD blob -> already present
+        _resp(200),  # HEAD empty-config blob -> already present
+        _resp(201),  # PUT manifest
+    ]
+    backend = _make_backend(session)
+    backend.upload(_LATEST_PATH, _DATA)
+
+    calls = session.request.call_args_list
+    assert len(calls) == 3
+    assert calls[0][0][0] == "HEAD"
+    assert calls[1][0][0] == "HEAD"
+    assert calls[2][0][0] == "PUT"
+
+
+@pytest.mark.remote
+def test_download_chunk_fetches_blob_via_path_digest() -> None:
+    session = MagicMock()
+    session.request.return_value = _resp(200, content=_DATA)  # GET blob
+    backend = _make_backend(session)
+    result = backend.download(_CHUNK_PATH)
+    assert result == _DATA
+    calls = session.request.call_args_list
+    assert len(calls) == 1
+    assert calls[0][0][0] == "GET"
+    assert calls[0][0][1].endswith(f"/blobs/sha256:{_CHUNK_HASH}")
+
+
+@pytest.mark.remote
+def test_download_fetches_blob_via_resolved_digest() -> None:
+    session = MagicMock()
+    manifest = {
+        "layers": [{"mediaType": "x", "digest": f"sha256:{_CHUNK_HASH}"}]
+    }
+    session.request.side_effect = [
+        _resp(200, json_body=manifest),  # GET manifest
+        _resp(200, content=_DATA),  # GET blob
+    ]
+    backend = _make_backend(session)
+    result = backend.download(_LATEST_PATH)
+    assert result == _DATA
+
+
+@pytest.mark.remote
+def test_download_raises_when_manifest_missing() -> None:
+    session = MagicMock()
+    session.request.return_value = _resp(404)
+    backend = _make_backend(session)
+    with pytest.raises(FileNotFoundError):
+        backend.download(_LATEST_PATH)
+
+
+# ---------------------------------------------------------------------------
+# list_prefix (non-chunk prefixes -> tag-list endpoint)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_list_prefix_filters_and_strips_prefix() -> None:
+    session = MagicMock()
+    tags_body = {
+        "tags": [
+            "envs_my-env_snapshots_snap-a.json",
+            "envs_my-env_snapshots_snap-b.json",
+            "envs_other-env_snapshots_snap-c.json",
+            "envs_my-env_latest.json",
+        ]
+    }
+    session.request.return_value = _resp(200, json_body=tags_body)
+    backend = _make_backend(session)
+    result = backend.list_prefix("envs/my-env/snapshots")
+    assert sorted(result) == sorted(["snap-a.json", "snap-b.json"])
+
+
+@pytest.mark.remote
+def test_list_prefix_empty_on_404() -> None:
+    session = MagicMock()
+    session.request.return_value = _resp(404)
+    backend = _make_backend(session)
+    assert backend.list_prefix("envs/my-env/snapshots") == []
+
+
+@pytest.mark.remote
+def test_list_prefix_paginates_via_link_header() -> None:
+    session = MagicMock()
+    page1 = _resp(
+        200,
+        json_body={"tags": ["envs_my-env_snapshots_snap-a.json"]},
+    )
+    page1.links = {
+        "next": {"url": "/v2/shepherd/tags/list?n=1000&last=envs_my-env_..."}
+    }
+    page2 = _resp(
+        200, json_body={"tags": ["envs_my-env_snapshots_snap-b.json"]}
+    )
+    page2.links = {}
+    session.request.side_effect = [page1, page2]
+    backend = _make_backend(session)
+    result = backend.list_prefix("envs/my-env/snapshots")
+    assert sorted(result) == sorted(["snap-a.json", "snap-b.json"])
+    assert session.request.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# list_prefix (chunk-shard prefixes -> per-shard .index.json)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_list_prefix_chunk_shard_reads_persisted_index() -> None:
+    session = MagicMock()
+    index_manifest = {
+        "layers": [{"mediaType": "x", "digest": "sha256:indexdigest"}]
+    }
+    session.request.side_effect = [
+        _resp(200, json_body=index_manifest),  # GET manifest for .index.json
+        _resp(200, content=json.dumps([_CHUNK_HASH, "other"]).encode()),
+    ]
+    backend = _make_backend(session)
+    assert sorted(backend.list_prefix("chunks/ab")) == sorted(
+        [_CHUNK_HASH, "other"]
+    )
+
+
+@pytest.mark.remote
+def test_list_prefix_chunk_shard_empty_when_no_index() -> None:
+    session = MagicMock()
+    session.request.return_value = _resp(404)  # .index.json not found
+    backend = _make_backend(session)
+    assert backend.list_prefix("chunks/ab") == []
+
+
+@pytest.mark.remote
+def test_list_prefix_chunk_shard_merges_pending_adds_and_removes() -> None:
+    session = MagicMock()
+    session.request.return_value = _resp(404)  # no persisted index yet
+    backend = _make_backend(session)
+    backend._pending_index_adds["ab"] = {_CHUNK_HASH, "brandnew"}
+    backend._pending_index_removes["ab"] = {"brandnew"}
+    assert backend.list_prefix("chunks/ab") == [_CHUNK_HASH]
+
+
+# ---------------------------------------------------------------------------
+# delete (chunk paths -> direct blob delete)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_delete_chunk_removes_blob_directly() -> None:
+    session = MagicMock()
+    session.request.return_value = _resp(202)  # DELETE blob
+    backend = _make_backend(session)
+    backend.delete(_CHUNK_PATH)
+    calls = session.request.call_args_list
+    assert len(calls) == 1
+    assert calls[0][0][0] == "DELETE"
+    assert calls[0][0][1].endswith(f"/blobs/sha256:{_CHUNK_HASH}")
+
+
+@pytest.mark.remote
+def test_delete_chunk_ignores_registry_that_rejects_delete() -> None:
+    session = MagicMock()
+    session.request.return_value = _resp(405)
+    backend = _make_backend(session)
+    backend.delete(_CHUNK_PATH)  # must not raise
+
+
+@pytest.mark.remote
+def test_delete_chunk_updates_pending_index_removes() -> None:
+    session = MagicMock()
+    session.request.return_value = _resp(202)
+    backend = _make_backend(session)
+    backend._pending_index_adds["ab"] = {_CHUNK_HASH}
+    backend.delete(_CHUNK_PATH)
+    assert backend._pending_index_removes["ab"] == {_CHUNK_HASH}
+    assert _CHUNK_HASH not in backend._pending_index_adds["ab"]
+
+
+# ---------------------------------------------------------------------------
+# delete (non-chunk paths -> tag+manifest-digest delete)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_delete_removes_manifest_by_digest() -> None:
+    session = MagicMock()
+    session.request.side_effect = [
+        _resp(200, headers={"Docker-Content-Digest": "sha256:deadbeef"}),
+        _resp(202),  # DELETE
+    ]
+    backend = _make_backend(session)
+    backend.delete(_LATEST_PATH)
+    calls = session.request.call_args_list
+    assert calls[1][0][0] == "DELETE"
+    assert calls[1][0][1].endswith("/manifests/sha256:deadbeef")
+
+
+@pytest.mark.remote
+def test_delete_noop_when_manifest_missing() -> None:
+    session = MagicMock()
+    session.request.return_value = _resp(404)
+    backend = _make_backend(session)
+    backend.delete(_LATEST_PATH)  # must not raise
+    assert session.request.call_count == 1  # only the GET, no DELETE
+
+
+@pytest.mark.remote
+def test_delete_ignores_registry_that_rejects_delete() -> None:
+    session = MagicMock()
+    session.request.side_effect = [
+        _resp(200, headers={"Docker-Content-Digest": "sha256:deadbeef"}),
+        _resp(405),  # registry disallows manifest deletion
+    ]
+    backend = _make_backend(session)
+    backend.delete(_LATEST_PATH)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# rename
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_rename_chunk_is_noop_on_blob_and_indexes_the_hash() -> None:
+    """upload(tmp_path, data) already wrote the blob at its permanent
+    digest — tmp and final chunk paths share the same hash/digest, so
+    there is no blob to move. rename() must not touch the blob at all;
+    it only needs to record the chunk as confirmed in its shard index."""
+    session = MagicMock()
+    backend = _make_backend(session)
+    src = f"chunks/ab/{_CHUNK_HASH}.tmp"
+    backend._resolve_digest = MagicMock()
+    backend.download = MagicMock()  # type: ignore[method-assign]
+    backend.upload = MagicMock()  # type: ignore[method-assign]
+    backend.delete = MagicMock()  # type: ignore[method-assign]
+
+    backend.rename(src, _CHUNK_PATH)
+
+    backend._resolve_digest.assert_not_called()
+    backend.download.assert_not_called()
+    backend.upload.assert_not_called()
+    backend.delete.assert_not_called()
+    assert backend._pending_index_adds["ab"] == {_CHUNK_HASH}
+
+
+@pytest.mark.remote
+def test_rename_chunk_undoes_pending_removal() -> None:
+    session = MagicMock()
+    backend = _make_backend(session)
+    backend._pending_index_removes["ab"] = {_CHUNK_HASH}
+
+    backend.rename(f"chunks/ab/{_CHUNK_HASH}.tmp", _CHUNK_PATH)
+
+    assert _CHUNK_HASH not in backend._pending_index_removes["ab"]
+    assert backend._pending_index_adds["ab"] == {_CHUNK_HASH}
+
+
+@pytest.mark.remote
+def test_rename_non_chunk_retags() -> None:
+    """rename() for a non-chunk path re-pushes the manifest under the
+    destination tag, then removes the source tag. Orchestration only —
+    the underlying HTTP sequence for resolve/download/upload/delete is
+    covered by their own dedicated tests above."""
+    session = MagicMock()
+    backend = _make_backend(session)
+    backend._resolve_digest = MagicMock(return_value=f"sha256:{_CHUNK_HASH}")
+    backend.download = MagicMock(return_value=_DATA)  # type: ignore[method-assign]
+    backend.upload = MagicMock()  # type: ignore[method-assign]
+    backend.delete = MagicMock()  # type: ignore[method-assign]
+
+    src = "envs/my-env/latest.json.tmp"
+    backend.rename(src, _LATEST_PATH)
+
+    backend.download.assert_called_once_with(src)
+    backend.upload.assert_called_once_with(_LATEST_PATH, _DATA)
+    backend.delete.assert_called_once_with(src)
+
+
+@pytest.mark.remote
+def test_rename_non_chunk_noop_when_src_missing() -> None:
+    session = MagicMock()
+    session.request.return_value = _resp(404)
+    backend = _make_backend(session)
+    backend.rename("envs/my-env/latest.json.tmp", _LATEST_PATH)
+    assert session.request.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Bearer-token auth challenge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_bearer_challenge_retries_with_token() -> None:
+    session = MagicMock()
+    challenge = _resp(
+        401,
+        headers={
+            "WWW-Authenticate": (
+                'Bearer realm="https://auth.example.com/token",'
+                'service="registry.example.com",'
+                'scope="repository:shepherd:pull"'
+            )
+        },
+    )
+    token_resp = _resp(200, json_body={"token": "test-token"})
+    final_resp = _resp(200)
+
+    def request_side_effect(method: str, url: str, **kwargs: Any) -> MagicMock:
+        if url.startswith("https://auth.example.com"):
+            return token_resp
+        if "Authorization" in (kwargs.get("headers") or {}):
+            return final_resp
+        return challenge
+
+    session.request.side_effect = request_side_effect
+    session.get.return_value = token_resp
+    backend = _make_backend(session)
+    resp = backend._request("HEAD", f"/blobs/sha256:{_CHUNK_HASH}")
+    assert resp is final_resp
+    session.get.assert_called_once()
+    auth_call_kwargs = session.get.call_args[1]
+    assert auth_call_kwargs["params"]["service"] == "registry.example.com"
+    assert auth_call_kwargs["params"]["scope"] == "repository:shepherd:pull"
+
+
+@pytest.mark.remote
+def test_bearer_challenge_caches_token_across_requests() -> None:
+    session = MagicMock()
+    challenge = _resp(
+        401,
+        headers={
+            "WWW-Authenticate": (
+                'Bearer realm="https://auth.example.com/token",'
+                'service="svc",scope="repository:shepherd:pull"'
+            )
+        },
+    )
+    token_resp = _resp(200, json_body={"token": "cached-token"})
+    ok_resp = _resp(200)
+
+    calls: list[str] = []
+
+    def request_side_effect(method: str, url: str, **kwargs: Any) -> MagicMock:
+        if "Authorization" in (kwargs.get("headers") or {}):
+            calls.append("authed")
+            return ok_resp
+        calls.append("challenge")
+        return challenge
+
+    session.request.side_effect = request_side_effect
+    session.get.return_value = token_resp
+    backend = _make_backend(session)
+
+    backend._request("HEAD", "/blobs/sha256:aaa")
+    backend._request("HEAD", "/blobs/sha256:bbb")
+
+    # Token endpoint hit only once; subsequent challenges reuse the cache.
+    assert session.get.call_count == 1
+
+
+@pytest.mark.remote
+def test_non_bearer_401_returns_original_response() -> None:
+    session = MagicMock()
+    session.request.return_value = _resp(
+        401, headers={"WWW-Authenticate": 'Basic realm="registry"'}
+    )
+    backend = _make_backend(session)
+    resp = backend._request("HEAD", f"/blobs/sha256:{_CHUNK_HASH}")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# close
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_close_closes_session() -> None:
+    session = MagicMock()
+    backend = _make_backend(session)
+    backend.close()
+    session.close.assert_called_once()
+
+
+@pytest.mark.remote
+def test_close_flushes_pending_shard_index() -> None:
+    session = MagicMock()
+    session.request.side_effect = [
+        _resp(404),  # GET manifest for .index.json -> base digest check
+        _resp(404),  # GET manifest for .index.json -> read persisted (none)
+        _resp(200),  # HEAD index blob -> already present (content varies
+        # in practice, but the mock doesn't need to be exact here)
+        _resp(200),  # HEAD empty-config blob -> already present
+        _resp(404),  # GET manifest for .index.json -> recheck (unchanged)
+        _resp(201),  # PUT manifest for .index.json
+    ]
+    backend = _make_backend(session)
+    backend._pending_index_adds["ab"] = {_CHUNK_HASH}
+
+    backend.close()
+
+    calls = session.request.call_args_list
+    assert calls[-1][0][0] == "PUT"
+    assert calls[-1][0][1].endswith("/manifests/chunks_ab_.index.json")
+    session.close.assert_called_once()
+    assert backend._pending_index_adds == {}
+
+
+@pytest.mark.remote
+def test_write_shard_index_retries_when_tag_moves_concurrently() -> None:
+    """If the index tag's manifest digest changes between the initial
+    read and the pre-write recheck (a concurrent writer, e.g. prune()),
+    the write must retry with a fresh read/merge instead of blindly
+    overwriting the concurrent update."""
+    session = MagicMock()
+    backend = _make_backend(session)
+    backend._pending_index_adds["ab"] = {_CHUNK_HASH}
+
+    # _manifest_digest is consulted twice per attempt (base + recheck):
+    # attempt 1 sees "d1" both times (no race) EXCEPT we want the
+    # recheck to observe a move, so: base="d1", recheck="d2" (raced);
+    # attempt 2: base="d2", recheck="d2" (stable) -> proceeds to PUT.
+    backend._manifest_digest = MagicMock(  # type: ignore[method-assign]
+        side_effect=["d1", "d2", "d2", "d2"]
+    )
+    # First read (during the raced attempt) sees {"old"}; second read
+    # (after the concurrent writer's change is visible) sees the
+    # concurrent writer's update too.
+    backend._effective_shard_index = MagicMock(  # type: ignore[method-assign]
+        side_effect=[["old"], ["old", "concurrent", _CHUNK_HASH]]
+    )
+    backend._upload_index_blob = MagicMock(  # type: ignore[method-assign]
+        return_value=("sha256:merged", b"merged-bytes")
+    )
+    backend._put_manifest = MagicMock()  # type: ignore[method-assign]
+
+    backend._write_shard_index("ab")
+
+    # Retried once (four _manifest_digest calls = two attempts), and
+    # the write that finally landed used the second (post-race) merge.
+    assert backend._manifest_digest.call_count == 4
+    assert backend._effective_shard_index.call_count == 2
+    backend._put_manifest.assert_called_once()
+    assert backend._upload_index_blob.call_args_list[-1] == (
+        (["old", "concurrent", _CHUNK_HASH],),
+        {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# _blob_size
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_blob_size_uses_session_cache_for_freshly_uploaded_chunk() -> None:
+    session = MagicMock()
+    session.request.side_effect = [
+        _resp(404),  # HEAD blob -> not present
+        _resp(202, headers={"Location": "/v2/shepherd/blobs/uploads/xyz"}),
+        _resp(201),  # PUT blob
+    ]
+    backend = _make_backend(session)
+    digest = f"sha256:{hashlib.sha256(_DATA).hexdigest()}"
+    backend.upload(_CHUNK_PATH, _DATA)
+
+    size = backend._blob_size(digest)
+
+    assert size == len(_DATA)
+    assert session.request.call_count == 3  # no extra HEAD issued
+
+
+@pytest.mark.remote
+def test_blob_size_falls_back_to_head_for_unknown_digest() -> None:
+    session = MagicMock()
+    session.request.return_value = _resp(200, headers={"Content-Length": "42"})
+    backend = _make_backend(session)
+
+    size = backend._blob_size(f"sha256:{_CHUNK_HASH}")
+
+    assert size == 42
+    assert session.request.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Per-snapshot OCI image assembly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_upload_snapshot_manifest_pushes_snapshot_and_latest_image() -> None:
+    session = MagicMock()
+    snapshot_id = "2026-08-08T00_00_00Z-abc123"
+    snapshot_path = f"envs/my-env/snapshots/{snapshot_id}.json"
+    other_hash = "cd" + "11" * 31
+    snapshot_data = json.dumps(
+        {
+            "snapshot_id": snapshot_id,
+            "environment": "my-env",
+            "shepherd_version": "0.0.0",
+            "created_at": "2026-08-08T00:00:00Z",
+            "chunks": [_CHUNK_HASH, other_hash],
+            "chunk_count": 2,
+            "total_size_bytes": 100,
+            "stored_size_bytes": 80,
+        }
+    ).encode()
+
+    session.request.side_effect = [
+        _resp(404),  # HEAD manifest-json blob -> not present
+        _resp(202, headers={"Location": "/v2/shepherd/blobs/uploads/m"}),
+        _resp(201),  # PUT manifest-json blob
+        _resp(200),  # HEAD empty-config blob -> present
+        _resp(201),  # PUT manifest tag for the snapshot-manifest json
+        _resp(200, headers={"Content-Length": "10"}),  # HEAD chunk 1 size
+        _resp(200, headers={"Content-Length": "20"}),  # HEAD chunk 2 size
+        _resp(201),  # PUT snapshot image manifest (per-snapshot tag)
+        _resp(201),  # PUT snapshot image manifest (latest tag)
+    ]
+    backend = _make_backend(session)
+    backend.upload(snapshot_path, snapshot_data)
+
+    calls = session.request.call_args_list
+    put_calls = [
+        c for c in calls if c[0][0] == "PUT" and "/manifests/" in c[0][1]
+    ]
+    tags = [c[0][1].rsplit("/manifests/", 1)[1] for c in put_calls]
+    assert _path_to_tag(snapshot_path) in tags
+    assert f"images_my-env_{snapshot_id}" in tags
+    assert "images_my-env_latest" in tags
+
+    snapshot_tag_call = next(
+        c for c in put_calls if c[0][1].endswith(f"images_my-env_{snapshot_id}")
+    )
+    pushed_manifest = json.loads(snapshot_tag_call[1]["data"])
+    assert [layer["digest"] for layer in pushed_manifest["layers"]] == [
+        f"sha256:{_CHUNK_HASH}",
+        f"sha256:{other_hash}",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# insecure flag controls scheme
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.remote
+def test_insecure_uses_http_scheme() -> None:
+    backend = RegistryBackend(host=_HOST, root_path="shepherd", insecure=True)
+    assert backend._base.startswith("http://")
+
+
+@pytest.mark.remote
+def test_secure_uses_https_scheme() -> None:
+    backend = RegistryBackend(host=_HOST, root_path="shepherd", insecure=False)
+    assert backend._base.startswith("https://")


### PR DESCRIPTION
## Summary

Adds Docker/OCI container registries as a third core `RemoteBackend`
transport, alongside FTP and SFTP, selectable via `remote add --registry`.
Transport-only change — the content-defined-chunking dedup algorithm
(ADR-0006) is unchanged; only the passive blob-store target is new.

Chunks are stored as **bare content-addressed blobs**: a chunk's SHA-256
hash (already computed for dedup) doubles as its OCI blob digest, so
existence/download resolve straight from the path with no manifest lookup,
and no per-chunk tag is ever created. Since OCI registries expose no
blob-listing API, a small per-shard index object
(`chunks/<shard>/.index.json`) replaces tag-listing for chunk enumeration
(`list_prefix`, used by push-time dedup checks and `prune`).

Writing a snapshot manifest additionally assembles one real multi-layer
OCI image for that snapshot (layers = the snapshot's chunk blobs, in
order) under an immutable per-snapshot tag and a mutable per-environment
`latest` tag, so `docker pull`/`crane manifest` see a real, inspectable
artifact instead of a wall of one-tag-per-object entries. See
[ADR-0007](docs/decisions/0007-registry-backend-snapshot-images.md) for
the full design and why registry-native dedup on a single
whole-environment blob would have regressed ADR-0006's incremental-dedup
guarantee.

## Design evolution

An earlier iteration of this PR tagged **every** stored path (chunk,
snapshot manifest, `latest.json`, `index.json`) individually — one
manifest + one tag per chunk, meaning a single environment push produced
thousands of disposable fake "images." That design technically satisfied
the `RemoteBackend` contract but ignored what makes a registry different
from a dumb KV store. It's been replaced with the bare-blob +
per-snapshot-image model above; see ADR-0007 for the full comparison and
rationale. `RemoteMng`, the `RemoteBackend` ABC, and the FTP/SFTP
transports are unaffected by either iteration.

## Notable bugs caught during implementation

Two bugs surfaced only by integration testing against a real `registry:2`
container — mocked unit tests missed both:

- **`rename()` for non-chunk (pointer/manifest) paths must always
  re-tag.** `push()` calls `upload(tmp_path, ...)` then
  `rename(tmp_path, final_path)`; a no-op here leaves content reachable
  only under its `.tmp` tag. (Chunk paths are the opposite case now:
  `rename()` for a chunk *is* correctly a no-op, because the blob is
  already at its permanent content-addressed digest — there's nothing to
  move.)
- **`delete()` deleted more than the target tag.** It resolves a tag to
  its manifest digest and issues `DELETE /manifests/<digest>` (the only
  delete verb the OCI Distribution Spec offers). Two tags with
  byte-identical content produce byte-identical manifest JSON and
  therefore the same digest — deleting one tag's manifest silently
  deleted every tag pointing at it. Fixed by embedding the tag name as an
  OCI annotation in each manifest so tags never collide on the same
  digest even when their content does.

A third issue was caught in review after the redesign: the per-shard
index flush was a plain read-merge-write with no protection against two
backend sessions racing on the same shard (e.g. a `push()`'s flush
landing concurrently with a `prune()`'s deletion), which could silently
resurrect an already-deleted chunk hash into the index. Fixed with an
optimistic-concurrency recheck (index tag's manifest digest, re-verified
immediately before the write, retried on conflict) — the OCI spec has no
atomic compare-and-swap for tags, so this narrows the race to a single
HTTP round trip rather than eliminating it outright; documented as a
known residual risk in ADR-0007.

## Design notes

- `exists()`/`download()` for chunk paths resolve the blob digest
  directly from the path (no HTTP round trip beyond the blob call
  itself); for everything else they still resolve via the tag's
  manifest, same as before.
- `list_prefix()` is index-backed for chunk-shard prefixes
  (`chunks/<shard>`) and tag-list-backed (paginated via `Link` headers)
  for everything else — both are load-bearing for `remote get` (snapshot
  enumeration) and `remote prune` (orphan scanning), not just a
  push-time optimization.
- Deletion support is registry-dependent (Docker Hub disables it
  entirely); `delete()` treats 404/405 as a no-op, matching FTP/SFTP's
  "best effort" stance.
- The per-snapshot OCI image is not runnable: its layers are opaque
  zstd-compressed chunks, not real tar diffs, so `docker pull`/`crane`
  work but `docker run`/`docker save` would not produce a coherent
  filesystem. It exists for registry-native storage/dedup visibility,
  not execution.
- New dependency: `requests` (no HTTP client previously in
  `src/requirements.txt`).

Full design writeup:
[ADR-0007](docs/decisions/0007-registry-backend-snapshot-images.md),
`docs/remote.md#registry-oci`,
[ADR-0006](docs/decisions/0006-remote-storage-deduplication.md)
(registry section superseded by ADR-0007).

## Test plan

- [x] 45 unit tests (`src/tests/test_remote_registry_backend.py`), mocked
      HTTP, covering exists/upload/download/list_prefix (incl.
      pagination)/delete/rename/Bearer-auth-challenge (incl.
      caching)/close, plus the bare-blob, per-shard-index, per-snapshot-
      image, and concurrency-retry behavior added in this update.
- [x] Extended the existing FTP/SFTP integration suite
      (`src/tests/integration/test_ftp_sftp_backends.py`) to a third
      `registry` parametrization — all 18 tests (6 tests × 3 backends)
      pass against real Docker containers (`registry:2` with
      `REGISTRY_STORAGE_DELETE_ENABLED=true`), including a direct fetch
      of the per-snapshot image manifest confirming its layer count/order
      matches the snapshot.
- [x] Full push → dehydrate → hydrate round-trip, second-push-transfers-
      zero-new-chunks dedup check, and orphan-chunk prune all verified
      against a live registry.
- [x] Full unit suite: 640 passed, no regressions.
- [x] `pyright .`: 0 errors.
- [x] `pre-commit run --all-files`: all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXCJmrq6XmDyqdku1c2TRx
