### PR TITLE
feat(env): pull-feedback label and streaming progress bar during env start

### DIFF
--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -315,13 +315,19 @@ class DockerComposeEnv(Environment):
                 for k in rendered_map.keys()
                 if k in started_gate_keys or k == gate_key
             ]
-            cp = self._run_compose(
-                compose_stack,
-                "up",
-                "-d",
-                capture=not self._is_verbose(),
-                category=f"start:{gate_key}",
-            )
+            missing = self._find_missing_images()
+            if missing:
+                self.set_pull_state(missing)
+            try:
+                cp = self._run_compose(
+                    compose_stack,
+                    "up",
+                    "-d",
+                    capture=not self._is_verbose(),
+                    category=f"start:{gate_key}",
+                )
+            finally:
+                self.clear_pull_state()
             if cp.returncode != 0:
                 raise NonRecoverableStartError(
                     f"Failed to start gate '{gate_key}' "
@@ -809,6 +815,32 @@ class DockerComposeEnv(Environment):
             self.envCfg.tag,
         )
         return services
+
+    def _find_missing_images(self) -> list[tuple[str, str]]:
+        """Return (service_tag, image) pairs for images absent locally."""
+        entries: list[tuple[str, str]] = []
+        seen_images: set[str] = set()
+        for svc in self.services:
+            for container in svc.svcCfg.containers or []:
+                img = getattr(container, "image", None)
+                if not img or img in seen_images:
+                    continue
+                seen_images.add(img)
+                result = subprocess.run(
+                    [
+                        "docker",
+                        "image",
+                        "inspect",
+                        "--format",
+                        "{{.Id}}",
+                        img,
+                    ],
+                    capture_output=True,
+                    text=True,
+                )
+                if result.returncode != 0:
+                    entries.append((svc.svcCfg.tag, img))
+        return entries
 
     def _run_compose(
         self,

--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -35,60 +35,57 @@ from .docker_compose_util import (
     run_compose_pull_stream,
 )
 
-_PULL_LINE_RE = re.compile(
-    r"^\s*(?P<service>[\w.\-]+)\s+"
-    r"(?P<status>Pulling|Waiting|Downloading|Verifying Checksum|"
-    r"Download complete|Extracting|Pull complete|Pulled|Already exists)"
-    r"(?:\s+\[[^\]]*\]\s*(?P<current>[\d.]+\s*\w+)\s*/\s*"
-    r"(?P<total>[\d.]+\s*\w+))?"
+# `docker compose pull` output has no per-line service attribution: layer
+# lines are keyed by a short layer hash, not by service or image. Each
+# image's layers are bracketed by summary lines ("Image <ref> Pulling" /
+# "Image <ref> Pulled"), and compose pulls images sequentially, so we track
+# a "current image" and attribute layer lines to it on a best-effort basis.
+_PULL_IMAGE_LINE_RE = re.compile(
+    r"^\s*Image\s+(?P<image>\S+)\s+(?P<status>Pulling|Pulled)\s*$"
+)
+_PULL_LAYER_LINE_RE = re.compile(
+    r"^\s*(?P<layer>[0-9a-fA-F]{6,})\s+"
+    r"(?P<status>Pulling fs layer|Waiting|Downloading|"
+    r"Verifying Checksum|Download complete|Extracting|"
+    r"Pull complete|Already exists)"
 )
 
-_SIZE_RE = re.compile(r"^([\d.]+)\s*([a-zA-Z]+)$")
-_SIZE_UNITS = {
-    "b": 1,
-    "kb": 1_000,
-    "mb": 1_000_000,
-    "gb": 1_000_000_000,
-    "tb": 1_000_000_000_000,
-}
 
+class _PullProgressTracker:
+    """Stateful, best-effort parser for `docker compose pull` output."""
 
-def _parse_size(text: str) -> Optional[float]:
-    """Parse a docker-style size string (e.g. "12.3MB") into bytes."""
-    match = _SIZE_RE.match(text.strip())
-    if not match:
-        return None
-    value, unit = match.groups()
-    multiplier = _SIZE_UNITS.get(unit.lower())
-    if multiplier is None:
-        return None
-    return float(value) * multiplier
+    def __init__(self) -> None:
+        self._current_image: Optional[str] = None
+        self._layers_seen: set[str] = set()
+        self._layers_done: set[str] = set()
 
+    def parse(self, line: str) -> Optional[tuple[str, str, Optional[int]]]:
+        """Feed one output line; returns (image, status, percent) or
+        None if the line carries no attributable progress."""
+        image_match = _PULL_IMAGE_LINE_RE.match(line)
+        if image_match:
+            image = image_match.group("image")
+            status = image_match.group("status")
+            if status == "Pulling":
+                self._current_image = image
+                self._layers_seen = set()
+                self._layers_done = set()
+                return image, "pulling", None
+            self._current_image = None
+            return image, "pulled", 100
 
-def _parse_pull_progress_line(
-    line: str,
-) -> Optional[tuple[str, str, Optional[int]]]:
-    """Parse one line of `docker compose pull` output.
-
-    Returns (service, status, percent) or None if the line isn't a
-    recognized pull-progress line.
-    """
-    match = _PULL_LINE_RE.match(line)
-    if not match:
-        return None
-    service = match.group("service")
-    status = match.group("status")
-    percent: Optional[int] = None
-    current_raw = match.group("current")
-    total_raw = match.group("total")
-    if current_raw and total_raw:
-        current = _parse_size(current_raw)
-        total = _parse_size(total_raw)
-        if current is not None and total:
-            percent = max(0, min(100, round(current / total * 100)))
-    elif status in ("Pull complete", "Pulled", "Already exists"):
-        percent = 100
-    return service, status, percent
+        if not self._current_image:
+            return None
+        layer_match = _PULL_LAYER_LINE_RE.match(line)
+        if not layer_match:
+            return None
+        layer = layer_match.group("layer")
+        status = layer_match.group("status")
+        self._layers_seen.add(layer)
+        if status in ("Pull complete", "Already exists"):
+            self._layers_done.add(layer)
+        percent = round(len(self._layers_done) / len(self._layers_seen) * 100)
+        return self._current_image, status, percent
 
 
 def _is_bind_mount(vol: VolumeCfg) -> bool:
@@ -889,9 +886,16 @@ class DockerComposeEnv(Environment):
         )
         return services
 
-    def _find_missing_images(self) -> list[tuple[str, str]]:
-        """Return (service_tag, image) pairs for images absent locally."""
-        entries: list[tuple[str, str]] = []
+    def _find_missing_images(self) -> list[tuple[str, str, str]]:
+        """Return (service_tag, compose_service_key, image) triples for
+        images absent locally.
+
+        `compose_service_key` is `container.run_container_name`, the key
+        under which the container appears in the rendered compose YAML
+        (and therefore the argument `docker compose pull` expects) --
+        this is not the same as the shepherd service tag.
+        """
+        entries: list[tuple[str, str, str]] = []
         seen_images: set[str] = set()
         for svc in self.services:
             for container in svc.svcCfg.containers or []:
@@ -912,33 +916,39 @@ class DockerComposeEnv(Environment):
                     text=True,
                 )
                 if result.returncode != 0:
-                    entries.append((svc.svcCfg.tag, img))
+                    compose_service_key = container.run_container_name
+                    if not compose_service_key:
+                        continue
+                    entries.append((svc.svcCfg.tag, compose_service_key, img))
         return entries
 
     def _run_compose_pull_streaming(
         self,
         compose_stack: list[str],
-        missing: list[tuple[str, str]],
+        missing: list[tuple[str, str, str]],
         *,
         category: str,
     ) -> subprocess.CompletedProcess[str]:
         """Run `docker compose pull` for *missing* services, updating
         structured per-image pull progress as output streams in."""
-        service_to_image = {service: image for service, image in missing}
-        services = list(service_to_image.keys())
+        image_to_tag = {image: svc_tag for svc_tag, _, image in missing}
+        services = [
+            compose_service_key for _, compose_service_key, _ in missing
+        ]
+        tracker = _PullProgressTracker()
 
         def on_line(line: str) -> None:
-            parsed = _parse_pull_progress_line(line)
+            parsed = tracker.parse(line)
             if not parsed:
                 return
-            service, status, percent = parsed
-            image = service_to_image.get(service)
-            if not image:
+            image, status, percent = parsed
+            svc_tag = image_to_tag.get(image)
+            if not svc_tag:
                 return
             self.update_pull_progress(
                 image,
                 PullImageProgress(
-                    service=service,
+                    service=svc_tag,
                     image=image,
                     status=status,
                     percent=percent,

--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import subprocess
 import time
 from typing import IO, Any, Optional, cast, override
@@ -20,11 +21,74 @@ import yaml
 from config import ConfigMng, EnvironmentCfg
 from config.config import InitCfg, ProbeCfg, VolumeCfg
 from environment import Environment
-from environment.environment import NonRecoverableStartError, ProbeRunResult
+from environment.environment import (
+    NonRecoverableStartError,
+    ProbeRunResult,
+    PullImageProgress,
+)
 from service import ServiceFactory
 from util.util import Util
 
-from .docker_compose_util import render_container, run_compose
+from .docker_compose_util import (
+    render_container,
+    run_compose,
+    run_compose_pull_stream,
+)
+
+_PULL_LINE_RE = re.compile(
+    r"^\s*(?P<service>[\w.\-]+)\s+"
+    r"(?P<status>Pulling|Waiting|Downloading|Verifying Checksum|"
+    r"Download complete|Extracting|Pull complete|Pulled|Already exists)"
+    r"(?:\s+\[[^\]]*\]\s*(?P<current>[\d.]+\s*\w+)\s*/\s*"
+    r"(?P<total>[\d.]+\s*\w+))?"
+)
+
+_SIZE_RE = re.compile(r"^([\d.]+)\s*([a-zA-Z]+)$")
+_SIZE_UNITS = {
+    "b": 1,
+    "kb": 1_000,
+    "mb": 1_000_000,
+    "gb": 1_000_000_000,
+    "tb": 1_000_000_000_000,
+}
+
+
+def _parse_size(text: str) -> Optional[float]:
+    """Parse a docker-style size string (e.g. "12.3MB") into bytes."""
+    match = _SIZE_RE.match(text.strip())
+    if not match:
+        return None
+    value, unit = match.groups()
+    multiplier = _SIZE_UNITS.get(unit.lower())
+    if multiplier is None:
+        return None
+    return float(value) * multiplier
+
+
+def _parse_pull_progress_line(
+    line: str,
+) -> Optional[tuple[str, str, Optional[int]]]:
+    """Parse one line of `docker compose pull` output.
+
+    Returns (service, status, percent) or None if the line isn't a
+    recognized pull-progress line.
+    """
+    match = _PULL_LINE_RE.match(line)
+    if not match:
+        return None
+    service = match.group("service")
+    status = match.group("status")
+    percent: Optional[int] = None
+    current_raw = match.group("current")
+    total_raw = match.group("total")
+    if current_raw and total_raw:
+        current = _parse_size(current_raw)
+        total = _parse_size(total_raw)
+        if current is not None and total:
+            percent = max(0, min(100, round(current / total * 100)))
+    elif status in ("Pull complete", "Pulled", "Already exists"):
+        percent = 100
+    return service, status, percent
 
 
 def _is_bind_mount(vol: VolumeCfg) -> bool:
@@ -317,17 +381,26 @@ class DockerComposeEnv(Environment):
             ]
             missing = self._find_missing_images()
             if missing:
-                self.set_pull_state(missing)
-            try:
-                cp = self._run_compose(
-                    compose_stack,
-                    "up",
-                    "-d",
-                    capture=not self._is_verbose(),
-                    category=f"start:{gate_key}",
-                )
-            finally:
-                self.clear_pull_state()
+                try:
+                    pull_result = self._run_compose_pull_streaming(
+                        compose_stack,
+                        missing,
+                        category=f"pull:{gate_key}",
+                    )
+                finally:
+                    self.clear_pull_state()
+                if pull_result.returncode != 0:
+                    raise NonRecoverableStartError(
+                        f"Failed to pull images for gate '{gate_key}' "
+                        f"for environment '{self.envCfg.tag}'."
+                    )
+            cp = self._run_compose(
+                compose_stack,
+                "up",
+                "-d",
+                capture=not self._is_verbose(),
+                category=f"start:{gate_key}",
+            )
             if cp.returncode != 0:
                 raise NonRecoverableStartError(
                     f"Failed to start gate '{gate_key}' "
@@ -841,6 +914,49 @@ class DockerComposeEnv(Environment):
                 if result.returncode != 0:
                     entries.append((svc.svcCfg.tag, img))
         return entries
+
+    def _run_compose_pull_streaming(
+        self,
+        compose_stack: list[str],
+        missing: list[tuple[str, str]],
+        *,
+        category: str,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run `docker compose pull` for *missing* services, updating
+        structured per-image pull progress as output streams in."""
+        service_to_image = {service: image for service, image in missing}
+        services = list(service_to_image.keys())
+
+        def on_line(line: str) -> None:
+            parsed = _parse_pull_progress_line(line)
+            if not parsed:
+                return
+            service, status, percent = parsed
+            image = service_to_image.get(service)
+            if not image:
+                return
+            self.update_pull_progress(
+                image,
+                PullImageProgress(
+                    service=service,
+                    image=image,
+                    status=status,
+                    percent=percent,
+                ),
+            )
+
+        should_log = self.is_command_log_enabled()
+        result = run_compose_pull_stream(
+            compose_stack,
+            *services,
+            project_name=self.envCfg.tag,
+            on_line=on_line,
+        )
+        if should_log:
+            self._log_compose_result(result, category=category)
+        if result.returncode != 0:
+            self._record_compose_failure(result, category=category)
+        return result
 
     def _run_compose(
         self,

--- a/src/docker/docker_compose_util.py
+++ b/src/docker/docker_compose_util.py
@@ -122,6 +122,81 @@ def run_compose(
                 logging.debug(f"Failed to remove temp compose file {p}: {e}")
 
 
+def run_compose_pull_stream(
+    yamls: str | Iterable[str],
+    *services: str,
+    project_name: Optional[str] = None,
+    on_line: Optional[Callable[[str], None]] = None,
+) -> subprocess.CompletedProcess[str]:
+    """
+    Run `docker compose pull <services>` streaming stdout line-by-line.
+
+    Each decoded line is passed to `on_line` as it arrives, so callers can
+    parse per-image pull progress while the command is still running.
+    """
+    if isinstance(yamls, str):
+        yaml_list = [yamls]
+    else:
+        yaml_list = list(yamls)
+
+    if not yaml_list:
+        raise ValueError(
+            "run_compose_pull_stream: at least one YAML must be provided"
+        )
+
+    tmp_paths: list[Path] = []
+    try:
+        for yml in yaml_list:
+            with tempfile.NamedTemporaryFile(
+                "w", suffix=".yml", delete=False
+            ) as tmp:
+                tmp.write(yml)
+                tmp_paths.append(Path(tmp.name))
+
+        cmd: list[str] = ["docker", "compose"]
+        if project_name:
+            cmd += ["-p", project_name]
+        for p in tmp_paths:
+            cmd += ["-f", str(p)]
+        cmd += ["pull", *services]
+
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        lines: list[str] = []
+        assert proc.stdout is not None
+        for raw_line in proc.stdout:
+            line = raw_line.rstrip("\n")
+            lines.append(line)
+            if on_line:
+                try:
+                    on_line(line)
+                except Exception as e:
+                    logging.debug("Failed handling pull progress line: %s", e)
+        returncode = proc.wait()
+
+        logging.debug(
+            f"docker compose pull command run:\n"
+            f"CMD: {' '.join(cmd)}\n"
+            f"with exit code {returncode}\n"
+            f"OUTPUT:\n{chr(10).join(lines)}"
+        )
+
+        return subprocess.CompletedProcess(
+            cmd, returncode=returncode, stdout="\n".join(lines), stderr=""
+        )
+    finally:
+        for p in tmp_paths:
+            try:
+                p.unlink(missing_ok=True)
+            except Exception as e:
+                logging.debug(f"Failed to remove temp compose file {p}: {e}")
+
+
 def build_docker_image(
     dockerfile_path: Path,
     context_path: Path,

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -59,6 +59,17 @@ class ProbeRunResult:
     timed_out: bool = False
 
 
+@dataclass
+class PullImageProgress:
+    """Streaming pull state for a single image, keyed by image in
+    ``Environment._pull_state``."""
+
+    service: str
+    image: str
+    status: str
+    percent: Optional[int] = None
+
+
 class NonRecoverableStartError(RuntimeError):
     """Raised when environment start cannot continue safely."""
 
@@ -99,7 +110,7 @@ class Environment(ABC):
         self._command_log_lock = threading.Lock()
         self._command_error_lock = threading.Lock()
         self._command_error: Optional[dict[str, str]] = None
-        self._pull_state: list[tuple[str, str]] = []
+        self._pull_state: dict[str, PullImageProgress] = {}
         self._pull_state_lock = threading.Lock()
 
     def _is_verbose(self) -> bool:
@@ -233,20 +244,27 @@ class Environment(ABC):
         with self._command_error_lock:
             self._command_error = None
 
-    def set_pull_state(self, entries: list[tuple[str, str]]) -> None:
-        """Record (service, image) pairs currently being pulled."""
+    def set_pull_state(self, entries: dict[str, PullImageProgress]) -> None:
+        """Replace the current pull state (keyed by image)."""
         with self._pull_state_lock:
-            self._pull_state = list(entries)
+            self._pull_state = dict(entries)
 
-    def get_pull_state(self) -> list[tuple[str, str]]:
+    def update_pull_progress(
+        self, image: str, progress: PullImageProgress
+    ) -> None:
+        """Update the progress entry for a single image being pulled."""
+        with self._pull_state_lock:
+            self._pull_state[image] = progress
+
+    def get_pull_state(self) -> dict[str, PullImageProgress]:
         """Return a snapshot of the current pull state."""
         with self._pull_state_lock:
-            return list(self._pull_state)
+            return dict(self._pull_state)
 
     def clear_pull_state(self) -> None:
         """Clear the current pull state."""
         with self._pull_state_lock:
-            self._pull_state = []
+            self._pull_state = {}
 
     def get_command_error(self) -> Optional[dict[str, str]]:
         with self._command_error_lock:

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -99,6 +99,8 @@ class Environment(ABC):
         self._command_log_lock = threading.Lock()
         self._command_error_lock = threading.Lock()
         self._command_error: Optional[dict[str, str]] = None
+        self._pull_state: list[tuple[str, str]] = []
+        self._pull_state_lock = threading.Lock()
 
     def _is_verbose(self) -> bool:
         return bool(self.cli_flags.get("verbose", False))
@@ -133,6 +135,7 @@ class Environment(ABC):
         """
         self.clear_command_log()
         self.clear_command_error()
+        self.clear_pull_state()
         self.on_start_cycle_begin()
         self.envCfg.status.rendered_config = self.render_target(True)
         self.sync_config()
@@ -229,6 +232,21 @@ class Environment(ABC):
     def clear_command_error(self) -> None:
         with self._command_error_lock:
             self._command_error = None
+
+    def set_pull_state(self, entries: list[tuple[str, str]]) -> None:
+        """Record (service, image) pairs currently being pulled."""
+        with self._pull_state_lock:
+            self._pull_state = list(entries)
+
+    def get_pull_state(self) -> list[tuple[str, str]]:
+        """Return a snapshot of the current pull state."""
+        with self._pull_state_lock:
+            return list(self._pull_state)
+
+    def clear_pull_state(self) -> None:
+        """Clear the current pull state."""
+        with self._pull_state_lock:
+            self._pull_state = []
 
     def get_command_error(self) -> Optional[dict[str, str]]:
         with self._command_error_lock:

--- a/src/environment/status_wait.py
+++ b/src/environment/status_wait.py
@@ -43,6 +43,23 @@ TRANSITION_FLASH_DURATION_SECONDS = 1.5
 READY_HIGHLIGHT_DURATION_SECONDS = 3.0
 
 
+def _image_basename(image: str) -> str:
+    """Return the short name of a docker image reference (drop registry)."""
+    return image.rsplit("/", 1)[-1]
+
+
+def _merge_pull_into_grouped(
+    grouped: GroupedStatus,
+    pull_state: list[tuple[str, str]],
+) -> GroupedStatus:
+    """Override rows for services that are currently pulling images."""
+    merged = dict(grouped)
+    for service, image in pull_state:
+        state = f"[dim]pulling[/dim] [dim cyan]({image})[/dim cyan]"
+        merged[service] = [["-", _image_basename(image), state]]
+    return merged
+
+
 def render_moving_shadow_text(
     phrase: str,
     tick: int,
@@ -384,6 +401,10 @@ def wait_for_env_state(
         # Used only when there is not yet a stable table snapshot to render,
         # or when an in-flight action would make an empty snapshot misleading.
         title = f"[white]{env.envCfg.tag}[/white]"
+        pull_state = env.get_pull_state()
+        if pull_state:
+            images = ", ".join(image for _, image in pull_state)
+            return f"{title} [dim]Pulling {images}...[/dim]"
         if wait_until_up:
             return f"{title} {starting_suffix(remaining, tick)}"
         if remaining is not None:
@@ -676,12 +697,18 @@ def wait_for_env_state(
                         )
                         return
                 else:
+                    display_grouped = snap_grouped
+                    pull_state = env.get_pull_state()
+                    if pull_state:
+                        display_grouped = _merge_pull_into_grouped(
+                            snap_grouped, pull_state
+                        )
                     show_ready = wait_until_up and condition_met(
                         snap_all_running, snap_any_running, snap_gate_status
                     )
                     live.update(
                         build_status_renderable(
-                            snap_grouped,
+                            display_grouped,
                             remaining=remaining,
                             tick=ui_tick_count,
                             show_ready=show_ready,

--- a/src/environment/status_wait.py
+++ b/src/environment/status_wait.py
@@ -11,7 +11,7 @@ import logging
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Callable, Optional, TypeAlias
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeAlias
 
 from rich.console import Group
 from rich.live import Live
@@ -24,6 +24,9 @@ from environment.render import (
     build_probe_status_tree,
 )
 from util.util import Util
+
+if TYPE_CHECKING:
+    from environment.environment import PullImageProgress
 
 GroupedStatus: TypeAlias = dict[str, list[list[str]]]
 GateStatus: TypeAlias = dict[str, Optional[bool]]
@@ -48,15 +51,27 @@ def _image_basename(image: str) -> str:
     return image.rsplit("/", 1)[-1]
 
 
+def _render_pull_bar(percent: Optional[int], width: int = 10) -> str:
+    """Render a simple block-character progress bar for a pull percentage."""
+    if percent is None:
+        return ""
+    filled = max(0, min(width, round(width * percent / 100)))
+    bar = "█" * filled + "░" * (width - filled)
+    return f"[dim cyan]{bar}[/dim cyan] {percent}%"
+
+
 def _merge_pull_into_grouped(
     grouped: GroupedStatus,
-    pull_state: list[tuple[str, str]],
+    pull_state: dict[str, "PullImageProgress"],
 ) -> GroupedStatus:
     """Override rows for services that are currently pulling images."""
     merged = dict(grouped)
-    for service, image in pull_state:
-        state = f"[dim]pulling[/dim] [dim cyan]({image})[/dim cyan]"
-        merged[service] = [["-", _image_basename(image), state]]
+    for image, progress in pull_state.items():
+        bar = _render_pull_bar(progress.percent)
+        status = f"[dim]{progress.status.lower()}[/dim]"
+        suffix = f" {bar}" if bar else ""
+        state = f"{status}{suffix} [dim cyan]({image})[/dim cyan]"
+        merged[progress.service] = [["-", _image_basename(image), state]]
     return merged
 
 
@@ -403,8 +418,15 @@ def wait_for_env_state(
         title = f"[white]{env.envCfg.tag}[/white]"
         pull_state = env.get_pull_state()
         if pull_state:
-            images = ", ".join(image for _, image in pull_state)
-            return f"{title} [dim]Pulling {images}...[/dim]"
+            labels: list[str] = []
+            for image, progress in pull_state.items():
+                pct = (
+                    f" {progress.percent}%"
+                    if progress.percent is not None
+                    else ""
+                )
+                labels.append(f"{image}{pct}")
+            return f"{title} [dim]Pulling {', '.join(labels)}...[/dim]"
         if wait_until_up:
             return f"{title} {starting_suffix(remaining, tick)}"
         if remaining is not None:

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -821,6 +821,196 @@ def test_start_impl_records_compose_failure_output(mocker: MockerFixture):
 
 
 @pytest.mark.docker
+def test_pull_state_round_trip(mocker: MockerFixture) -> None:
+    env_cfg = SimpleNamespace(tag="test-env", services=[], volumes=[])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+
+    assert env.get_pull_state() == []
+
+    env.set_pull_state([("web", "nginx:latest"), ("db", "postgres:14")])
+    assert env.get_pull_state() == [
+        ("web", "nginx:latest"),
+        ("db", "postgres:14"),
+    ]
+
+    env.clear_pull_state()
+    assert env.get_pull_state() == []
+
+
+@pytest.mark.docker
+def test_find_missing_images_returns_absent_images(
+    mocker: MockerFixture,
+) -> None:
+    env_cfg = SimpleNamespace(tag="test-env", services=[], volumes=[])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    env.services = [
+        SimpleNamespace(
+            svcCfg=SimpleNamespace(
+                tag="db",
+                containers=[SimpleNamespace(image="postgres:14")],
+            )
+        ),
+        SimpleNamespace(
+            svcCfg=SimpleNamespace(
+                tag="cache",
+                containers=[SimpleNamespace(image="redis:7")],
+            )
+        ),
+    ]
+
+    def fake_inspect(
+        *args: Any, **kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        cmd = args[0] if args else []
+        image = cmd[-1]
+        returncode = 0 if image == "postgres:14" else 1
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=returncode, stdout="", stderr=""
+        )
+
+    mocker.patch(
+        "docker.docker_compose_env.subprocess.run", side_effect=fake_inspect
+    )
+
+    missing = env._find_missing_images()
+
+    assert missing == [("cache", "redis:7")]
+
+
+@pytest.mark.docker
+def test_find_missing_images_deduplicates_shared_images(
+    mocker: MockerFixture,
+) -> None:
+    """The same image used by two services is only inspected once."""
+    env_cfg = SimpleNamespace(tag="test-env", services=[], volumes=[])
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    env.services = [
+        SimpleNamespace(
+            svcCfg=SimpleNamespace(
+                tag="svc1",
+                containers=[SimpleNamespace(image="nginx:latest")],
+            )
+        ),
+        SimpleNamespace(
+            svcCfg=SimpleNamespace(
+                tag="svc2",
+                containers=[SimpleNamespace(image="nginx:latest")],
+            )
+        ),
+    ]
+
+    mock_run = mocker.patch(
+        "docker.docker_compose_env.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr=""
+        ),
+    )
+
+    missing = env._find_missing_images()
+
+    assert missing == [("svc1", "nginx:latest")]
+    assert mock_run.call_count == 1
+
+
+@pytest.mark.docker
+def test_start_impl_sets_and_clears_pull_state_on_success(
+    mocker: MockerFixture,
+) -> None:
+    env_cfg = SimpleNamespace(
+        tag="pull-env",
+        services=[],
+        volumes=[],
+        status=SimpleNamespace(
+            rendered_config={
+                "ungated": "name: pull-env\nservices: {}\n",
+            }
+        ),
+    )
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    env.services = [
+        SimpleNamespace(
+            svcCfg=SimpleNamespace(
+                tag="web",
+                containers=[SimpleNamespace(image="nginx:latest")],
+            )
+        ),
+    ]
+    mocker.patch(
+        "docker.docker_compose_env.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr=""
+        ),
+    )
+
+    seen_pull_state: list[tuple[str, str]] = []
+
+    def fake_run_compose(
+        *args: Any, **kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        seen_pull_state.extend(env.get_pull_state())
+        return subprocess.CompletedProcess(
+            args=["docker", "compose", "up", "-d"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+    mocker.patch(
+        "docker.docker_compose_env.run_compose", side_effect=fake_run_compose
+    )
+
+    env.start_impl(started_gate_keys=set(), probe_results=None)
+
+    assert seen_pull_state == [("web", "nginx:latest")]
+    assert env.get_pull_state() == []
+
+
+@pytest.mark.docker
+def test_start_impl_clears_pull_state_on_failure(
+    mocker: MockerFixture,
+) -> None:
+    env_cfg = SimpleNamespace(
+        tag="pull-fail-env",
+        services=[],
+        volumes=[],
+        status=SimpleNamespace(
+            rendered_config={
+                "ungated": "name: pull-fail-env\nservices: {}\n",
+            }
+        ),
+    )
+    env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
+    env.services = [
+        SimpleNamespace(
+            svcCfg=SimpleNamespace(
+                tag="web",
+                containers=[SimpleNamespace(image="nginx:latest")],
+            )
+        ),
+    ]
+    mocker.patch(
+        "docker.docker_compose_env.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr=""
+        ),
+    )
+    mocker.patch(
+        "docker.docker_compose_env.run_compose",
+        return_value=subprocess.CompletedProcess(
+            args=["docker", "compose", "up", "-d"],
+            returncode=1,
+            stdout="",
+            stderr="",
+        ),
+    )
+
+    with pytest.raises(NonRecoverableStartError):
+        env.start_impl(started_gate_keys=set(), probe_results=None)
+
+    assert env.get_pull_state() == []
+
+
+@pytest.mark.docker
 def test_start_rolls_back_with_stop_on_non_recoverable_gate_failure(
     mocker: MockerFixture,
 ):

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -20,8 +20,15 @@ from click.testing import CliRunner
 from pytest_mock import MockerFixture
 from test_util import read_fixture
 
-from docker.docker_compose_env import DockerComposeEnv
-from environment.environment import NonRecoverableStartError, ProbeRunResult
+from docker.docker_compose_env import (
+    DockerComposeEnv,
+    _parse_pull_progress_line,
+)
+from environment.environment import (
+    NonRecoverableStartError,
+    ProbeRunResult,
+    PullImageProgress,
+)
 from shepctl import ShepherdMng, cli
 from util import Util
 
@@ -820,21 +827,60 @@ def test_start_impl_records_compose_failure_output(mocker: MockerFixture):
     assert "--- stderr ---" in err["body"]
 
 
+def test_parse_pull_progress_line_extracts_percent_from_size() -> None:
+    parsed = _parse_pull_progress_line(
+        "web Downloading [====>          ]  10MB/40MB"
+    )
+    assert parsed == ("web", "Downloading", 25)
+
+
+def test_parse_pull_progress_line_without_size_has_no_percent() -> None:
+    parsed = _parse_pull_progress_line("web Pulling")
+    assert parsed == ("web", "Pulling", None)
+
+
+def test_parse_pull_progress_line_terminal_status_is_100_percent() -> None:
+    assert _parse_pull_progress_line("web Pull complete") == (
+        "web",
+        "Pull complete",
+        100,
+    )
+    assert _parse_pull_progress_line("web Already exists") == (
+        "web",
+        "Already exists",
+        100,
+    )
+
+
+def test_parse_pull_progress_line_ignores_unrecognized_lines() -> None:
+    assert _parse_pull_progress_line("[+] Pulling 2/2") is None
+    assert _parse_pull_progress_line("") is None
+
+
 @pytest.mark.docker
 def test_pull_state_round_trip(mocker: MockerFixture) -> None:
     env_cfg = SimpleNamespace(tag="test-env", services=[], volumes=[])
     env = DockerComposeEnv(mocker.Mock(), mocker.Mock(), env_cfg)
 
-    assert env.get_pull_state() == []
+    assert env.get_pull_state() == {}
 
-    env.set_pull_state([("web", "nginx:latest"), ("db", "postgres:14")])
-    assert env.get_pull_state() == [
-        ("web", "nginx:latest"),
-        ("db", "postgres:14"),
-    ]
+    web_progress = PullImageProgress(
+        service="web", image="nginx:latest", status="Pulling", percent=None
+    )
+    env.set_pull_state({"nginx:latest": web_progress})
+    assert env.get_pull_state() == {"nginx:latest": web_progress}
+
+    db_progress = PullImageProgress(
+        service="db", image="postgres:14", status="Downloading", percent=42
+    )
+    env.update_pull_progress("postgres:14", db_progress)
+    assert env.get_pull_state() == {
+        "nginx:latest": web_progress,
+        "postgres:14": db_progress,
+    }
 
     env.clear_pull_state()
-    assert env.get_pull_state() == []
+    assert env.get_pull_state() == {}
 
 
 @pytest.mark.docker
@@ -913,7 +959,7 @@ def test_find_missing_images_deduplicates_shared_images(
 
 
 @pytest.mark.docker
-def test_start_impl_sets_and_clears_pull_state_on_success(
+def test_start_impl_pulls_missing_images_with_progress_before_up(
     mocker: MockerFixture,
 ) -> None:
     env_cfg = SimpleNamespace(
@@ -942,31 +988,51 @@ def test_start_impl_sets_and_clears_pull_state_on_success(
         ),
     )
 
-    seen_pull_state: list[tuple[str, str]] = []
+    seen_pull_state: list[dict[str, Any]] = []
 
-    def fake_run_compose(
-        *args: Any, **kwargs: Any
+    def fake_pull_stream(
+        yamls: Any,
+        *services: str,
+        project_name: Any = None,
+        on_line: Any = None,
     ) -> subprocess.CompletedProcess[str]:
-        seen_pull_state.extend(env.get_pull_state())
+        assert services == ("web",)
+        if on_line:
+            on_line("web Downloading [==========>                ]  10MB/20MB")
+            seen_pull_state.append(dict(env.get_pull_state()))
         return subprocess.CompletedProcess(
-            args=["docker", "compose", "up", "-d"],
+            args=["docker", "compose", "pull", "web"],
             returncode=0,
             stdout="",
             stderr="",
         )
 
     mocker.patch(
-        "docker.docker_compose_env.run_compose", side_effect=fake_run_compose
+        "docker.docker_compose_env.run_compose_pull_stream",
+        side_effect=fake_pull_stream,
+    )
+    mocker.patch(
+        "docker.docker_compose_env.run_compose",
+        return_value=subprocess.CompletedProcess(
+            args=["docker", "compose", "up", "-d"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        ),
     )
 
     env.start_impl(started_gate_keys=set(), probe_results=None)
 
-    assert seen_pull_state == [("web", "nginx:latest")]
-    assert env.get_pull_state() == []
+    assert len(seen_pull_state) == 1
+    progress = seen_pull_state[0]["nginx:latest"]
+    assert progress.service == "web"
+    assert progress.status == "Downloading"
+    assert progress.percent == 50
+    assert env.get_pull_state() == {}
 
 
 @pytest.mark.docker
-def test_start_impl_clears_pull_state_on_failure(
+def test_start_impl_clears_pull_state_on_pull_failure(
     mocker: MockerFixture,
 ) -> None:
     env_cfg = SimpleNamespace(
@@ -995,19 +1061,19 @@ def test_start_impl_clears_pull_state_on_failure(
         ),
     )
     mocker.patch(
-        "docker.docker_compose_env.run_compose",
+        "docker.docker_compose_env.run_compose_pull_stream",
         return_value=subprocess.CompletedProcess(
-            args=["docker", "compose", "up", "-d"],
+            args=["docker", "compose", "pull", "web"],
             returncode=1,
             stdout="",
-            stderr="",
+            stderr="pull failed",
         ),
     )
 
     with pytest.raises(NonRecoverableStartError):
         env.start_impl(started_gate_keys=set(), probe_results=None)
 
-    assert env.get_pull_state() == []
+    assert env.get_pull_state() == {}
 
 
 @pytest.mark.docker

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -20,10 +20,7 @@ from click.testing import CliRunner
 from pytest_mock import MockerFixture
 from test_util import read_fixture
 
-from docker.docker_compose_env import (
-    DockerComposeEnv,
-    _parse_pull_progress_line,
-)
+from docker.docker_compose_env import DockerComposeEnv, _PullProgressTracker
 from environment.environment import (
     NonRecoverableStartError,
     ProbeRunResult,
@@ -827,34 +824,66 @@ def test_start_impl_records_compose_failure_output(mocker: MockerFixture):
     assert "--- stderr ---" in err["body"]
 
 
-def test_parse_pull_progress_line_extracts_percent_from_size() -> None:
-    parsed = _parse_pull_progress_line(
-        "web Downloading [====>          ]  10MB/40MB"
+# Captured from a real `docker compose pull` run (compose v5.4.0 / Docker
+# 29.7.1) against a single-image, multi-layer pull. Layer lines are keyed
+# by a short hash, not by service/image -- only the "Image ... Pulling/
+# Pulled" bookends name the image, hence the stateful tracker.
+_REAL_PULL_OUTPUT = [
+    " Image nginx:alpine Pulling ",
+    " 3cd534fe98c6 Pulling fs layer 0B",
+    " 1223f016b4e4 Pulling fs layer 0B",
+    " 3cd534fe98c6 Downloading 32.16kB",
+    " 3cd534fe98c6 Download complete 0B",
+    " 3cd534fe98c6 Extracting 1.891MB",
+    " 3cd534fe98c6 Pull complete 0B",
+    " 1223f016b4e4 Download complete 0B",
+    " 1223f016b4e4 Extracting 627B",
+    " 1223f016b4e4 Pull complete 0B",
+    " Image nginx:alpine Pulled ",
+]
+
+
+def test_pull_progress_tracker_tracks_current_image_bookends() -> None:
+    tracker = _PullProgressTracker()
+
+    assert tracker.parse(" Image nginx:alpine Pulling ") == (
+        "nginx:alpine",
+        "pulling",
+        None,
     )
-    assert parsed == ("web", "Downloading", 25)
-
-
-def test_parse_pull_progress_line_without_size_has_no_percent() -> None:
-    parsed = _parse_pull_progress_line("web Pulling")
-    assert parsed == ("web", "Pulling", None)
-
-
-def test_parse_pull_progress_line_terminal_status_is_100_percent() -> None:
-    assert _parse_pull_progress_line("web Pull complete") == (
-        "web",
-        "Pull complete",
+    assert tracker.parse(" Image nginx:alpine Pulled ") == (
+        "nginx:alpine",
+        "pulled",
         100,
     )
-    assert _parse_pull_progress_line("web Already exists") == (
-        "web",
-        "Already exists",
-        100,
-    )
 
 
-def test_parse_pull_progress_line_ignores_unrecognized_lines() -> None:
-    assert _parse_pull_progress_line("[+] Pulling 2/2") is None
-    assert _parse_pull_progress_line("") is None
+def test_pull_progress_tracker_ignores_layer_lines_before_pulling() -> None:
+    tracker = _PullProgressTracker()
+    assert tracker.parse(" 3cd534fe98c6 Downloading 32.16kB") is None
+
+
+def test_pull_progress_tracker_percent_reflects_completed_layer_fraction() -> (
+    None
+):
+    tracker = _PullProgressTracker()
+    results = [tracker.parse(line) for line in _REAL_PULL_OUTPUT]
+    non_none = [r for r in results if r is not None]
+
+    assert non_none[0] == ("nginx:alpine", "pulling", None)
+    assert non_none[-1] == ("nginx:alpine", "pulled", 100)
+
+    # After the first layer's "Pull complete", 1 of 2 seen layers is done.
+    pull_complete_events = [r for r in non_none if r[1] == "Pull complete"]
+    assert pull_complete_events[0] == ("nginx:alpine", "Pull complete", 50)
+    assert pull_complete_events[1] == ("nginx:alpine", "Pull complete", 100)
+
+
+def test_pull_progress_tracker_ignores_unrecognized_lines() -> None:
+    tracker = _PullProgressTracker()
+    tracker._current_image = "nginx:alpine"
+    assert tracker.parse("[+] Pulling 2/2") is None
+    assert tracker.parse("") is None
 
 
 @pytest.mark.docker
@@ -893,13 +922,23 @@ def test_find_missing_images_returns_absent_images(
         SimpleNamespace(
             svcCfg=SimpleNamespace(
                 tag="db",
-                containers=[SimpleNamespace(image="postgres:14")],
+                containers=[
+                    SimpleNamespace(
+                        image="postgres:14",
+                        run_container_name="db-db-test-env",
+                    )
+                ],
             )
         ),
         SimpleNamespace(
             svcCfg=SimpleNamespace(
                 tag="cache",
-                containers=[SimpleNamespace(image="redis:7")],
+                containers=[
+                    SimpleNamespace(
+                        image="redis:7",
+                        run_container_name="cache-cache-test-env",
+                    )
+                ],
             )
         ),
     ]
@@ -920,7 +959,7 @@ def test_find_missing_images_returns_absent_images(
 
     missing = env._find_missing_images()
 
-    assert missing == [("cache", "redis:7")]
+    assert missing == [("cache", "cache-cache-test-env", "redis:7")]
 
 
 @pytest.mark.docker
@@ -934,13 +973,23 @@ def test_find_missing_images_deduplicates_shared_images(
         SimpleNamespace(
             svcCfg=SimpleNamespace(
                 tag="svc1",
-                containers=[SimpleNamespace(image="nginx:latest")],
+                containers=[
+                    SimpleNamespace(
+                        image="nginx:latest",
+                        run_container_name="svc1-svc1-test-env",
+                    )
+                ],
             )
         ),
         SimpleNamespace(
             svcCfg=SimpleNamespace(
                 tag="svc2",
-                containers=[SimpleNamespace(image="nginx:latest")],
+                containers=[
+                    SimpleNamespace(
+                        image="nginx:latest",
+                        run_container_name="svc2-svc2-test-env",
+                    )
+                ],
             )
         ),
     ]
@@ -954,7 +1003,7 @@ def test_find_missing_images_deduplicates_shared_images(
 
     missing = env._find_missing_images()
 
-    assert missing == [("svc1", "nginx:latest")]
+    assert missing == [("svc1", "svc1-svc1-test-env", "nginx:latest")]
     assert mock_run.call_count == 1
 
 
@@ -977,7 +1026,12 @@ def test_start_impl_pulls_missing_images_with_progress_before_up(
         SimpleNamespace(
             svcCfg=SimpleNamespace(
                 tag="web",
-                containers=[SimpleNamespace(image="nginx:latest")],
+                containers=[
+                    SimpleNamespace(
+                        image="nginx:latest",
+                        run_container_name="nginx-web-pull-env",
+                    )
+                ],
             )
         ),
     ]
@@ -996,12 +1050,14 @@ def test_start_impl_pulls_missing_images_with_progress_before_up(
         project_name: Any = None,
         on_line: Any = None,
     ) -> subprocess.CompletedProcess[str]:
-        assert services == ("web",)
+        assert services == ("nginx-web-pull-env",)
         if on_line:
-            on_line("web Downloading [==========>                ]  10MB/20MB")
+            on_line(" Image nginx:latest Pulling ")
+            on_line(" abc123 Pulling fs layer 0B")
+            on_line(" abc123 Downloading 10MB")
             seen_pull_state.append(dict(env.get_pull_state()))
         return subprocess.CompletedProcess(
-            args=["docker", "compose", "pull", "web"],
+            args=["docker", "compose", "pull", "nginx-web-pull-env"],
             returncode=0,
             stdout="",
             stderr="",
@@ -1027,7 +1083,7 @@ def test_start_impl_pulls_missing_images_with_progress_before_up(
     progress = seen_pull_state[0]["nginx:latest"]
     assert progress.service == "web"
     assert progress.status == "Downloading"
-    assert progress.percent == 50
+    assert progress.percent == 0
     assert env.get_pull_state() == {}
 
 
@@ -1050,7 +1106,12 @@ def test_start_impl_clears_pull_state_on_pull_failure(
         SimpleNamespace(
             svcCfg=SimpleNamespace(
                 tag="web",
-                containers=[SimpleNamespace(image="nginx:latest")],
+                containers=[
+                    SimpleNamespace(
+                        image="nginx:latest",
+                        run_container_name="nginx-web-pull-fail-env",
+                    )
+                ],
             )
         ),
     ]
@@ -1063,7 +1124,7 @@ def test_start_impl_clears_pull_state_on_pull_failure(
     mocker.patch(
         "docker.docker_compose_env.run_compose_pull_stream",
         return_value=subprocess.CompletedProcess(
-            args=["docker", "compose", "pull", "web"],
+            args=["docker", "compose", "pull", "nginx-web-pull-fail-env"],
             returncode=1,
             stdout="",
             stderr="pull failed",

--- a/src/tests/test_environment_mng.py
+++ b/src/tests/test_environment_mng.py
@@ -18,7 +18,11 @@ from rich.panel import Panel
 from rich.text import Text
 from rich.tree import Tree
 
-from environment.environment import EnvironmentMng, ProbeRunResult
+from environment.environment import (
+    EnvironmentMng,
+    ProbeRunResult,
+    PullImageProgress,
+)
 from environment.render import (
     build_env_details_tree,
     build_env_status_tree,
@@ -28,6 +32,7 @@ from environment.status_wait import (
     WaitForEnvStateHooks,
     _image_basename,
     _merge_pull_into_grouped,
+    _render_pull_bar,
     render_moving_shadow_text,
     wait_for_env_state,
     watch_probe_state,
@@ -567,6 +572,17 @@ def test_check_probes_renders_probe_status_tree(mocker: MockerFixture):
     fake_console.print.assert_called_once_with("probe-tree")
 
 
+def test_render_pull_bar_none_percent_is_empty():
+    assert _render_pull_bar(None) == ""
+
+
+def test_render_pull_bar_scales_filled_blocks():
+    bar = _render_pull_bar(50, width=10)
+    assert bar.count("█") == 5
+    assert bar.count("░") == 5
+    assert "50%" in bar
+
+
 def test_image_basename_strips_registry_prefix():
     assert _image_basename("nginx:latest") == "nginx:latest"
     assert _image_basename("docker.io/library/postgres:14") == "postgres:14"
@@ -577,12 +593,21 @@ def test_merge_pull_into_grouped_overrides_pulling_services():
         "web": [["-", "nginx", "[dim]stopped[/dim]"]],
         "db": [["-", "postgres", "[dim]stopped[/dim]"]],
     }
+    pull_state = {
+        "nginx:latest": PullImageProgress(
+            service="web",
+            image="nginx:latest",
+            status="Downloading",
+            percent=50,
+        )
+    }
 
-    merged = _merge_pull_into_grouped(grouped, [("web", "nginx:latest")])
+    merged = _merge_pull_into_grouped(grouped, pull_state)
 
     assert set(merged.keys()) == {"web", "db"}
     web_row = merged["web"][0]
-    assert "pulling" in web_row[2]
+    assert "downloading" in web_row[2]
+    assert "50%" in web_row[2]
     assert "nginx:latest" in web_row[2]
     assert web_row[1] == "nginx:latest"
     assert merged["db"] == grouped["db"]
@@ -591,7 +616,7 @@ def test_merge_pull_into_grouped_overrides_pulling_services():
 def test_merge_pull_into_grouped_noop_when_no_pull_state():
     grouped = {"web": [["-", "nginx", "[dim]stopped[/dim]"]]}
 
-    merged = _merge_pull_into_grouped(grouped, [])
+    merged = _merge_pull_into_grouped(grouped, {})
 
     assert merged == grouped
 

--- a/src/tests/test_environment_mng.py
+++ b/src/tests/test_environment_mng.py
@@ -26,6 +26,8 @@ from environment.render import (
 )
 from environment.status_wait import (
     WaitForEnvStateHooks,
+    _image_basename,
+    _merge_pull_into_grouped,
     render_moving_shadow_text,
     wait_for_env_state,
     watch_probe_state,
@@ -50,6 +52,7 @@ def test_wait_for_env_up_does_not_exit_while_starting(mocker: MockerFixture):
 
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
 
     status_samples: list[
         tuple[dict[str, list[list[str]]], bool, bool, bool]
@@ -99,6 +102,7 @@ def test_wait_for_env_up_propagates_action_error(mocker: MockerFixture):
 
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
     env.get_services.return_value = []
     mocker.patch.object(
         mng, "_collect_env_status", return_value=({}, False, False, False)
@@ -121,6 +125,7 @@ def test_wait_for_env_up_timeout_calls_print_error(mocker: MockerFixture):
 
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
     env.get_services.return_value = []
 
     fake_console = mocker.Mock()
@@ -145,6 +150,7 @@ def test_wait_for_env_down_timeout_calls_print_error(mocker: MockerFixture):
 
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
     env.get_services.return_value = []
 
     fake_console = mocker.Mock()
@@ -168,6 +174,7 @@ def test_wait_for_env_down_hides_gates_column(mocker: MockerFixture):
     setattr(mng, "_status_poll_seconds", 0.001)
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
     env.get_services.return_value = []
 
     fake_console = mocker.Mock()
@@ -225,6 +232,7 @@ def test_wait_for_env_up_non_terminal_waits_for_running_state(
     setattr(mng, "_status_poll_seconds", 0.001)
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
     env.get_services.return_value = []
 
     status_samples: list[
@@ -272,6 +280,7 @@ def test_wait_for_env_down_non_terminal_waits_for_stopped_state(
     setattr(mng, "_status_poll_seconds", 0.001)
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
     env.get_services.return_value = []
 
     status_samples: list[
@@ -319,6 +328,7 @@ def test_wait_for_env_up_quiet_still_polls_until_running(
     setattr(mng, "_status_poll_seconds", 0.001)
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
     env.get_services.return_value = []
 
     status_samples: list[
@@ -363,6 +373,7 @@ def test_wait_for_env_up_quiet_still_enforces_timeout(mocker: MockerFixture):
     setattr(mng, "_status_poll_seconds", 0.001)
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
     env.get_services.return_value = []
 
     mocker.patch.object(
@@ -491,6 +502,7 @@ def test_evaluate_gate_status_success_and_exception(mocker: MockerFixture):
 
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
 
     env.check_probes.return_value = [
         ProbeRunResult(tag="a", exit_code=0, timed_out=False),
@@ -553,6 +565,35 @@ def test_check_probes_renders_probe_status_tree(mocker: MockerFixture):
     assert exit_code == 0
     build_tree.assert_called_once()
     fake_console.print.assert_called_once_with("probe-tree")
+
+
+def test_image_basename_strips_registry_prefix():
+    assert _image_basename("nginx:latest") == "nginx:latest"
+    assert _image_basename("docker.io/library/postgres:14") == "postgres:14"
+
+
+def test_merge_pull_into_grouped_overrides_pulling_services():
+    grouped = {
+        "web": [["-", "nginx", "[dim]stopped[/dim]"]],
+        "db": [["-", "postgres", "[dim]stopped[/dim]"]],
+    }
+
+    merged = _merge_pull_into_grouped(grouped, [("web", "nginx:latest")])
+
+    assert set(merged.keys()) == {"web", "db"}
+    web_row = merged["web"][0]
+    assert "pulling" in web_row[2]
+    assert "nginx:latest" in web_row[2]
+    assert web_row[1] == "nginx:latest"
+    assert merged["db"] == grouped["db"]
+
+
+def test_merge_pull_into_grouped_noop_when_no_pull_state():
+    grouped = {"web": [["-", "nginx", "[dim]stopped[/dim]"]]}
+
+    merged = _merge_pull_into_grouped(grouped, [])
+
+    assert merged == grouped
 
 
 def test_build_env_status_tree_with_command_log_panel(mocker: MockerFixture):
@@ -864,6 +905,7 @@ def test_wait_for_env_down_terminal_main_loop(mocker: MockerFixture):
 
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
     env.get_services.return_value = []
 
     status_samples: list[
@@ -939,6 +981,7 @@ def test_wait_for_env_up_terminal_no_action_waits_for_first_snapshot(
 
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
     env.get_services.return_value = []
 
     calls = {"count": 0}
@@ -996,6 +1039,7 @@ def test_wait_for_env_up_watch_clears_ready_badge_on_regression(
 ):
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
 
     status_samples: list[
         tuple[dict[str, list[list[str]]], bool, bool, bool]
@@ -1090,6 +1134,7 @@ def test_wait_for_env_up_watch_flashes_ready_badge_briefly(
 ):
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
 
     status_samples: list[
         tuple[dict[str, list[list[str]]], bool, bool, bool]
@@ -1174,6 +1219,7 @@ def test_wait_for_env_up_watch_marks_changed_container_and_probe_for_flash(
 ):
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
 
     status_samples: list[
         tuple[dict[str, list[list[str]]], bool, bool, bool]
@@ -1307,6 +1353,7 @@ def test_wait_for_env_state_uses_custom_progress_label(
 ):
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
     status_samples: list[
         tuple[dict[str, list[list[str]]], bool, bool, bool]
     ] = [
@@ -1456,6 +1503,7 @@ def test_build_env_details_tree(mocker: MockerFixture):
     )
     env = mocker.Mock()
     env.envCfg = SimpleNamespace(tag="test-env")
+    env.get_pull_state.return_value = []
     env.get_services.return_value = [svc_1, svc_2]
 
     tree = build_env_details_tree(env)


### PR DESCRIPTION
## Summary
- Show a "pulling" label/row in the live status tree when `env start` needs to fetch missing docker images, instead of the generic spinner (#258).
- Replace the black-box `docker compose up -d` pull with an explicit streamed `docker compose pull`, parsing per-image progress and rendering a block-character progress bar (#259).

## Test plan
- [x] `pytest` full suite green (671 passed)
- [x] `pyright .` clean
- [x] `pre-commit run --all-files` clean
- [ ] Manual smoke: `shepctl env start <tag>` against an env with an uncached image, confirm pulling row/progress bar appears and clears once pull completes

Fixes: #258
Fixes: #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXCJmrq6XmDyqdku1c2TRx