### PR TITLE
fix(config): expose plugin config to ${VAR} template resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,8 @@ and this project adheres to
 ## [0.0.1] - Unreleased
 
 ### Added
+
+- Plugin `config` values are now available to `${VAR}` template
+  resolution in that plugin's `service_templates`/`env_templates`, no
+  longer requiring a separately-exported, identically-named shell
+  variable (#278).

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -86,6 +86,15 @@ Fields:
 config fields. YAML booleans are normalized, and placeholders such as
 `${PLUGIN_ENABLED}` are preserved until resolution time.
 
+Every key in a plugin's `config` block is also available to `${VAR}`
+placeholder resolution — including in that plugin's own
+`service_templates`/`env_templates` (`context_path`, `dockerfile_path`,
+`volumes`, etc). With the example above, `${region}` resolves to
+`eu-west-1` anywhere in the config tree, no separately-exported shell
+variable required. Resolution precedence for a given `${KEY}` is:
+`~/.shpd.values` (`user_values`) → plugin `config` → environment
+variable.
+
 ## Plugin Descriptor
 
 Each installed plugin ships a descriptor that defines its metadata and

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1564,6 +1564,21 @@ class ConfigMng:
 
         return user_values
 
+    def _build_resolver(self, config: Config) -> Dict[str, str]:
+        """
+        Merge plugin config values (defaults) under user_values (explicit
+        overrides) into the template resolver mapping, so a plugin's own
+        `config` dict is available to that plugin's `${VAR}` template
+        resolution without also requiring a same-named shell/user_values
+        variable.
+        """
+        resolver: Dict[str, str] = {}
+        for plugin_cfg in config.plugins or []:
+            for key, value in (plugin_cfg.config or {}).items():
+                resolver[str(key)] = str(value)
+        resolver.update(self.user_values)
+        return resolver
+
     def load_config(self) -> Config:
         """
         Loads and processes the configuration file.
@@ -1577,7 +1592,7 @@ class ConfigMng:
 
         # Reparse through model constructors to normalize defaults/types.
         config = parse_config(yaml.dump(config_data, sort_keys=False))
-        config.set_resolver(self.user_values)
+        config.set_resolver(self._build_resolver(config))
         return config
 
     def load(self):

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -223,6 +223,125 @@ def test_load_config(mocker: MockerFixture):
     assert config.envs[0].status.rendered_config is None
 
 
+_MINIMAL_VALUES = (
+    "shpd_path=/tmp/shpd\n"
+    "log_file=/tmp/shpd/shepctl.log\n"
+    "log_level=WARNING\n"
+    "log_stdout=false\n"
+    "log_format=%(asctime)s - %(levelname)s - %(message)s\n"
+)
+
+
+def _load_config_with_yaml(
+    mocker: MockerFixture, config_yaml: str, values: str = _MINIMAL_VALUES
+) -> Config:
+    mock_open1 = mock_open(read_data=values)
+    mock_open2 = mock_open(read_data=config_yaml)
+    mocker.patch("os.path.exists", return_value=True)
+    mocker.patch(
+        "builtins.open",
+        side_effect=[mock_open1.return_value, mock_open2.return_value],
+    )
+    cMng = ConfigMng(".shpd.conf")
+    return cMng.load_config()
+
+
+@pytest.mark.cfg
+def test_plugin_config_resolves_template_placeholder(mocker: MockerFixture):
+    """A plugin's own `config` values resolve ${VAR} placeholders in that
+    plugin's service_templates, without a same-named shell/user_values
+    variable (shepherd#278)."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+plugins:
+  - id: acme
+    enabled: true
+    config:
+      region: eu-west-1
+service_templates:
+  - tag: svc
+    factory: docker
+    containers:
+      - tag: c
+        image: nginx:latest
+        build:
+          context_path: ${region}
+          dockerfile_path: ${region}/Dockerfile
+"""
+    config = _load_config_with_yaml(mocker, config_yaml)
+    config.set_resolved()
+
+    assert config.service_templates
+    build = config.service_templates[0].containers[0].build
+    assert build
+    assert build.context_path == "eu-west-1"
+    assert build.dockerfile_path == "eu-west-1/Dockerfile"
+
+
+@pytest.mark.cfg
+def test_user_values_override_plugin_config(mocker: MockerFixture):
+    """A user_values entry with the same key takes precedence over a
+    plugin's `config` value on collision."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+plugins:
+  - id: acme
+    enabled: true
+    config:
+      region: eu-west-1
+service_templates:
+  - tag: svc
+    factory: docker
+    containers:
+      - tag: c
+        image: nginx:latest
+        build:
+          context_path: ${region}
+          dockerfile_path: ${region}/Dockerfile
+"""
+    values = _MINIMAL_VALUES + "region=us-east-1\n"
+    config = _load_config_with_yaml(mocker, config_yaml, values)
+    config.set_resolved()
+
+    build = config.service_templates[0].containers[0].build
+    assert build
+    assert build.context_path == "us-east-1"
+
+
+@pytest.mark.cfg
+def test_plugin_config_resolution_no_plugins(mocker: MockerFixture):
+    """No plugins/config present: resolution behaves exactly as before,
+    falling back to the environment variable."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+service_templates:
+  - tag: svc
+    factory: docker
+    containers:
+      - tag: c
+        image: nginx:latest
+        build:
+          context_path: ${SOME_ENV_ONLY_VAR}
+          dockerfile_path: ${SOME_ENV_ONLY_VAR}/Dockerfile
+"""
+    mocker.patch.dict(os.environ, {"SOME_ENV_ONLY_VAR": "from-env"})
+    config = _load_config_with_yaml(mocker, config_yaml)
+    config.set_resolved()
+
+    build = config.service_templates[0].containers[0].build
+    assert build
+    assert build.context_path == "from-env"
+
+
 @pytest.mark.cfg
 def test_core_canonical_template_lookup(mocker: MockerFixture):
     cMng = _load_config_manager(mocker)


### PR DESCRIPTION
## Summary
- `${VAR}` placeholders in a plugin's `service_templates`/`env_templates` (`context_path`, `dockerfile_path`, `volumes`, etc.) previously resolved only against `~/.shpd.values`/the shell environment — never against the plugin's own `config` dict (the `default_config` block in `plugin.yaml`, persisted under `plugins[].config`). A plugin author already exposing a path as plugin config for their own CLI commands had to separately export an identically-named shell variable before `env up`/`svc build`, or bind mounts/build paths silently resolved to a blank string (`docker-compose` warns `"VAR" variable is not set. Defaulting to a blank string.`) and failed at container-start with an opaque OCI "not a directory" error instead of a clear config error.
- `ConfigMng.load_config()` now merges every plugin's `config` dict into the resolver mapping (as defaults) under `user_values` (explicit override on collision, unchanged precedence otherwise, `os.environ` remains the final fallback). Everything downstream (`set_resolved`/`set_unresolved`/`store_config`/`add_or_set_environment`) already reuses whatever resolver was stamped at load time, so this is the only call site that needs to change.
- Docs: `docs/plugins.md` documents the new resolution precedence; `CHANGELOG.md` updated.

## Test plan
- [x] `cd src && pytest` — 645 passed, no regressions (3 new tests covering: plugin config resolves a template placeholder, user_values overrides plugin config on collision, no-plugins/no-config falls back to environment exactly as before)
- [x] `cd src && pyright .` — 0 errors
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Manual: installed system-wide from this branch (`scripts/install.sh --install-method source`), pointed a real plugin's service templates at `${some_plugin_config_key}` instead of a shell-exported var, ran `shepctl env up` with nothing exported — bind mounts/build paths resolved correctly

Fixes #278