### PR TITLE
feat(svc,env): add --follow/--tail/--since to logs, add env logs

### DIFF
--- a/src/docker/docker_compose_env.py
+++ b/src/docker/docker_compose_env.py
@@ -30,6 +30,7 @@ from service import ServiceFactory
 from util.util import Util
 
 from .docker_compose_util import (
+    logs_compose_args,
     render_container,
     run_compose,
     run_compose_pull_stream,
@@ -552,6 +553,35 @@ class DockerComposeEnv(Environment):
                 capture=not self._is_verbose(),
                 category="reload",
             )
+
+    @override
+    def get_logs_impl(
+        self,
+        follow: bool = False,
+        tail: Optional[int] = None,
+        since: Optional[str] = None,
+    ):
+        """
+        Show logs (combined stdout+stderr) for every service/container in the
+        environment, interleaved and prefixed by service name — the same
+        behavior as running `docker compose logs` with no service argument.
+        """
+        rendered_map = self.envCfg.status.rendered_config
+        if not rendered_map:
+            Util.print_error_and_die(
+                f"Environment: '{self.envCfg.tag}' is not running."
+            )
+            return
+        log_args = logs_compose_args(follow=follow, tail=tail, since=since)
+        # `follow` blocks and streams live, so it is never buffered/captured.
+        capture = not self._is_verbose() and not follow
+        self._run_compose(
+            list(rendered_map.values()),
+            "logs",
+            *log_args,
+            capture=capture,
+            category="logs",
+        )
 
     @override
     def render_target_impl(self, resolved: bool = False) -> dict[str, str]:

--- a/src/docker/docker_compose_svc.py
+++ b/src/docker/docker_compose_svc.py
@@ -16,7 +16,12 @@ from config import ConfigMng, EnvironmentCfg, ServiceCfg
 from service import Service
 from util import Util
 
-from .docker_compose_util import build_container, render_container, run_compose
+from .docker_compose_util import (
+    build_container,
+    logs_compose_args,
+    render_container,
+    run_compose,
+)
 
 
 class DockerComposeSvc(Service):
@@ -205,15 +210,25 @@ class DockerComposeSvc(Service):
             )
 
     @override
-    def get_stdout_impl(self, cnt_tag: Optional[str] = None):
+    def get_logs_impl(
+        self,
+        cnt_tag: Optional[str] = None,
+        follow: bool = False,
+        tail: Optional[int] = None,
+        since: Optional[str] = None,
+    ):
         """
-        Show container logs for this service.
+        Show container logs (combined stdout+stderr) for this service.
 
         If the service has multiple containers, caller must specify `cnt_tag`
-        to avoid ambiguous output streams.
+        to avoid ambiguous output streams. `docker compose logs` does not
+        separate stdout from stderr, so both are interleaved as docker's log
+        driver produced them.
         """
         rendered_stack = self._get_rendered_compose_stack()
-        capture = self._is_quiet() and not self._is_verbose()
+        # `follow` blocks and streams live, so it is never buffered/captured.
+        capture = self._is_quiet() and not self._is_verbose() and not follow
+        log_args = logs_compose_args(follow=follow, tail=tail, since=since)
 
         if rendered_stack:
             if cnt_tag:
@@ -227,6 +242,7 @@ class DockerComposeSvc(Service):
                     run_compose(
                         rendered_stack,
                         "logs",
+                        *log_args,
                         container.run_container_name or "",
                         project_name=self.envCfg.tag,
                         capture=capture,
@@ -235,6 +251,7 @@ class DockerComposeSvc(Service):
                 run_compose(
                     rendered_stack,
                     "logs",
+                    *log_args,
                     self.svcCfg.containers[0].run_container_name or "",
                     project_name=self.envCfg.tag,
                     capture=capture,

--- a/src/docker/docker_compose_util.py
+++ b/src/docker/docker_compose_util.py
@@ -197,6 +197,26 @@ def run_compose_pull_stream(
                 logging.debug(f"Failed to remove temp compose file {p}: {e}")
 
 
+def logs_compose_args(
+    *,
+    follow: bool = False,
+    tail: Optional[int] = None,
+    since: Optional[str] = None,
+) -> list[str]:
+    """
+    Build the `docker compose logs` flag list shared by service- and
+    environment-level log commands.
+    """
+    args: list[str] = []
+    if follow:
+        args.append("--follow")
+    if tail is not None:
+        args += ["--tail", str(tail)]
+    if since:
+        args += ["--since", since]
+    return args
+
+
 def build_docker_image(
     dockerfile_path: Path,
     context_path: Path,

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -278,6 +278,16 @@ class Environment(ABC):
         """Reload the environment."""
         return self.reload_impl()
 
+    def get_logs(
+        self,
+        follow: bool = False,
+        tail: Optional[int] = None,
+        since: Optional[str] = None,
+    ):
+        """Show logs (combined stdout+stderr) for every service/container in
+        the environment."""
+        return self.get_logs_impl(follow=follow, tail=tail, since=since)
+
     def render(self, resolved: bool) -> str:
         """Render the environment configuration."""
         return self.envCfg.get_yaml(resolved)
@@ -457,6 +467,17 @@ class Environment(ABC):
     @abstractmethod
     def reload_impl(self):
         """Reload the environment."""
+        pass
+
+    @abstractmethod
+    def get_logs_impl(
+        self,
+        follow: bool = False,
+        tail: Optional[int] = None,
+        since: Optional[str] = None,
+    ):
+        """Show logs (combined stdout+stderr) for every service/container in
+        the environment."""
         pass
 
     @abstractmethod
@@ -909,6 +930,22 @@ class EnvironmentMng:
                 watch_after=True,
             )
         Util.print(env.envCfg.tag)
+
+    def logs_env(
+        self,
+        envCfg: EnvironmentCfg,
+        follow: bool = False,
+        tail: Optional[int] = None,
+        since: Optional[str] = None,
+    ):
+        """Show logs (combined stdout+stderr) for every service in an
+        environment."""
+        env = self.get_environment_from_cfg(envCfg)
+        if not env.is_running():
+            Util.print_error_and_die(
+                f"Environment '{env.envCfg.tag}' is not started."
+            )
+        env.get_logs(follow=follow, tail=tail, since=since)
 
     def render_env(
         self,

--- a/src/plugin/context.py
+++ b/src/plugin/context.py
@@ -192,8 +192,12 @@ class PluginServiceView(Protocol):
         envCfg: EnvironmentCfg,
         svc_tag: str,
         cnt_tag: Optional[str] = None,
+        follow: bool = False,
+        tail: Optional[int] = None,
+        since: Optional[str] = None,
     ) -> None:
-        """Stream stdout of the service (or one of its containers)."""
+        """Stream logs (combined stdout+stderr) of the service (or one of
+        its containers)."""
         ...
 
     def shell_svc(

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -117,9 +117,17 @@ class Service(ABC):
         """Reload the service."""
         return self.reload_impl(cnt_tag)
 
-    def get_stdout(self, cnt_tag: Optional[str] = None):
-        """Show the service stdout."""
-        return self.get_stdout_impl(cnt_tag)
+    def get_logs(
+        self,
+        cnt_tag: Optional[str] = None,
+        follow: bool = False,
+        tail: Optional[int] = None,
+        since: Optional[str] = None,
+    ):
+        """Show the service logs (combined stdout+stderr)."""
+        return self.get_logs_impl(
+            cnt_tag, follow=follow, tail=tail, since=since
+        )
 
     def get_shell(self, cnt_tag: Optional[str] = None):
         """Get a shell session for the service."""
@@ -153,8 +161,14 @@ class Service(ABC):
         pass
 
     @abstractmethod
-    def get_stdout_impl(self, cnt_tag: Optional[str] = None):
-        """Show the service stdout."""
+    def get_logs_impl(
+        self,
+        cnt_tag: Optional[str] = None,
+        follow: bool = False,
+        tail: Optional[int] = None,
+        since: Optional[str] = None,
+    ):
+        """Show the service logs (combined stdout+stderr)."""
         pass
 
     @abstractmethod
@@ -347,11 +361,14 @@ class ServiceMng:
         envCfg: EnvironmentCfg,
         svc_tag: str,
         cnt_tag: Optional[str] = None,
+        follow: bool = False,
+        tail: Optional[int] = None,
+        since: Optional[str] = None,
     ):
-        """Get service stdout."""
+        """Get service logs (combined stdout+stderr)."""
         service = self.get_service(envCfg, svc_tag)
         if service:
-            service.get_stdout(cnt_tag)
+            service.get_logs(cnt_tag, follow=follow, tail=tail, since=since)
 
     def shell_svc(
         self,

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -585,6 +585,37 @@ def status_env(
     shepherd.environmentMng.status_env(envCfg, watch=watch)
 
 
+@env.command(name="logs")
+@click.option(
+    "-f", "--follow", is_flag=True, help="Follow log output as it's produced."
+)
+@click.option(
+    "--tail",
+    type=int,
+    default=None,
+    help="Number of lines to show from the end of the logs.",
+)
+@click.option(
+    "--since",
+    default=None,
+    help="Show logs since timestamp or relative duration (e.g. 10m, 1h).",
+)
+@click.pass_obj
+@require_hydrated_env
+def logs_env(
+    shepherd: ShepherdMng,
+    envCfg: EnvironmentCfg,
+    follow: bool = False,
+    tail: Optional[int] = None,
+    since: Optional[str] = None,
+):
+    """Show logs for every service in the environment (combined
+    stdout+stderr, interleaved and prefixed by service name)."""
+    shepherd.environmentMng.logs_env(
+        envCfg, follow=follow, tail=tail, since=since
+    )
+
+
 def _resolve_env_tag(shepherd: ShepherdMng, env_tag: Optional[str]) -> str:
     if env_tag:
         return env_tag
@@ -856,6 +887,20 @@ def build(
 @svc.command(name="logs")
 @click.argument("svc_tag", required=True)
 @click.argument("cnt_tag", required=False)
+@click.option(
+    "-f", "--follow", is_flag=True, help="Follow log output as it's produced."
+)
+@click.option(
+    "--tail",
+    type=int,
+    default=None,
+    help="Number of lines to show from the end of the logs.",
+)
+@click.option(
+    "--since",
+    default=None,
+    help="Show logs since timestamp or relative duration (e.g. 10m, 1h).",
+)
 @click.pass_obj
 @require_active_env
 def logs(
@@ -863,9 +908,14 @@ def logs(
     envCfg: EnvironmentCfg,
     svc_tag: str,
     cnt_tag: Optional[str] = None,
+    follow: bool = False,
+    tail: Optional[int] = None,
+    since: Optional[str] = None,
 ):
-    """Show service logs."""
-    shepherd.serviceMng.logs_svc(envCfg, svc_tag, cnt_tag)
+    """Show service logs (combined stdout+stderr)."""
+    shepherd.serviceMng.logs_svc(
+        envCfg, svc_tag, cnt_tag, follow=follow, tail=tail, since=since
+    )
 
 
 @svc.command(name="shell")

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -1781,6 +1781,100 @@ def test_reload_env_env_not_started(
 
 
 @pytest.mark.docker
+def test_env_logs(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("env_docker", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    mock_subprocess_with_running_ps(mocker)
+
+    result = runner.invoke(cli, ["env", "up"])
+
+    mock_subproc = mock_subprocess_running_ps_and(
+        mocker, "mocked docker compose output"
+    )
+
+    result = runner.invoke(cli, ["env", "logs"])
+    assert result.exit_code == 0
+    mock_subproc.assert_called()
+    assert any(
+        "logs" in (call.args[0] if call.args else [])
+        for call in mock_subproc.call_args_list
+    )
+
+
+@pytest.mark.docker
+def test_env_logs_flags(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("env_docker", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    mock_subprocess_with_running_ps(mocker)
+
+    result = runner.invoke(cli, ["env", "up"])
+
+    mock_subproc = mock_subprocess_running_ps_and(
+        mocker, "mocked docker compose output"
+    )
+
+    result = runner.invoke(
+        cli, ["env", "logs", "--follow", "--tail", "50", "--since", "10m"]
+    )
+    assert result.exit_code == 0
+
+    logs_calls = [
+        call.args[0]
+        for call in mock_subproc.call_args_list
+        if call.args and "logs" in call.args[0]
+    ]
+    assert logs_calls, "Expected a 'docker compose logs' invocation"
+    logs_cmd = logs_calls[0]
+    assert "--follow" in logs_cmd
+    assert "--tail" in logs_cmd
+    assert "50" in logs_cmd
+    assert "--since" in logs_cmd
+    assert "10m" in logs_cmd
+
+
+@pytest.mark.docker
+def test_env_logs_env_not_started(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("env_docker", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    mocker.patch(
+        "docker.docker_compose_util.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=["docker", "compose", "logs"],
+            returncode=0,
+            stdout="mocked docker compose output",
+            stderr="",
+        ),
+    )
+
+    result = runner.invoke(cli, ["env", "logs"])
+    assert result.exit_code != 0
+
+
+@pytest.mark.docker
 def test_status_env(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -882,6 +882,54 @@ def test_cli_logs_svc(
 
 
 @pytest.mark.shpd
+def test_cli_logs_svc_flags(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    mock_logs = mocker.patch.object(ServiceMng, "logs_svc")
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(
+        cli,
+        [
+            "svc",
+            "logs",
+            "service_tag",
+            "--follow",
+            "--tail",
+            "50",
+            "--since",
+            "10m",
+        ],
+    )
+    assert result.exit_code == 0
+    mock_logs.assert_called_once_with(
+        mocker.ANY, "service_tag", None, follow=True, tail=50, since="10m"
+    )
+
+
+@pytest.mark.shpd
+def test_cli_logs_env(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    mock_logs = mocker.patch.object(EnvironmentMng, "logs_env")
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["env", "logs"])
+    assert result.exit_code == 0
+    mock_logs.assert_called_once_with(
+        mocker.ANY, follow=False, tail=None, since=None
+    )
+
+
+@pytest.mark.shpd
 def test_cli_shell_svc(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):

--- a/src/tests/test_svc_docker_compose.py
+++ b/src/tests/test_svc_docker_compose.py
@@ -503,6 +503,46 @@ def test_logs_svc_cnt_2(
 
 
 @pytest.mark.docker
+def test_logs_svc_flags(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("svc_docker", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    mock_subprocess_with_running_ps(mocker)
+
+    result = runner.invoke(cli, ["env", "up"])
+
+    mock_subproc = mocker.patch(
+        "docker.docker_compose_util.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=["docker", "compose", "logs", "test-test-1"],
+            returncode=0,
+            stdout="mocked docker compose output",
+            stderr="",
+        ),
+    )
+
+    result = runner.invoke(
+        cli,
+        ["svc", "logs", "test", "--follow", "--tail", "50", "--since", "10m"],
+    )
+    assert result.exit_code == 0
+    mock_subproc.assert_called_once()
+    logs_cmd = mock_subproc.call_args.args[0]
+    assert "--follow" in logs_cmd
+    assert "--tail" in logs_cmd
+    assert "50" in logs_cmd
+    assert "--since" in logs_cmd
+    assert "10m" in logs_cmd
+
+
+@pytest.mark.docker
 def test_shell_svc(
     shpd_conf: tuple[Path, Path],
     runner: CliRunner,


### PR DESCRIPTION
## Summary
- Renamed `Service.get_stdout`/`get_stdout_impl` to `get_logs`/`get_logs_impl` and clarified that output is combined stdout+stderr (via `docker compose logs`, which doesn't separate streams) — the old naming was misleading.
- Added `--follow/-f`, `--tail <n>`, `--since <duration>` to `svc logs`, threaded through to the underlying `docker compose logs` call. Extracted the shared flag-building logic into `docker_compose_util.logs_compose_args`.
- Added a new `env logs` command showing logs for every service in an environment at once (no container arg — same behavior as plain `docker compose logs`, merging all containers with service-name prefixes), reusing the same three flags.
- Updated the `PluginContext.logs_svc` protocol signature to match.

Splitting stdout/stderr into separate streams is out of scope here — see the issue for reasoning.

Fixes #285

## Test plan
- [x] `cd src && pytest -k logs` — 12 passed (service- and env-level logs, flag threading, CLI wiring, completion)
- [x] `cd src && pytest` — 663 passed
- [x] `cd src && pyright .` — 0 errors
- [x] `pre-commit run --all-files` — all hooks pass