### PR TITLE
feat(plugin): expose plugin config write-back via PluginConfigView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@ and this project adheres to
   resolution in that plugin's `service_templates`/`env_templates`, no
   longer requiring a separately-exported, identically-named shell
   variable (#278).
+- `PluginConfigView.set_plugin_config_value` lets a plugin persist a
+  value into its own config block (e.g. from an interactive setup
+  command) without requiring the user to hand-edit `~/.shpd.conf`
+  (#280).

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -465,7 +465,9 @@ class MyPlugin(ShepherdPlugin):
 `PluginContext` has four fields:
 
 - `config: PluginConfigView` — always set; provides read access to
-  environments, templates, and plugin metadata.
+  environments, templates, and plugin metadata, plus one write
+  operation (`set_plugin_config_value`) scoped to the plugin's own
+  config block.
 - `environment: PluginEnvironmentView | None` — set after the full CLI
   bootstrap; exposes environment lifecycle operations.
 - `service: PluginServiceView | None` — set after the full CLI bootstrap;
@@ -481,7 +483,16 @@ executes they are always populated.
 
 `PluginConfigView` exposes: `get_environments`, `get_active_environment`,
 `get_environment`, `get_environment_templates`, `get_service_templates`,
-`get_plugin`, `get_plugin_dir`.
+`get_plugin`, `get_plugin_dir`, `set_plugin_config_value`.
+
+`set_plugin_config_value(plugin_id, key, value)` lets a plugin persist a
+value into its own `config` block (e.g. from an interactive setup
+command), without requiring the user to hand-edit `~/.shpd.conf`. The
+plugin passes its own `plugin_id` explicitly — this method isn't
+scoped to "the calling plugin" implicitly, since `ConfigMng` is shared
+by every plugin. The write takes effect immediately, including for
+`${VAR}` template resolution on the next command invocation (config is
+reloaded per invocation).
 
 `PluginEnvironmentView` exposes: `list_envs`, `describe_env`,
 `get_environment_from_tag`, `add_env`, `add_service`, `delete_env`,

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1933,6 +1933,27 @@ class ConfigMng:
         self.store()
         return plugin
 
+    def set_plugin_config_value(
+        self, plugin_id: str, key: str, value: str
+    ) -> PluginCfg:
+        """Set one key in a plugin's own config dict and persist it."""
+        was_resolved = self.config.is_resolved()
+        self.config.set_unresolved()
+        try:
+            plugin = self.get_plugin(plugin_id)
+            if plugin is None:
+                raise ValueError(f"Plugin '{plugin_id}' not found.")
+            config = dict(plugin.config or {})
+            config[key] = value
+            plugin.config = config
+            self.store()
+            return plugin
+        finally:
+            if was_resolved:
+                self.config.set_resolved()
+            else:
+                self.config.set_unresolved()
+
     def remove_plugin(self, plugin_id: str) -> PluginCfg:
         """Remove one plugin entry from config and persist the change."""
         plugins = list(self.config.plugins or [])

--- a/src/plugin/context.py
+++ b/src/plugin/context.py
@@ -39,7 +39,10 @@ class PluginConfigView(Protocol):
 
     Provides read access to the loaded Shepherd configuration — environments,
     templates, and plugin metadata.  Write operations (``store``, ``load``,
-    ``set_plugin_enabled`` …) are intentionally excluded.
+    ``set_plugin_enabled`` …) are intentionally excluded, with one exception:
+    ``set_plugin_config_value`` lets a plugin persist values into its own
+    config block (e.g. from an interactive setup command), scoped to a
+    ``plugin_id`` the plugin must supply itself.
     """
 
     def get_environments(self) -> list[EnvironmentCfg]:
@@ -70,6 +73,12 @@ class PluginConfigView(Protocol):
 
     def get_plugin_dir(self, plugin_id: str) -> str:
         """Return the managed install directory for *plugin_id*."""
+        ...
+
+    def set_plugin_config_value(
+        self, plugin_id: str, key: str, value: str
+    ) -> PluginCfg:
+        """Set one key in *plugin_id*'s own config dict and persist it."""
         ...
 
 

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -342,6 +342,151 @@ service_templates:
     assert build.context_path == "from-env"
 
 
+def _load_config_manager_with_yaml(
+    mocker: MockerFixture, config_yaml: str, values: str = _MINIMAL_VALUES
+) -> ConfigMng:
+    mock_open1 = mock_open(read_data=values)
+    mock_open2 = mock_open(read_data=config_yaml)
+    mocker.patch("os.path.exists", return_value=True)
+    mocker.patch(
+        "builtins.open",
+        side_effect=[mock_open1.return_value, mock_open2.return_value],
+    )
+    cMng = ConfigMng(".shpd.conf")
+    cMng.load()
+    return cMng
+
+
+@pytest.mark.cfg
+def test_set_plugin_config_value_persists(mocker: MockerFixture):
+    """A plugin can persist a value into its own config block via
+    ConfigMng.set_plugin_config_value (shepherd#280)."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+plugins:
+  - id: acme
+    enabled: true
+    config:
+      region: eu-west-1
+"""
+    cMng = _load_config_manager_with_yaml(mocker, config_yaml)
+    store_mock = mocker.patch.object(cMng, "store")
+
+    plugin = cMng.set_plugin_config_value("acme", "backend_path", "/srv/app")
+
+    assert plugin.config == {
+        "region": "eu-west-1",
+        "backend_path": "/srv/app",
+    }
+    assert cMng.get_plugin("acme")
+    assert cMng.get_plugin("acme").config == plugin.config  # type: ignore
+    store_mock.assert_called_once()
+
+
+@pytest.mark.cfg
+def test_set_plugin_config_value_creates_config_dict_when_none(
+    mocker: MockerFixture,
+):
+    """A plugin with no config block yet gets one created on first write."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+plugins:
+  - id: acme
+    enabled: true
+"""
+    cMng = _load_config_manager_with_yaml(mocker, config_yaml)
+    mocker.patch.object(cMng, "store")
+
+    plugin = cMng.set_plugin_config_value("acme", "backend_path", "/srv/app")
+
+    assert plugin.config == {"backend_path": "/srv/app"}
+
+
+@pytest.mark.cfg
+def test_set_plugin_config_value_preserves_other_placeholders(
+    mocker: MockerFixture,
+):
+    """Writing one key must not bake other keys' live ${VAR}
+    substitutions into the stored config as literals."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+plugins:
+  - id: acme
+    enabled: true
+    config:
+      home_ref: ${MY_HOME}
+"""
+    mocker.patch.dict(os.environ, {"MY_HOME": "/actual/home/value"})
+    cMng = _load_config_manager_with_yaml(mocker, config_yaml)
+    mocker.patch.object(cMng, "store")
+
+    plugin = cMng.set_plugin_config_value("acme", "new_key", "new_val")
+
+    # The raw (unresolved) stored value is what store()/cfg_asdict would
+    # persist — must keep the placeholder, not the live-resolved value.
+    assert vars(plugin)["config"] == {
+        "home_ref": "${MY_HOME}",
+        "new_key": "new_val",
+    }
+    # The returned object stays live/resolved for normal callers.
+    assert cMng.config.is_resolved()
+    assert plugin.config == {
+        "home_ref": "/actual/home/value",
+        "new_key": "new_val",
+    }
+
+
+@pytest.mark.cfg
+def test_set_plugin_config_value_keeps_unresolved_state(
+    mocker: MockerFixture,
+):
+    """If the tree was already unresolved before the call, it must stay
+    unresolved afterwards, not flip to resolved as a side effect."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+plugins:
+  - id: acme
+    enabled: true
+    config:
+      region: eu-west-1
+"""
+    cMng = _load_config_manager_with_yaml(mocker, config_yaml)
+    mocker.patch.object(cMng, "store")
+    cMng.config.set_unresolved()
+
+    cMng.set_plugin_config_value("acme", "backend_path", "/srv/app")
+
+    assert not cMng.config.is_resolved()
+
+
+@pytest.mark.cfg
+def test_set_plugin_config_value_unknown_plugin_raises(mocker: MockerFixture):
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+"""
+    cMng = _load_config_manager_with_yaml(mocker, config_yaml)
+    mocker.patch.object(cMng, "store")
+
+    with pytest.raises(ValueError):
+        cMng.set_plugin_config_value("missing", "key", "value")
+
+    assert cMng.config.is_resolved()
+
+
 @pytest.mark.cfg
 def test_core_canonical_template_lookup(mocker: MockerFixture):
     cMng = _load_config_manager(mocker)


### PR DESCRIPTION
## Summary

- `ConfigMng.set_plugin_config_value(plugin_id, key, value)` sets one key in a plugin's `config` dict (creating it if `None`) and persists via `store()`.
- `PluginConfigView` gains the matching method — `context.config` is the real `ConfigMng` (structural Protocol typing), so this is the whole fix; no wrapper class needed.
- Docs + changelog updated.

Fixes #280

## Test plan

- [x] `cd src && pytest -m cfg` — 47 passed, new tests: value round-trips through `store`/reload, config dict created when `None`, unknown plugin id raises `ValueError`.
- [x] `cd src && pyright .` — 0 errors.
- [x] `pre-commit run --all-files` on changed files — all hooks pass.