### PR TITLE
feat(config): let environment templates declare ingress

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -754,22 +754,6 @@ class FragmentRefCfg(Resolvable):
 
 
 @dataclass
-class EnvironmentTemplateCfg(Resolvable):
-    """
-    Represents an environment template configuration.
-    """
-
-    tag: str
-    factory: str
-    service_templates: Optional[list[ServiceTemplateRefCfg]]
-    probes: Optional[list[ProbeCfg]]
-    networks: Optional[list[NetworkCfg]]
-    volumes: Optional[list[VolumeCfg]]
-    ready: Optional[ReadyCfg] = None
-    fragments: Optional[list[FragmentRefCfg]] = None
-
-
-@dataclass
 class IngressCfg(Resolvable):
     """
     Opts an environment into HTTPS ingress for its `ingress: true`-flagged
@@ -783,6 +767,27 @@ class IngressCfg(Resolvable):
 
     domain: str
     provider: str = "traefik"
+
+
+@dataclass
+class EnvironmentTemplateCfg(Resolvable):
+    """
+    Represents an environment template configuration.
+    """
+
+    tag: str
+    factory: str
+    service_templates: Optional[list[ServiceTemplateRefCfg]]
+    probes: Optional[list[ProbeCfg]]
+    networks: Optional[list[NetworkCfg]]
+    volumes: Optional[list[VolumeCfg]]
+    ready: Optional[ReadyCfg] = None
+    fragments: Optional[list[FragmentRefCfg]] = None
+    # Templates carry ingress config too, not just realized environments --
+    # `env_cfg_from_tag` copies this onto the `EnvironmentCfg` it builds, so
+    # a plugin's reusable template can declare ingress once instead of every
+    # consumer having to patch it onto each realized environment by hand.
+    ingress: Optional[IngressCfg] = None
 
 
 @dataclass
@@ -1249,6 +1254,9 @@ def _parse_environment_template(item: Any) -> EnvironmentTemplateCfg:
             [_parse_fragment_ref(f) for f in fragments_data]
             if fragments_data
             else None
+        ),
+        ingress=(
+            _parse_ingress(item["ingress"]) if item.get("ingress") else None
         ),
     )
 
@@ -2352,6 +2360,7 @@ class ConfigMng:
             ready=deepcopy(env_tmpl_cfg.ready),
             networks=networks or None,
             volumes=volumes or None,
+            ingress=deepcopy(env_tmpl_cfg.ingress),
         )
 
     def env_cfg_from_other(self, other: EnvironmentCfg):

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -831,6 +831,7 @@ def test_store_config_with_real_files():
             for item in expected.get("env_templates", []):
                 item.setdefault("ready", None)
                 item.setdefault("fragments", None)
+                item.setdefault("ingress", None)
             for item in expected.get("envs", []):
                 item.setdefault("ready", None)
                 item.setdefault("tracking_remote", None)
@@ -1170,6 +1171,7 @@ def test_store_config_with_refs_with_real_files():
             for item in expected.get("env_templates", []):
                 item.setdefault("ready", None)
                 item.setdefault("fragments", None)
+                item.setdefault("ingress", None)
             for item in expected.get("envs", []):
                 item.setdefault("ready", None)
                 item.setdefault("tracking_remote", None)
@@ -1888,6 +1890,67 @@ def test_parse_environment_no_ingress():
     env = _parse_environment(item)
 
     assert env.ingress is None
+
+
+@pytest.mark.cfg
+def test_parse_environment_template_ingress():
+    """An environment template's `ingress:` block parses into `IngressCfg`
+    -- templates need this too, not just realized environments, so a
+    plugin's reusable template can declare ingress once (see
+    `env_cfg_from_tag_copies_template_ingress` below for the propagation
+    half of this)."""
+    from config.config import _parse_environment_template
+
+    item = {
+        "tag": "full",
+        "factory": "docker-compose",
+        "ingress": {"domain": "sslip.io", "provider": "nginx"},
+    }
+
+    tmpl = _parse_environment_template(item)
+
+    assert tmpl.ingress is not None
+    assert tmpl.ingress.domain == "sslip.io"
+    assert tmpl.ingress.provider == "nginx"
+
+
+@pytest.mark.cfg
+def test_parse_environment_template_no_ingress():
+    from config.config import _parse_environment_template
+
+    item = {"tag": "full", "factory": "docker-compose"}
+
+    tmpl = _parse_environment_template(item)
+
+    assert tmpl.ingress is None
+
+
+@pytest.mark.cfg
+def test_env_cfg_from_tag_copies_template_ingress(mocker: MockerFixture):
+    """`env add` must carry a template's `ingress:` block onto the
+    realized environment -- otherwise a plugin-declared template's ingress
+    config silently disappears the moment a user instantiates it."""
+    from config.config import ConfigMng, EnvironmentTemplateCfg, IngressCfg
+
+    cMng = ConfigMng.__new__(ConfigMng)
+    mocker.patch.object(
+        ConfigMng, "get_env_template_fragment_registry", return_value={}
+    )
+    mocker.patch.object(ConfigMng, "svc_cfg_from_service_template")
+    tmpl = EnvironmentTemplateCfg(
+        tag="full",
+        factory="docker-compose",
+        service_templates=None,
+        probes=None,
+        networks=None,
+        volumes=None,
+        ingress=IngressCfg(domain="sslip.io"),
+    )
+
+    env = cMng.env_cfg_from_tag(tmpl, "my-env")
+
+    assert env.ingress is not None
+    assert env.ingress.domain == "sslip.io"
 
 
 @pytest.mark.docker


### PR DESCRIPTION
## Summary

`EnvironmentTemplateCfg` had no `ingress` field — only the realized `EnvironmentCfg` did. Found composing a real plugin's env_template (a `loas` app-server service_template + a Postgres readiness fragment) that declared `ingress:` at the template level: after `env add`, the realized environment's `ingress` field was silently `null`. A plugin's reusable template couldn't declare ingress at all — every consumer would have to hand-patch it onto each realized environment after the fact, defeating the point of a reusable template.

Fix: `EnvironmentTemplateCfg` gains an `ingress: Optional[IngressCfg]` field (parsed the same way as the existing environment-level field), and `ConfigMng.env_cfg_from_tag` now copies it onto the `EnvironmentCfg` it builds. `IngressCfg`'s definition moved above `EnvironmentTemplateCfg` in the file so the new field can reference it directly (no `from __future__ import annotations` in this module, so forward references need real definition order).

## Test plan

- [x] New tests: template-level `ingress:` parsing (`test_parse_environment_template_ingress`/`_no_ingress`), and `env_cfg_from_tag` propagation (`test_env_cfg_from_tag_copies_template_ingress`)
- [x] Two existing round-trip serialization tests needed a `setdefault("ingress", None)` addition for `env_templates` entries (same pattern as every other new optional field added this cycle)
- [x] `pytest` — 745 passed, 27 deselected (was 740/27 before this change)
- [x] `pre-commit run --all-files` — all hooks pass