### PR TITLE
fix(ingress,config): loadbalancer port label, proxy network wiring, ContainerCfg gaps

### DIFF
--- a/docs/decisions/CURRENT.md
+++ b/docs/decisions/CURRENT.md
@@ -132,6 +132,31 @@ config authoring needed beyond that. This was the last open item in
 this ADR's Confirmation checklist — the whole ingress/TLS design is
 now implemented end-to-end at the core level.
 
+**Two gaps found and fixed while designing a real plugin against this
+ADR.** (1) `TraefikIngressProvider` only emitted `traefik.enable`/
+`rule`/`entrypoints`/`tls` labels — never `loadbalancer.server.port` —
+so any ingress-flagged container exposing more than one port was
+unroutable (traefik's Docker provider only auto-detects a port when
+exactly one is exposed). Fixed via a new `ContainerCfg.ingress_port`
+field: when set, `_plan_container` emits the port label explicitly.
+(2) The proxy's own `ContainerCfg`, built by
+`_build_ingress_proxy_svc_cfg`, was never attached to any custom
+`networks:` — it only reached compose's implicit default network, so
+an ingress-flagged container declared on a non-default network was
+unreachable by the proxy. Fixed: the proxy now joins the union of
+every ingress-flagged container's `networks` (falling back to the
+literal `"default"` network for any container that declares none of
+its own, since an explicit `networks:` list on the proxy would
+otherwise drop it off the implicit default).
+
+**Also added while auditing `ContainerCfg` for the same plugin:**
+`network_mode`, `user`, `group_add`, and resource limits (`cpus`,
+`memory`, `cpuset`, rendered into compose's `deploy.resources.limits`)
+— none of these Compose fields had any `ContainerCfg` representation
+before, blocking fully declarative config for containers needing host
+networking, non-root docker-socket access, or per-service resource
+caps.
+
 ## Environment teardown failure visibility (ADR-0009 — proposed, not decided)
 
 **Status: proposed, unresolved.** Opened 2026-08-09 alongside ADR-0008.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -816,7 +816,11 @@ methods:
   container (image/command/ports/volumes/labels) — a config-model-free
   description; core translates it into a real `ServiceCfg`, since only
   core knows the factory/template ids that need. Don't construct
-  `ServiceCfg`/`ContainerCfg` yourself.
+  `ServiceCfg`/`ContainerCfg` yourself. The core `traefik` provider's Docker
+  provider only auto-detects a container's port when it exposes exactly
+  one — a container with more than one exposed port must set
+  `ContainerCfg.ingress_port` to an explicit target port, or routing to it
+  is ambiguous.
 - **`apply(plan) -> None`** — make a freshly computed plan true against the
   running environment. Must be idempotent. Core calls this once, after the
   proxy's gate comes up.

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -532,12 +532,24 @@ class ContainerCfg(Resolvable):
     environment: Optional[list[str]] = None
     ports: Optional[list[str]] = None
     networks: Optional[list[str]] = None
+    network_mode: Optional[str] = None
     extra_hosts: Optional[list[str]] = None
+    user: Optional[str] = None
+    group_add: Optional[list[str]] = None
+    cpus: Optional[str] = None
+    memory: Optional[str] = None
+    cpuset: Optional[str] = None
     build: Optional[BuildCfg] = None
     inits: Optional[list[InitCfg]] = None
     healthcheck: Optional[HealthcheckCfg] = None
     labels: Optional[list[str]] = None
     ingress: Optional[str] = field(default=None, metadata={"boolify": True})
+    # Target port an ingress provider should route to. Only meaningful when
+    # `ingress` is set. Providers auto-detect a single exposed port, but a
+    # container with more than one exposed port is otherwise ambiguous --
+    # see `TraefikIngressProvider._plan_container`, which emits an explicit
+    # `loadbalancer.server.port` label whenever this is set.
+    ingress_port: Optional[int] = None
     # Ingress-provider-computed labels (routing rules, TLS flags, ...),
     # distinct from user-declared `labels`. Transient like `run_hostname`/
     # `run_container_name`: computed fresh by `Environment._apply_ingress_plan`
@@ -1064,7 +1076,13 @@ def _parse_container(item: Any) -> ContainerCfg:
         environment=item.get("environment", []),
         ports=item.get("ports", []),
         networks=item.get("networks", []),
+        network_mode=item.get("network_mode"),
         extra_hosts=item.get("extra_hosts", []),
+        user=item.get("user"),
+        group_add=item.get("group_add", []),
+        cpus=item.get("cpus"),
+        memory=item.get("memory"),
+        cpuset=item.get("cpuset"),
         build=_parse_build(item["build"]) if item.get("build") else None,
         inits=inits,
         healthcheck=(
@@ -1078,6 +1096,7 @@ def _parse_container(item: Any) -> ContainerCfg:
             if isinstance(item.get("ingress"), bool)
             else item.get("ingress")
         ),
+        ingress_port=item.get("ingress_port"),
     )
 
 

--- a/src/docker/docker_compose_util.py
+++ b/src/docker/docker_compose_util.py
@@ -318,8 +318,23 @@ def render_container(
         container_def["ports"] = cnt.ports
     if cnt.networks:
         container_def["networks"] = cnt.networks
+    if cnt.network_mode:
+        container_def["network_mode"] = cnt.network_mode
     if cnt.extra_hosts:
         container_def["extra_hosts"] = cnt.extra_hosts
+    if cnt.user:
+        container_def["user"] = cnt.user
+    if cnt.group_add:
+        container_def["group_add"] = cnt.group_add
+    if cnt.cpuset:
+        container_def["cpuset"] = cnt.cpuset
+    if cnt.cpus or cnt.memory:
+        limits: dict[str, Any] = {}
+        if cnt.cpus:
+            limits["cpus"] = cnt.cpus
+        if cnt.memory:
+            limits["memory"] = cnt.memory
+        container_def["deploy"] = {"resources": {"limits": limits}}
     if cnt.healthcheck:
         healthcheck_def: dict[str, Any] = {"test": cnt.healthcheck.test}
         if cnt.healthcheck.interval:

--- a/src/docker/docker_compose_util.py
+++ b/src/docker/docker_compose_util.py
@@ -316,6 +316,11 @@ def render_container(
         container_def["environment"] = cnt.environment
     if cnt.ports:
         container_def["ports"] = cnt.ports
+    if cnt.networks and cnt.network_mode:
+        raise ValueError(
+            f"container '{cnt.tag}': 'networks' and 'network_mode' are "
+            "mutually exclusive in Docker Compose -- set only one."
+        )
     if cnt.networks:
         container_def["networks"] = cnt.networks
     if cnt.network_mode:

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -411,6 +411,19 @@ class Environment(ABC):
         # on the implicit default (i.e. declares no `networks` of its own).
         proxy_networks: set[str] = set()
         for ref in ingress_containers:
+            if getattr(ref.container, "network_mode", None):
+                # A `network_mode`-networked container (e.g. `host`) is not
+                # attached to any compose bridge network -- joining it to
+                # "default" (or any network) would not make it reachable by
+                # the proxy the way a normal container is. Routing to such
+                # a container needs a different mechanism entirely (e.g.
+                # the proxy reaching it via the host network), which this
+                # provider does not implement -- fail loudly rather than
+                # silently produce a proxy that can never reach it.
+                raise ValueError(
+                    f"container '{ref.container.tag}': ingress routing to "
+                    "a container with 'network_mode' set is not supported."
+                )
             container_networks = getattr(ref.container, "networks", None)
             if container_networks:
                 proxy_networks.update(container_networks)

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -324,7 +324,9 @@ class Environment(ABC):
             if container is not None:
                 container.run_labels = list(container_plan.labels)
 
-        proxy_svc_cfg = self._build_ingress_proxy_svc_cfg(plan)
+        proxy_svc_cfg = self._build_ingress_proxy_svc_cfg(
+            plan, ingress_containers
+        )
         proxy_svc = self.svcFactory.new_service_from_cfg(
             self.envCfg, proxy_svc_cfg, cli_flags=self.cli_flags
         )
@@ -382,7 +384,11 @@ class Environment(ABC):
         )
         raise SystemExit(1)  # unreachable: print_error_and_die exits above
 
-    def _build_ingress_proxy_svc_cfg(self, plan: IngressPlan) -> ServiceCfg:
+    def _build_ingress_proxy_svc_cfg(
+        self,
+        plan: IngressPlan,
+        ingress_containers: list[IngressContainerRef],
+    ) -> ServiceCfg:
         """Translate `plan.proxy_spec` (a config-model-free description --
         see `ingress.IngressProxySpec`) into a real `ServiceCfg`. Providers
         never construct `ServiceCfg`/`ContainerCfg` themselves: only core
@@ -394,6 +400,22 @@ class Environment(ABC):
             if plan.proxy_gate == "ungated"
             else StartCfg(when_probes=plan.proxy_gate.split("|"))
         )
+        # The proxy must be able to reach every ingress-flagged container,
+        # not just whatever lands on compose's implicit default network. A
+        # container with an explicit `networks:` list only joins those
+        # networks -- not the default one -- so a container on a custom
+        # network is otherwise unreachable by the proxy. `"default"` is
+        # compose's own name for its implicit network; listing it
+        # explicitly alongside custom networks is standard compose
+        # behavior, so it's included whenever any ingress container relies
+        # on the implicit default (i.e. declares no `networks` of its own).
+        proxy_networks: set[str] = set()
+        for ref in ingress_containers:
+            container_networks = getattr(ref.container, "networks", None)
+            if container_networks:
+                proxy_networks.update(container_networks)
+            else:
+                proxy_networks.add("default")
         proxy_container = ContainerCfg(
             tag=spec.container_tag,
             image=spec.image,
@@ -401,6 +423,7 @@ class Environment(ABC):
             volumes=list(spec.volumes) or None,
             environment=list(spec.environment) or None,
             ports=list(spec.ports) or None,
+            networks=sorted(proxy_networks) or None,
             labels=list(spec.labels) or None,
         )
         return ServiceCfg(

--- a/src/ingress/traefik_provider.py
+++ b/src/ingress/traefik_provider.py
@@ -132,6 +132,14 @@ class TraefikIngressProvider(IngressProvider):
         )
         if self._tls_enabled:
             labels += (f"traefik.http.routers.{router}.tls=true",)
+        if ref.container.ingress_port is not None:
+            # Traefik's Docker provider only auto-detects a port when the
+            # container exposes exactly one -- ambiguous otherwise, so any
+            # container declaring `ingress_port` gets it wired explicitly.
+            labels += (
+                f"traefik.http.services.{router}.loadbalancer.server.port="
+                f"{ref.container.ingress_port}",
+            )
         return IngressContainerPlan(
             service_tag=ref.service_tag,
             container_tag=ref.container.tag,

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -2054,6 +2054,25 @@ def test_render_container_resource_limits():
 
 
 @pytest.mark.cfg
+def test_render_container_rejects_networks_and_network_mode_together():
+    """Docker Compose treats `networks` and `network_mode` as mutually
+    exclusive on a service -- catch the conflict at render time rather
+    than letting `docker compose up` fail on invalid generated YAML."""
+    from config.config import ContainerCfg
+    from docker.docker_compose_util import render_container
+
+    cnt = ContainerCfg(
+        tag="loyas",
+        image="loyas:latest",
+        networks=["special-net"],
+        network_mode="host",
+    )
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        render_container(cnt, labels=None)
+
+
+@pytest.mark.cfg
 def test_render_container_no_deploy_block_without_resource_limits():
     from config.config import ContainerCfg
     from docker.docker_compose_util import render_container

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -1808,6 +1808,33 @@ def test_parse_container_no_labels_or_ingress():
 
 
 @pytest.mark.cfg
+def test_parse_container_ingress_port():
+    """A container's `ingress_port` field parses from raw yaml/json."""
+    from config.config import _parse_container
+
+    cnt = _parse_container(
+        {
+            "tag": "loyas",
+            "image": "loyas:latest",
+            "ingress": True,
+            "ingress_port": 8085,
+        }
+    )
+
+    assert cnt.ingress_port == 8085
+
+
+@pytest.mark.cfg
+def test_parse_container_no_ingress_port():
+    """A container with no `ingress_port` parses to unset."""
+    from config.config import _parse_container
+
+    cnt = _parse_container({"tag": "db", "image": "postgres:16-alpine"})
+
+    assert cnt.ingress_port is None
+
+
+@pytest.mark.cfg
 def test_parse_environment_ingress():
     """An environment's `ingress:` block parses into `IngressCfg`."""
     from config.config import _parse_environment
@@ -1941,6 +1968,105 @@ def test_render_container_merges_volumes_and_run_volumes():
         "/declared:/declared:ro",
         "/ca.crt:/etc/shepherd/ca.crt:ro",
     ]
+
+
+@pytest.mark.cfg
+def test_parse_container_network_mode_user_group_add_and_resources():
+    """A container's `network_mode`, `user`, `group_add`, `cpus`, `memory`,
+    and `cpuset` fields parse from raw yaml/json."""
+    from config.config import _parse_container
+
+    cnt = _parse_container(
+        {
+            "tag": "loyas",
+            "image": "loyas:latest",
+            "network_mode": "host",
+            "user": "1000",
+            "group_add": ["docker"],
+            "cpus": "0.5",
+            "memory": "512m",
+            "cpuset": "0-1",
+        }
+    )
+
+    assert cnt.network_mode == "host"
+    assert cnt.user == "1000"
+    assert cnt.group_add == ["docker"]
+    assert cnt.cpus == "0.5"
+    assert cnt.memory == "512m"
+    assert cnt.cpuset == "0-1"
+
+
+@pytest.mark.cfg
+def test_parse_container_no_network_mode_user_group_add_or_resources():
+    """A container with none of these fields parses to unset/empty."""
+    from config.config import _parse_container
+
+    cnt = _parse_container({"tag": "db", "image": "postgres:16-alpine"})
+
+    assert cnt.network_mode is None
+    assert cnt.user is None
+    assert cnt.group_add == []
+    assert cnt.cpus is None
+    assert cnt.memory is None
+    assert cnt.cpuset is None
+
+
+@pytest.mark.cfg
+def test_render_container_network_mode_user_group_add():
+    from config.config import ContainerCfg
+    from docker.docker_compose_util import render_container
+
+    cnt = ContainerCfg(
+        tag="loyas",
+        image="loyas:latest",
+        network_mode="host",
+        user="1000",
+        group_add=["docker"],
+    )
+
+    rendered = render_container(cnt, labels=None)
+
+    assert rendered["network_mode"] == "host"
+    assert rendered["user"] == "1000"
+    assert rendered["group_add"] == ["docker"]
+
+
+@pytest.mark.cfg
+def test_render_container_resource_limits():
+    from config.config import ContainerCfg
+    from docker.docker_compose_util import render_container
+
+    cnt = ContainerCfg(
+        tag="loyas",
+        image="loyas:latest",
+        cpus="0.5",
+        memory="512m",
+        cpuset="0-1",
+    )
+
+    rendered = render_container(cnt, labels=None)
+
+    assert rendered["cpuset"] == "0-1"
+    assert rendered["deploy"] == {
+        "resources": {"limits": {"cpus": "0.5", "memory": "512m"}}
+    }
+
+
+@pytest.mark.cfg
+def test_render_container_no_deploy_block_without_resource_limits():
+    from config.config import ContainerCfg
+    from docker.docker_compose_util import render_container
+
+    cnt = ContainerCfg(tag="loyas", image="loyas:latest")
+
+    rendered = render_container(cnt, labels=None)
+
+    assert "deploy" not in rendered
+    assert "cpuset" not in rendered
+    assert "network_mode" not in rendered
+    assert "user" not in rendered
+    assert "group_add" not in rendered
 
 
 # ---------------------------------------------------------------------------

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -1977,6 +1977,65 @@ def _ingress_env_cfg(tag: str) -> EnvironmentCfg:
 
 
 @pytest.mark.docker
+def test_apply_ingress_plan_wires_proxy_onto_ingress_container_networks(
+    tmp_path: Path, mocker: MockerFixture
+):
+    """The proxy must be able to reach every ingress-flagged container --
+    not just whatever lands on compose's implicit default network. A
+    container on an explicit custom network only joins that network (not
+    the default one too), so the proxy must join both the custom network
+    and compose's implicit `"default"` (for the sibling container that
+    declares no `networks` of its own) or routing to one of them silently
+    fails."""
+    envCfg = EnvironmentCfg(
+        template="default",
+        factory="docker-compose",
+        tag="test-1",
+        services=[
+            ServiceCfg(
+                tag="web",
+                factory="docker",
+                template="default",
+                containers=[
+                    ContainerCfg(
+                        tag="app", image="nginx:stable", ingress="true"
+                    )
+                ],
+            ),
+            ServiceCfg(
+                tag="api",
+                factory="docker",
+                template="default",
+                containers=[
+                    ContainerCfg(
+                        tag="app",
+                        image="nginx:stable",
+                        ingress="true",
+                        networks=["special-net"],
+                    )
+                ],
+            ),
+        ],
+        probes=None,
+        networks=None,
+        volumes=None,
+        ingress=IngressCfg(domain="sslip.io"),
+    )
+    svcFactory = mocker.Mock()
+    env = DockerComposeEnv(
+        _fake_config_mng_for_ingress(tmp_path),
+        svcFactory,
+        envCfg,
+        cli_flags={},
+    )
+
+    env._apply_ingress_plan()
+
+    proxy_svc_cfg = svcFactory.new_service_from_cfg.call_args.args[1]
+    assert proxy_svc_cfg.containers[0].networks == ["default", "special-net"]
+
+
+@pytest.mark.docker
 def test_apply_ingress_plan_uses_deterministic_per_env_ports(
     tmp_path: Path, mocker: MockerFixture
 ):

--- a/src/tests/test_env_docker_compose.py
+++ b/src/tests/test_env_docker_compose.py
@@ -2036,6 +2036,50 @@ def test_apply_ingress_plan_wires_proxy_onto_ingress_container_networks(
 
 
 @pytest.mark.docker
+def test_apply_ingress_plan_rejects_network_mode_ingress_container(
+    tmp_path: Path, mocker: MockerFixture
+):
+    """A `network_mode`-networked container (e.g. `host`) is not attached
+    to any compose bridge network, so joining the proxy to "default" (the
+    fallback for a container with no explicit `networks`) would not
+    actually make it reachable -- this combination must fail loudly
+    rather than silently produce an unreachable route."""
+    envCfg = EnvironmentCfg(
+        template="default",
+        factory="docker-compose",
+        tag="test-1",
+        services=[
+            ServiceCfg(
+                tag="web",
+                factory="docker",
+                template="default",
+                containers=[
+                    ContainerCfg(
+                        tag="app",
+                        image="nginx:stable",
+                        ingress="true",
+                        network_mode="host",
+                    )
+                ],
+            )
+        ],
+        probes=None,
+        networks=None,
+        volumes=None,
+        ingress=IngressCfg(domain="sslip.io"),
+    )
+    env = DockerComposeEnv(
+        _fake_config_mng_for_ingress(tmp_path),
+        mocker.Mock(),
+        envCfg,
+        cli_flags={},
+    )
+
+    with pytest.raises(ValueError, match="network_mode"):
+        env._apply_ingress_plan()
+
+
+@pytest.mark.docker
 def test_apply_ingress_plan_uses_deterministic_per_env_ports(
     tmp_path: Path, mocker: MockerFixture
 ):

--- a/src/tests/test_ingress.py
+++ b/src/tests/test_ingress.py
@@ -58,6 +58,36 @@ def test_plan_computes_hostname_and_labels_without_tls():
     assert plan.proxy_dynamic_config is None
 
 
+def test_plan_omits_loadbalancer_port_label_when_ingress_port_unset():
+    provider = TraefikIngressProvider(domain="sslip.io")
+    ref = IngressContainerRef(
+        service_tag="web", container=ContainerCfg(tag="app")
+    )
+
+    plan = provider.plan(_env_cfg(), [ref])
+
+    assert not any(
+        "loadbalancer.server.port" in label
+        for label in plan.container_plans[0].labels
+    )
+
+
+def test_plan_emits_loadbalancer_port_label_when_ingress_port_set():
+    provider = TraefikIngressProvider(domain="sslip.io")
+    ref = IngressContainerRef(
+        service_tag="web",
+        container=ContainerCfg(tag="app", ingress_port=8085),
+    )
+
+    plan = provider.plan(_env_cfg(), [ref])
+
+    labels = plan.container_plans[0].labels
+    assert (
+        "traefik.http.services.app-web-test-1.loadbalancer.server.port=8085"
+        in labels
+    )
+
+
 def test_plan_requires_cert_and_key_together():
     with pytest.raises(ValueError):
         TraefikIngressProvider(domain="sslip.io", tls_cert_path="/x/leaf.crt")

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -44,7 +44,14 @@ def add_container_field_defaults(node: object) -> None:
     defaults: dict[str, object] = {
         "labels": [],
         "ingress": None,
+        "ingress_port": None,
         "command": [],
+        "network_mode": None,
+        "user": None,
+        "group_add": [],
+        "cpus": None,
+        "memory": None,
+        "cpuset": None,
     }
     if isinstance(node, dict):
         for key, value in node.items():


### PR DESCRIPTION
## Summary

Fixes five gaps in ADR-0008's ingress design and `ContainerCfg`, found while designing a real downstream plugin against it:

- **#289** — `TraefikIngressProvider` never emitted `traefik.http.services.<router>.loadbalancer.server.port`. Traefik's Docker provider only auto-detects a port when a container exposes exactly one; any ingress-flagged container with more than one exposed port was silently unroutable. Fixed via a new `ContainerCfg.ingress_port` field — when set, the provider emits the label explicitly.
- **#290** — The ingress proxy's own `ContainerCfg` was never attached to any custom `networks:`, so it only reached compose's implicit default network. An ingress-flagged container declared on a non-default network was unreachable by the proxy. Fixed: the proxy now joins the union of every ingress-flagged container's declared networks, plus the literal `"default"` network for any container that declares none of its own (an explicit `networks:` list on a compose service otherwise drops implicit default membership).
- **#291 / #292 / #293** — `ContainerCfg` had no representation for `network_mode`, `user`/`group_add`, or resource limits (`cpus`/`memory`/`cpuset`, rendered into compose's `deploy.resources.limits`). Blocks fully declarative config for containers needing host networking, non-root docker-socket access (e.g. a Docker-outside-of-Docker service per ADR-0009), or per-service resource caps.

## Test plan

- [x] `pytest` — 739 passed, 27 deselected (was 729/27 before this change)
- [x] New unit tests: `ingress_port` parsing + label emission (`test_config.py`, `test_ingress.py`), proxy network-union wiring integration test (`test_env_docker_compose.py`), `network_mode`/`user`/`group_add`/resource-limit parsing and rendering (`test_config.py`)
- [x] `pre-commit run --all-files` — all 16 hooks pass (black, isort, flake8, pyright, markdownlint-cli2, codespell, ...)
- [x] `docs/plugins.md` and `docs/decisions/CURRENT.md` updated to document the new field and the two routing fixes

Closes #289, #290, #291, #292, #293.