### PR TITLE
docs(pr-prep): forbid AI-agent co-author trailers on commits

### DIFF
--- a/docs/agent-workflows/pr-prep.md
+++ b/docs/agent-workflows/pr-prep.md
@@ -46,6 +46,8 @@ Commit format
 - A commit-message template is available at `docs/commit-template`; copy
   it to `~/.commit-template` and set `git config init.templateDir
   ~/.commit-template` to use it by default.
+- No `Co-Authored-By` trailer (or similar attribution footer) for any
+  AI agent, on any commit.
 
 Before every commit
 ---------------------


### PR DESCRIPTION
## Summary
- Adds a rule to the `pr-prep` agent workflow: no `Co-Authored-By` (or similar attribution footer) for any AI agent, on any commit.