### PR TITLE
fix(docker): resolve named-volume names with compose's project prefix

### DIFF
--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -120,6 +120,21 @@ class DockerComposeEnv(Environment):
                     return True
         return False
 
+    def _resolved_volume_name(self, vol: VolumeCfg) -> str:
+        """Return the actual Docker volume name for a non-bind-mount volume.
+
+        External volumes use their own explicit name. Volumes shepherd
+        renders itself never carry a `name:` entry in the generated compose
+        YAML, so Compose applies its default project-scoped naming
+        (`<project>_<volume>`) — and every compose invocation in this class
+        runs with `-p envCfg.tag` (see `_run_compose`). Resolving to bare
+        `vol.tag` here would look up a volume Compose never created; Docker
+        would silently auto-vivify an empty one instead of erroring.
+        """
+        if vol.is_external() and vol.name:
+            return vol.name
+        return f"{self.envCfg.tag}_{vol.tag}"
+
     @override
     def get_volume_tar_streams(
         self, allow_sudo: bool = False
@@ -143,9 +158,7 @@ class DockerComposeEnv(Environment):
                     (vol.tag, self._path_tar_stream(device, allow_sudo))
                 )
             else:
-                vol_name = (
-                    vol.name if vol.is_external() and vol.name else vol.tag
-                )
+                vol_name = self._resolved_volume_name(vol)
                 result.append(
                     (vol.tag, self._docker_volume_tar_stream(vol_name))
                 )
@@ -198,9 +211,7 @@ class DockerComposeEnv(Environment):
                 if device:
                     Util.delete_dir(device)
             else:
-                vol_name = (
-                    vol.name if vol.is_external() and vol.name else vol.tag
-                )
+                vol_name = self._resolved_volume_name(vol)
                 subprocess.run(
                     ["docker", "volume", "rm", "--force", vol_name],
                     check=True,
@@ -211,7 +222,7 @@ class DockerComposeEnv(Environment):
         for vol in self.envCfg.volumes or []:
             if _is_bind_mount(vol):
                 continue
-            vol_name = vol.name if vol.is_external() and vol.name else vol.tag
+            vol_name = self._resolved_volume_name(vol)
             src = os.path.join(self.get_path(), "volumes", vol.tag)
             if not os.path.isdir(src):
                 logging.warning(

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -1917,7 +1917,12 @@ def test_volume_streams_bind_mount_sudo(mocker: MockerFixture) -> None:
 
 @pytest.mark.env
 def test_volume_streams_named_volume(mocker: MockerFixture) -> None:
-    """Named volume → ``docker run --rm -v <tag>:/mnt``."""
+    """Named volume → ``docker run --rm -v <env>_<tag>:/mnt``.
+
+    Compose project-prefixes non-external volume names by default (every
+    compose invocation in this class runs with ``-p envCfg.tag``), so the
+    real Docker volume is ``<env.tag>_<vol.tag>``, not the bare tag.
+    """
     env_cfg = _make_env_cfg_with_volumes([_named_vol("uploads")])
     env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
 
@@ -1933,7 +1938,35 @@ def test_volume_streams_named_volume(mocker: MockerFixture) -> None:
     assert tag == "uploads"
     cmd = mock_popen.call_args[0][0]
     assert "docker" in cmd
-    assert "uploads:/mnt" in cmd
+    assert "test-env_uploads:/mnt" in cmd
+
+
+@pytest.mark.env
+def test_resolved_volume_name_prefixes_non_external(
+    mocker: MockerFixture,
+) -> None:
+    """Non-external volumes resolve to Compose's default project-scoped
+    name (``<env.tag>_<vol.tag>``), matching what ``docker compose -p
+    envCfg.tag`` actually creates for a volume with no explicit ``name:``.
+    """
+    env_cfg = _make_env_cfg_with_volumes([_named_vol("uploads")])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    assert env._resolved_volume_name(_named_vol("uploads")) == (
+        "test-env_uploads"
+    )
+
+
+@pytest.mark.env
+def test_resolved_volume_name_external_uses_own_name(
+    mocker: MockerFixture,
+) -> None:
+    """External volumes are never prefixed — they use their own name."""
+    env_cfg = _make_env_cfg_with_volumes([])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    assert (
+        env._resolved_volume_name(_external_vol("ext_vol", "prod_db_backup"))
+        == "prod_db_backup"
+    )
 
 
 @pytest.mark.env
@@ -1990,7 +2023,7 @@ def test_remove_local_volumes_named_volume(mocker: MockerFixture) -> None:
 
     mock_run.assert_called_once()
     cmd = mock_run.call_args[0][0]
-    assert cmd == ["docker", "volume", "rm", "--force", "uploads"]
+    assert cmd == ["docker", "volume", "rm", "--force", "test-env_uploads"]
 
 
 @pytest.mark.env
@@ -2028,7 +2061,7 @@ def test_restore_local_volumes_named_volume(
 
     assert mock_run.call_count == 2
     first_cmd = mock_run.call_args_list[0][0][0]
-    assert first_cmd == ["docker", "volume", "create", "uploads"]
+    assert first_cmd == ["docker", "volume", "create", "test-env_uploads"]
     second_cmd = mock_run.call_args_list[1][0][0]
     assert "busybox:stable-glibc" in second_cmd
 


### PR DESCRIPTION
## Summary

`env push`/`pull`/`prune` silently archived and restored an empty,
freshly auto-created Docker volume instead of the environment's real
named volume, for any `docker-compose` environment using an ordinary
(non-external, non-bind-mount) named volume.

## Root cause

`DockerComposeEnv.get_volume_tar_streams` / `restore_local_volumes` /
`remove_local_volumes` resolved a non-external volume's Docker volume
name as the bare `vol.tag`. But the compose YAML `DockerComposeEnv`
renders never sets an explicit `name:` for non-external volumes, so
Compose applies its default project-prefixed naming
(`<project>_<volume>`) — every compose invocation in this class runs
with `-p envCfg.tag`. `docker run -v <name>:/mnt` doesn't error when
`<name>` doesn't exist; it silently auto-creates a fresh empty volume.
So `env push` never failed — it just tarred an empty volume and
reported a near-empty snapshot.

Found while smoke-testing the registry remote-storage backend
(#273) with a real 155 MiB / 2000-file dataset: `env push` reported
"1 chunk, 273 B stored" against multiple named volumes that actually
held real data.

## Fix

Added `_resolved_volume_name()`, used consistently by all three call
sites: external volumes still use their own explicit name; everything
else resolves to `<envCfg.tag>_<vol.tag>`, matching what Compose
actually creates.

Fixes: #274

## Test plan

- [x] `pytest tests/test_env_docker_compose.py` — updated + new unit
      tests (compose-prefixed name, external volume still unprefixed)
- [x] Full suite: 642 passed
- [x] `pyright .`: 0 errors
- [x] `pre-commit run --all-files`
- [x] Manual: real env with 6 named volumes (Postgres data + crawled
      blob/staging/archive data, 145.9 MiB) — `env push` now stores
      the real data; repeat push shows 0 new chunks (dedup); `env
      dehydrate` + `env hydrate` round-trips byte-identical (SHA-256
      verified)