### PR TITLE
fix(shepctl): attach plugin managers for verbs added to an existing scope

### DIFF
--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -280,6 +280,22 @@ def cli(
                 load_runtime_plugins=load_runtime_plugins,
                 plugin_runtime_mng=preloaded_runtime,
             )
+        # A verb added to an *existing* core scope (e.g. `env doctor`) is
+        # found by Click's normal static lookup at every level up to the
+        # verb itself, so `_load_plugin_runtime_for_click` (which only
+        # runs when `get_command` falls through to the plugin registry)
+        # never fires while resolving the scope -- only later, resolving
+        # the unknown verb under it. Without this, that later call sees no
+        # cached runtime in `ctx.meta` and builds a second, throwaway
+        # `PluginRuntimeMng` with no managers attached, so the plugin
+        # command's `PluginContext.environment`/`.service`/`.remote` stay
+        # `None` despite `attach_managers` having already run on the real
+        # one above. Caching the real, fully-attached instance here closes
+        # that gap -- any later lazy lookup reuses it instead of building
+        # a disconnected one.
+        runtime_mng = getattr(ctx.obj, "pluginRuntimeMng", None)
+        if runtime_mng is not None:
+            ctx.meta["plugin_runtime_mng"] = runtime_mng
 
 
 @cli.command(name="test", hidden=True)

--- a/src/tests/test_plugin_runtime.py
+++ b/src/tests/test_plugin_runtime.py
@@ -273,6 +273,63 @@ def test_cli_executes_plugin_verb_under_core_scope(
     assert "plugin-doctor:network" in result.output
 
 
+_CONTEXT_CHECKING_DOCTOR_MAIN = """
+import click
+
+from plugin import PluginCommandSpec, ShepherdPlugin
+
+
+class RuntimeFixturePlugin(ShepherdPlugin):
+    def get_commands(self):
+        context = self.context
+
+        @click.command(name="doctor")
+        def doctor():
+            click.echo(f"environment-attached:{context.environment is not None}")
+            click.echo(f"service-attached:{context.service is not None}")
+
+        return [PluginCommandSpec(scope="env", verb="doctor", command=doctor)]
+"""
+
+
+@pytest.mark.shpd
+def test_cli_attaches_managers_for_verb_added_to_existing_scope(
+    shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
+):
+    """A verb a plugin adds to an *existing* core scope (e.g. `env doctor`,
+    the exact example docs/plugins.md itself uses) is found by Click's
+    normal static lookup at every level up to the verb name -- unlike a
+    plugin-owned scope, the plugin registry is only ever consulted once,
+    lazily, resolving that last unknown verb. Regression test for the bug
+    where that lazy lookup built a second, disconnected `PluginRuntimeMng`
+    with no managers attached, leaving `PluginContext.environment`/
+    `.service` `None` in the command handler despite `attach_managers`
+    having already run against the real one built for the CLI invocation.
+    """
+    shpd_path = shpd_conf[0]
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    _install_fixture_plugin(
+        shpd_path, main_content=_CONTEXT_CHECKING_DOCTOR_MAIN
+    )
+    _write_plugin_inventory(
+        shpd_yaml,
+        [
+            {
+                "id": "runtime-plugin",
+                "enabled": True,
+                "version": "1.0.0",
+                "config": None,
+            }
+        ],
+    )
+
+    result = runner.invoke(cli, ["env", "doctor"])
+
+    assert result.exit_code == 0
+    assert "environment-attached:True" in result.output
+    assert "service-attached:True" in result.output
+
+
 @pytest.mark.shpd
 def test_cli_adds_environment_from_plugin_template(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture


### PR DESCRIPTION
## Summary

Found while building a real plugin (`shepherd-plugin-logobject`) whose `env clean` command (a verb added to the existing core `env` scope, exactly the shape `docs/plugins.md`'s own `env doctor` example uses) crashed with `AssertionError` on `context.environment is not None` despite the documented contract that `PluginContext.environment`/`.service` are always populated by the time a command handler runs.

Root cause: a verb added to an *existing* core scope is found by Click's normal static lookup at every level up to the verb name itself — the lazy plugin-registry fallback (`_load_plugin_runtime_for_click`) only ever fires resolving that last, unknown verb, *after* the root `cli()` callback has already built and fully attached the real `PluginRuntimeMng` via `attach_managers`. Since that callback never cached its instance into `ctx.meta`, the later lazy lookup built a **second, disconnected** `PluginRuntimeMng` with no managers attached — so the plugin command's `PluginContext.environment`/`.service` stayed `None`.

This did not affect plugin-*owned* scopes (e.g. `observability tail`), because resolving the scope name itself already triggers and caches the lazy loader before the verb is resolved — the existing test `test_cli_reuses_preloaded_runtime_for_plugin_commands` only covers that path, not the "extend an existing scope" path.

Fix: cache the real, attached `PluginRuntimeMng` into `ctx.meta` right after `ShepherdMng` builds it, so any later lazy lookup within the same invocation reuses it instead of building a disconnected one.

## Test plan

- [x] New regression test `test_cli_attaches_managers_for_verb_added_to_existing_scope` (`test_plugin_runtime.py`) — verified it fails without the fix (`AssertionError`... reverted `shepctl.py` locally to confirm) and passes with it.
- [x] `pytest` — 742 passed, 27 deselected (was 739/27 before this change)
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Verified live against a real installed plugin (`env clean`, a verb added to the `env` scope) — reproduced the bug pre-fix, confirmed fixed post-fix.