### PR TITLE
feat(config): add environment-scoped config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@ and this project adheres to
   resolution in that plugin's `service_templates`/`env_templates`, no
   longer requiring a separately-exported, identically-named shell
   variable (#278).
+- `PluginConfigView.set_plugin_config_value` lets a plugin persist a
+  value into its own config block (e.g. from an interactive setup
+  command) without requiring the user to hand-edit `~/.shpd.conf`
+  (#280).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,8 @@ and this project adheres to
   value into its own config block (e.g. from an interactive setup
   command) without requiring the user to hand-edit `~/.shpd.conf`
   (#280).
+- Environment instances can now carry their own `config` block,
+  distinct from their plugin's config, overriding it for that
+  environment's `${VAR}` template resolution only.
+  `PluginConfigView.set_environment_config_value` persists into it
+  (#281).

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -91,9 +91,31 @@ placeholder resolution — including in that plugin's own
 `service_templates`/`env_templates` (`context_path`, `dockerfile_path`,
 `volumes`, etc). With the example above, `${region}` resolves to
 `eu-west-1` anywhere in the config tree, no separately-exported shell
-variable required. Resolution precedence for a given `${KEY}` is:
-`~/.shpd.values` (`user_values`) → plugin `config` → environment
-variable.
+variable required.
+
+An individual environment instance (an entry under `envs:`, the thing
+created by `env add <template> <tag>`) can also carry its own `config`
+block, keyed exactly like a plugin's:
+
+```yaml
+envs:
+  - tag: my-env
+    template: acme/full
+    factory: acme-env-factory
+    config:
+      region: us-east-1
+```
+
+This is the one case where two different scopes both apply to the same
+`${VAR}` name: the environment's own `config` overrides its plugin's
+`config` default for templates resolved within *that* environment's
+subtree only — sibling environments, and anything outside `envs:`,
+keep resolving against the plugin default. Resolution precedence for a
+given `${KEY}`, most specific override last:
+
+plugin `config` (default) → environment `config` (per-instance
+override, if set) → `~/.shpd.values` (`user_values`, always wins) →
+process environment variable (final fallback).
 
 ## Plugin Descriptor
 
@@ -483,7 +505,8 @@ executes they are always populated.
 
 `PluginConfigView` exposes: `get_environments`, `get_active_environment`,
 `get_environment`, `get_environment_templates`, `get_service_templates`,
-`get_plugin`, `get_plugin_dir`, `set_plugin_config_value`.
+`get_plugin`, `get_plugin_dir`, `set_plugin_config_value`,
+`set_environment_config_value`.
 
 `set_plugin_config_value(plugin_id, key, value)` lets a plugin persist a
 value into its own `config` block (e.g. from an interactive setup
@@ -493,6 +516,12 @@ scoped to "the calling plugin" implicitly, since `ConfigMng` is shared
 by every plugin. The write takes effect immediately, including for
 `${VAR}` template resolution on the next command invocation (config is
 reloaded per invocation).
+
+`set_environment_config_value(env_tag, key, value)` is the same idea
+one scope level down — it writes into a specific environment's own
+`config` block instead of the plugin's. Useful when a value should
+differ per environment instance rather than being shared machine-wide
+(see the environment-scoped `${VAR}` resolution note above).
 
 `PluginEnvironmentView` exposes: `list_envs`, `describe_env`,
 `get_environment_from_tag`, `add_env`, `add_service`, `delete_env`,

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -465,7 +465,9 @@ class MyPlugin(ShepherdPlugin):
 `PluginContext` has four fields:
 
 - `config: PluginConfigView` — always set; provides read access to
-  environments, templates, and plugin metadata.
+  environments, templates, and plugin metadata, plus one write
+  operation (`set_plugin_config_value`) scoped to the plugin's own
+  config block.
 - `environment: PluginEnvironmentView | None` — set after the full CLI
   bootstrap; exposes environment lifecycle operations.
 - `service: PluginServiceView | None` — set after the full CLI bootstrap;
@@ -481,7 +483,16 @@ executes they are always populated.
 
 `PluginConfigView` exposes: `get_environments`, `get_active_environment`,
 `get_environment`, `get_environment_templates`, `get_service_templates`,
-`get_plugin`, `get_plugin_dir`.
+`get_plugin`, `get_plugin_dir`, `set_plugin_config_value`.
+
+`set_plugin_config_value(plugin_id, key, value)` lets a plugin persist a
+value into its own `config` block (e.g. from an interactive setup
+command), without requiring the user to hand-edit `~/.shpd.conf`. The
+plugin passes its own `plugin_id` explicitly — this method isn't
+scoped to "the calling plugin" implicitly, since `ConfigMng` is shared
+by every plugin. The write takes effect immediately, including for
+`${VAR}` template resolution on the next command invocation (config is
+reloaded per invocation).
 
 `PluginEnvironmentView` exposes: `list_envs`, `describe_env`,
 `get_environment_from_tag`, `add_env`, `add_service`, `delete_env`,

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -208,50 +208,82 @@ class Resolvable:
         resolved: bool,
         obj: Any = None,
         refMap: dict[str, "Resolvable"] | None = None,
+        user_values: dict[str, str] | None = None,
     ):
         """
         Propagate resolver/reference context and resolution mode recursively.
 
         This is the core state-wiring pass used by `set_resolved`,
-        `set_unresolved`, and `set_resolver`.
+        `set_unresolved`, and `set_resolver`. `user_values` is the same
+        mapping reference for the whole tree (it always wins in
+        `_resolve_str`, see there); `resolver` is the per-node mapping —
+        an `EnvironmentCfg` with its own `config` dict merges that on top
+        of the incoming `resolver` for itself and its subtree only,
+        leaving sibling subtrees on the unmerged mapping.
         """
         if obj is None:
             obj = self
 
         if is_dataclass(obj) and isinstance(obj, Resolvable):
             lRefMap = obj._set_refMap(refMap)
-            object.__setattr__(obj, "_resolver", resolver or os.environ)
+            node_resolver = resolver
+            if isinstance(obj, EnvironmentCfg) and obj.config and resolved:
+                node_resolver = dict(resolver or {})
+                node_resolver.update(
+                    {str(k): str(v) for k, v in obj.config.items()}
+                )
+            object.__setattr__(obj, "_resolver", node_resolver or os.environ)
+            object.__setattr__(obj, "_user_values", user_values or {})
             for f in fields(obj):
                 if fVal := getattr(obj, f.name, None):
-                    self._walk_and_set(resolver, resolved, fVal, lRefMap)
+                    self._walk_and_set(
+                        node_resolver, resolved, fVal, lRefMap, user_values
+                    )
             object.__setattr__(obj, "_resolved", resolved)
 
         elif isinstance(obj, list):
             for item in cast(list[Any], obj):
-                self._walk_and_set(resolver, resolved, item, refMap)
+                self._walk_and_set(
+                    resolver, resolved, item, refMap, user_values
+                )
 
         elif isinstance(obj, dict):
             for _, v in cast(dict[str, Any], obj).items():
-                self._walk_and_set(resolver, resolved, v, refMap)
+                self._walk_and_set(resolver, resolved, v, refMap, user_values)
 
     def set_resolved(self):
-        self._walk_and_set(getattr(self, "_resolver", None), True)
+        self._walk_and_set(
+            getattr(self, "_resolver", None),
+            True,
+            user_values=getattr(self, "_user_values", None),
+        )
 
     def set_unresolved(self):
-        self._walk_and_set(getattr(self, "_resolver", None), False)
+        self._walk_and_set(
+            getattr(self, "_resolver", None),
+            False,
+            user_values=getattr(self, "_user_values", None),
+        )
 
-    def set_resolver(self, mapping: dict[str, str] | None):
-        self._walk_and_set(mapping, True)
+    def set_resolver(
+        self,
+        mapping: dict[str, str] | None,
+        user_values: dict[str, str] | None = None,
+    ):
+        self._walk_and_set(mapping, True, user_values=user_values)
 
     def is_resolved(self) -> bool:
         return getattr(self, "_resolved", False)
 
     def _resolve_str(self, s: str) -> str:
         mapping = getattr(self, "_resolver", None) or os.environ
+        user_values: dict[str, str] = getattr(self, "_user_values", None) or {}
         refMap = cast(dict[str, Resolvable], getattr(self, "_refMap", {}))
 
         def var_repl(match: Match[str]) -> str:
             key = match.group(1)
+            if key in user_values:
+                return str(user_values[key])
             if key in mapping:
                 return str(mapping[key])
             return os.environ.get(key, match.group(0))
@@ -720,6 +752,7 @@ class EnvironmentCfg(Resolvable):
     tracking_remote: Optional[str] = None
     dehydrated: Optional[bool] = None
     status: EntityStatus = field(default_factory=EntityStatus)
+    config: Optional[dict[str, Any]] = None
 
     def get_service(self, svcTag: str) -> Optional[ServiceCfg]:
         """
@@ -1271,6 +1304,7 @@ def _parse_environment(item: Any) -> EnvironmentCfg:
         tracking_remote=item.get("tracking_remote"),
         dehydrated=item.get("dehydrated"),
         status=_parse_status(item["status"]),
+        config=item.get("config"),
     )
 
 
@@ -1564,19 +1598,21 @@ class ConfigMng:
 
         return user_values
 
-    def _build_resolver(self, config: Config) -> Dict[str, str]:
+    def _build_plugin_resolver(self, config: Config) -> Dict[str, str]:
         """
-        Merge plugin config values (defaults) under user_values (explicit
-        overrides) into the template resolver mapping, so a plugin's own
-        `config` dict is available to that plugin's `${VAR}` template
-        resolution without also requiring a same-named shell/user_values
-        variable.
+        Build the base template resolver mapping from plugin config values
+        (defaults), so a plugin's own `config` dict is available to that
+        plugin's `${VAR}` template resolution without also requiring a
+        same-named shell/user_values variable. `user_values` is layered on
+        top separately (see `set_resolver`) rather than merged in here, so
+        an `EnvironmentCfg`'s own `config` (per-environment overrides, see
+        `Resolvable._walk_and_set`) can sit between the two: plugin config
+        default → environment override → user_values (always wins).
         """
         resolver: Dict[str, str] = {}
         for plugin_cfg in config.plugins or []:
             for key, value in (plugin_cfg.config or {}).items():
                 resolver[str(key)] = str(value)
-        resolver.update(self.user_values)
         return resolver
 
     def load_config(self) -> Config:
@@ -1592,7 +1628,9 @@ class ConfigMng:
 
         # Reparse through model constructors to normalize defaults/types.
         config = parse_config(yaml.dump(config_data, sort_keys=False))
-        config.set_resolver(self._build_resolver(config))
+        config.set_resolver(
+            self._build_plugin_resolver(config), self.user_values
+        )
         return config
 
     def load(self):
@@ -2015,6 +2053,33 @@ class ConfigMng:
                 return
         self.config.envs.append(newEnv)
         self.store()
+
+    def set_environment_config_value(
+        self, env_tag: str, key: str, value: str
+    ) -> EnvironmentCfg:
+        """Set one key in an environment's own config dict and persist it.
+
+        Values set here override the plugin's own config defaults, but are
+        still overridable by `~/.shpd.values` (`user_values`), for that
+        environment's `${VAR}` template resolution — see
+        `Resolvable._walk_and_set`.
+        """
+        was_resolved = self.config.is_resolved()
+        self.config.set_unresolved()
+        try:
+            for env in self.config.envs:
+                if env.tag == env_tag:
+                    config = dict(env.config or {})
+                    config[key] = value
+                    env.config = config
+                    self.store()
+                    return env
+            raise ValueError(f"Environment '{env_tag}' not found.")
+        finally:
+            if was_resolved:
+                self.config.set_resolved()
+            else:
+                self.config.set_unresolved()
 
     def remove_environment(self, envTag: str):
         """

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1933,6 +1933,27 @@ class ConfigMng:
         self.store()
         return plugin
 
+    def set_plugin_config_value(
+        self, plugin_id: str, key: str, value: str
+    ) -> PluginCfg:
+        """Set one key in a plugin's own config dict and persist it."""
+        was_resolved = self.config.is_resolved()
+        self.config.set_unresolved()
+        try:
+            plugin = self.get_plugin(plugin_id)
+            if plugin is None:
+                raise ValueError(f"Plugin '{plugin_id}' not found.")
+            config = dict(plugin.config or {})
+            config[key] = value
+            plugin.config = config
+            self.store()
+            return plugin
+        finally:
+            if was_resolved:
+                self.config.set_resolved()
+            else:
+                self.config.set_unresolved()
+
     def remove_plugin(self, plugin_id: str) -> PluginCfg:
         """Remove one plugin entry from config and persist the change."""
         plugins = list(self.config.plugins or [])

--- a/src/plugin/context.py
+++ b/src/plugin/context.py
@@ -39,7 +39,10 @@ class PluginConfigView(Protocol):
 
     Provides read access to the loaded Shepherd configuration — environments,
     templates, and plugin metadata.  Write operations (``store``, ``load``,
-    ``set_plugin_enabled`` …) are intentionally excluded.
+    ``set_plugin_enabled`` …) are intentionally excluded, with one exception:
+    ``set_plugin_config_value`` lets a plugin persist values into its own
+    config block (e.g. from an interactive setup command), scoped to a
+    ``plugin_id`` the plugin must supply itself.
     """
 
     def get_environments(self) -> list[EnvironmentCfg]:
@@ -70,6 +73,12 @@ class PluginConfigView(Protocol):
 
     def get_plugin_dir(self, plugin_id: str) -> str:
         """Return the managed install directory for *plugin_id*."""
+        ...
+
+    def set_plugin_config_value(
+        self, plugin_id: str, key: str, value: str
+    ) -> PluginCfg:
+        """Set one key in *plugin_id*'s own config dict and persist it."""
         ...
 
 

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -488,6 +488,233 @@ envs: []
 
 
 @pytest.mark.cfg
+def test_environment_config_overrides_plugin_config(mocker: MockerFixture):
+    """An environment's own `config` overrides its plugin's `config`
+    default when resolving ${VAR} placeholders within that environment's
+    own subtree (shepherd#281)."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+plugins:
+  - id: acme
+    enabled: true
+    config:
+      region: eu-west-1
+envs:
+  - tag: my-env
+    template: t
+    factory: f
+    status: {}
+    config:
+      region: us-east-1
+    services:
+      - tag: svc
+        factory: docker
+        template: svc-template
+        status: {}
+        containers:
+          - tag: c
+            image: nginx:latest
+            build:
+              context_path: ${region}
+              dockerfile_path: ${region}/Dockerfile
+"""
+    config = _load_config_with_yaml(mocker, config_yaml)
+    config.set_resolved()
+
+    build = config.envs[0].services[0].containers[0].build
+    assert build
+    assert build.context_path == "us-east-1"
+
+
+@pytest.mark.cfg
+def test_environment_without_config_falls_back_to_plugin_config(
+    mocker: MockerFixture,
+):
+    """An environment with no `config` block resolves against its
+    plugin's `config` default, unchanged (regression guard)."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+plugins:
+  - id: acme
+    enabled: true
+    config:
+      region: eu-west-1
+envs:
+  - tag: my-env
+    template: t
+    factory: f
+    status: {}
+    services:
+      - tag: svc
+        factory: docker
+        template: svc-template
+        status: {}
+        containers:
+          - tag: c
+            image: nginx:latest
+            build:
+              context_path: ${region}
+              dockerfile_path: ${region}/Dockerfile
+"""
+    config = _load_config_with_yaml(mocker, config_yaml)
+    config.set_resolved()
+
+    build = config.envs[0].services[0].containers[0].build
+    assert build
+    assert build.context_path == "eu-west-1"
+
+
+@pytest.mark.cfg
+def test_user_values_override_environment_config(mocker: MockerFixture):
+    """`user_values` still wins over an environment's own `config` value
+    on collision — the override escape hatch stays final."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+plugins:
+  - id: acme
+    enabled: true
+    config:
+      region: eu-west-1
+envs:
+  - tag: my-env
+    template: t
+    factory: f
+    status: {}
+    config:
+      region: us-east-1
+    services:
+      - tag: svc
+        factory: docker
+        template: svc-template
+        status: {}
+        containers:
+          - tag: c
+            image: nginx:latest
+            build:
+              context_path: ${region}
+              dockerfile_path: ${region}/Dockerfile
+"""
+    values = _MINIMAL_VALUES + "region=ap-south-1\n"
+    config = _load_config_with_yaml(mocker, config_yaml, values)
+    config.set_resolved()
+
+    build = config.envs[0].services[0].containers[0].build
+    assert build
+    assert build.context_path == "ap-south-1"
+
+
+@pytest.mark.cfg
+def test_set_environment_config_value_persists(mocker: MockerFixture):
+    """A plugin can persist a value into a specific environment's own
+    config block via ConfigMng.set_environment_config_value
+    (shepherd#281)."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs:
+  - tag: my-env
+    template: t
+    factory: f
+    status: {}
+    config:
+      region: eu-west-1
+"""
+    cMng = _load_config_manager_with_yaml(mocker, config_yaml)
+    store_mock = mocker.patch.object(cMng, "store")
+
+    env = cMng.set_environment_config_value(
+        "my-env", "backend_path", "/srv/app"
+    )
+
+    assert env.config == {"region": "eu-west-1", "backend_path": "/srv/app"}
+    store_mock.assert_called_once()
+    assert cMng.config.is_resolved()
+
+
+@pytest.mark.cfg
+def test_set_environment_config_value_preserves_other_placeholders(
+    mocker: MockerFixture,
+):
+    """Writing one key must not bake other keys' live ${VAR}
+    substitutions into the stored config as literals."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs:
+  - tag: my-env
+    template: t
+    factory: f
+    status: {}
+    config:
+      home_ref: ${MY_HOME}
+"""
+    mocker.patch.dict(os.environ, {"MY_HOME": "/actual/home/value"})
+    cMng = _load_config_manager_with_yaml(mocker, config_yaml)
+    mocker.patch.object(cMng, "store")
+
+    env = cMng.set_environment_config_value("my-env", "new_key", "new_val")
+
+    assert vars(env)["config"] == {
+        "home_ref": "${MY_HOME}",
+        "new_key": "new_val",
+    }
+    assert cMng.config.is_resolved()
+
+
+@pytest.mark.cfg
+def test_set_environment_config_value_keeps_unresolved_state(
+    mocker: MockerFixture,
+):
+    """If the tree was already unresolved before the call, it must stay
+    unresolved afterwards, not flip to resolved as a side effect."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs:
+  - tag: my-env
+    template: t
+    factory: f
+    status: {}
+    config:
+      region: eu-west-1
+"""
+    cMng = _load_config_manager_with_yaml(mocker, config_yaml)
+    mocker.patch.object(cMng, "store")
+    cMng.config.set_unresolved()
+
+    cMng.set_environment_config_value("my-env", "backend_path", "/srv/app")
+
+    assert not cMng.config.is_resolved()
+
+
+@pytest.mark.cfg
+def test_set_environment_config_value_unknown_env_raises(
+    mocker: MockerFixture,
+):
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+"""
+    cMng = _load_config_manager_with_yaml(mocker, config_yaml)
+    mocker.patch.object(cMng, "store")
+
+    with pytest.raises(ValueError):
+        cMng.set_environment_config_value("missing", "key", "value")
+
+    assert cMng.config.is_resolved()
+
+
+@pytest.mark.cfg
 def test_core_canonical_template_lookup(mocker: MockerFixture):
     cMng = _load_config_manager(mocker)
 
@@ -608,6 +835,7 @@ def test_store_config_with_real_files():
                 item.setdefault("ready", None)
                 item.setdefault("tracking_remote", None)
                 item.setdefault("dehydrated", None)
+                item.setdefault("config", None)
             for remote in expected.get("remotes") or []:
                 remote.setdefault("host", None)
                 remote.setdefault("port", None)
@@ -944,6 +1172,7 @@ def test_store_config_with_refs_with_real_files():
                 item.setdefault("ready", None)
                 item.setdefault("tracking_remote", None)
                 item.setdefault("dehydrated", None)
+                item.setdefault("config", None)
             y2: str = yaml.dump(expected, sort_keys=True)
             assert y1 == y2
 

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -342,6 +342,151 @@ service_templates:
     assert build.context_path == "from-env"
 
 
+def _load_config_manager_with_yaml(
+    mocker: MockerFixture, config_yaml: str, values: str = _MINIMAL_VALUES
+) -> ConfigMng:
+    mock_open1 = mock_open(read_data=values)
+    mock_open2 = mock_open(read_data=config_yaml)
+    mocker.patch("os.path.exists", return_value=True)
+    mocker.patch(
+        "builtins.open",
+        side_effect=[mock_open1.return_value, mock_open2.return_value],
+    )
+    cMng = ConfigMng(".shpd.conf")
+    cMng.load()
+    return cMng
+
+
+@pytest.mark.cfg
+def test_set_plugin_config_value_persists(mocker: MockerFixture):
+    """A plugin can persist a value into its own config block via
+    ConfigMng.set_plugin_config_value (shepherd#280)."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+plugins:
+  - id: acme
+    enabled: true
+    config:
+      region: eu-west-1
+"""
+    cMng = _load_config_manager_with_yaml(mocker, config_yaml)
+    store_mock = mocker.patch.object(cMng, "store")
+
+    plugin = cMng.set_plugin_config_value("acme", "backend_path", "/srv/app")
+
+    assert plugin.config == {
+        "region": "eu-west-1",
+        "backend_path": "/srv/app",
+    }
+    assert cMng.get_plugin("acme")
+    assert cMng.get_plugin("acme").config == plugin.config  # type: ignore
+    store_mock.assert_called_once()
+
+
+@pytest.mark.cfg
+def test_set_plugin_config_value_creates_config_dict_when_none(
+    mocker: MockerFixture,
+):
+    """A plugin with no config block yet gets one created on first write."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+plugins:
+  - id: acme
+    enabled: true
+"""
+    cMng = _load_config_manager_with_yaml(mocker, config_yaml)
+    mocker.patch.object(cMng, "store")
+
+    plugin = cMng.set_plugin_config_value("acme", "backend_path", "/srv/app")
+
+    assert plugin.config == {"backend_path": "/srv/app"}
+
+
+@pytest.mark.cfg
+def test_set_plugin_config_value_preserves_other_placeholders(
+    mocker: MockerFixture,
+):
+    """Writing one key must not bake other keys' live ${VAR}
+    substitutions into the stored config as literals."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+plugins:
+  - id: acme
+    enabled: true
+    config:
+      home_ref: ${MY_HOME}
+"""
+    mocker.patch.dict(os.environ, {"MY_HOME": "/actual/home/value"})
+    cMng = _load_config_manager_with_yaml(mocker, config_yaml)
+    mocker.patch.object(cMng, "store")
+
+    plugin = cMng.set_plugin_config_value("acme", "new_key", "new_val")
+
+    # The raw (unresolved) stored value is what store()/cfg_asdict would
+    # persist — must keep the placeholder, not the live-resolved value.
+    assert vars(plugin)["config"] == {
+        "home_ref": "${MY_HOME}",
+        "new_key": "new_val",
+    }
+    # The returned object stays live/resolved for normal callers.
+    assert cMng.config.is_resolved()
+    assert plugin.config == {
+        "home_ref": "/actual/home/value",
+        "new_key": "new_val",
+    }
+
+
+@pytest.mark.cfg
+def test_set_plugin_config_value_keeps_unresolved_state(
+    mocker: MockerFixture,
+):
+    """If the tree was already unresolved before the call, it must stay
+    unresolved afterwards, not flip to resolved as a side effect."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+plugins:
+  - id: acme
+    enabled: true
+    config:
+      region: eu-west-1
+"""
+    cMng = _load_config_manager_with_yaml(mocker, config_yaml)
+    mocker.patch.object(cMng, "store")
+    cMng.config.set_unresolved()
+
+    cMng.set_plugin_config_value("acme", "backend_path", "/srv/app")
+
+    assert not cMng.config.is_resolved()
+
+
+@pytest.mark.cfg
+def test_set_plugin_config_value_unknown_plugin_raises(mocker: MockerFixture):
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+"""
+    cMng = _load_config_manager_with_yaml(mocker, config_yaml)
+    mocker.patch.object(cMng, "store")
+
+    with pytest.raises(ValueError):
+        cMng.set_plugin_config_value("missing", "key", "value")
+
+    assert cMng.config.is_resolved()
+
+
 @pytest.mark.cfg
 def test_core_canonical_template_lookup(mocker: MockerFixture):
     cMng = _load_config_manager(mocker)

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -270,6 +270,7 @@ status:
     expected_obj.setdefault("ready", None)
     expected_obj.setdefault("tracking_remote", None)
     expected_obj.setdefault("dehydrated", None)
+    expected_obj.setdefault("config", None)
     y2: str = yaml.dump(expected_obj, sort_keys=True)
     assert y1 == y2
 
@@ -426,6 +427,7 @@ status:
     expected_obj.setdefault("ready", None)
     expected_obj.setdefault("tracking_remote", None)
     expected_obj.setdefault("dehydrated", None)
+    expected_obj.setdefault("config", None)
     y2: str = yaml.dump(expected_obj, sort_keys=True)
     assert y1 == y2
 


### PR DESCRIPTION
## Summary

Stacked on #282 (plugin config write-back) — this PR's diff includes that commit until #282 merges; only the second commit (`feat(config): add environment-scoped config values`) is new here.

- `EnvironmentCfg.config: Optional[dict[str, Any]]`, mirroring `PluginCfg.config`.
- `ConfigMng.set_environment_config_value(env_tag, key, value)`, same shape as `set_plugin_config_value`.
- `${VAR}` resolution: `Resolvable._walk_and_set` now merges, per `EnvironmentCfg` subtree, `plugin config default → environment config override`, then `user_values` is checked ahead of both (moved out of the flat resolver dict and threaded through as its own `_user_values` attribute so it can stay the final override regardless of which layer supplied a given key) → process environment variable fallback, unchanged.
- `PluginConfigView.set_environment_config_value` exposes the write to plugins.
- Docs + changelog updated.

Fixes #281

## Test plan

- [x] `cd src && pytest -m cfg` — 52 passed. New tests: env config overrides plugin config within its own subtree; env without config falls back to plugin config (regression guard); `user_values` still wins over env config; `set_environment_config_value` round-trips through `store`/reload; unknown env tag raises.
- [x] `cd src && pytest` (full suite) — 653 passed. Two existing snapshot tests (`test_store_config_with_real_files`, `test_store_config_with_refs_with_real_files`, `test_env_render_compose_env_ext_net`, `test_env_render_compose_env_resolved`) updated for the new `config: null` field in `EnvironmentCfg`'s serialized shape.
- [x] `cd src && pyright .` — 0 errors.
- [x] `pre-commit run --all-files` on changed files — all hooks pass.