### PR TITLE
feat: expose envs_path, exec_svc, and per-env config/values overrides to plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -114,8 +114,27 @@ keep resolving against the plugin default. Resolution precedence for a
 given `${KEY}`, most specific override last:
 
 plugin `config` (default) → environment `config` (per-instance
-override, if set) → `~/.shpd.values` (`user_values`, always wins) →
-process environment variable (final fallback).
+override, if set) → `~/.shpd.values` (`user_values`, always wins over
+`config`) → per-environment values file (below, wins over the global
+`~/.shpd.values` for that environment's subtree only) → process
+environment variable (final fallback).
+
+An environment can also have its own values file, the per-environment
+analogue of `~/.shpd.values`: `envs_path/<tag>/.shpd.values`, same
+`key=value` format. Unlike `config` (which sits *below* the global
+values file), a per-environment values file sits *above* it — it's for
+overriding what `~/.shpd.values` would otherwise apply everywhere,
+scoped to one specific environment, without editing the global file.
+Missing is the common case (most environments have none) and not an
+error. Nothing manages this file for you today — no `plugin install`
+scaffolding, no `env add` prompt, no CLI command to point at it. Create
+it by hand at the path above if you need it, e.g. to give one
+environment a different `${db_password}` than every other environment
+on the same host without touching `~/.shpd.values`.
+
+`shepctl env config set/get/unset` manage an environment's `config`
+block from the CLI directly (no plugin required) — there is currently
+no equivalent CLI surface for the per-environment values file itself.
 
 ## Plugin Descriptor
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1711,9 +1711,29 @@ class ConfigMng:
 
         # Reparse through model constructors to normalize defaults/types.
         config = parse_config(yaml.dump(config_data, sort_keys=False))
-        config.set_resolver(
-            self._build_plugin_resolver(config), self.user_values
-        )
+
+        # `envs_path` itself only references `user_values` (e.g.
+        # `${shpd_path}`), so it can be resolved standalone, ahead of the
+        # real resolver below -- then exposed as `${envs_path}` so
+        # templates can anchor persistent state under shepherd's own
+        # per-environment directory (`${envs_path}/#{env.tag}/...`)
+        # instead of requiring a hand-supplied host path.
+        config.set_resolver({}, self.user_values)
+        resolved_envs_path = config.envs_path
+
+        resolver = self._build_plugin_resolver(config)
+        resolver["envs_path"] = resolved_envs_path
+        # `var_repl` (`_resolve_str`) checks `user_values` before
+        # `resolver`, and a real `~/.shpd.conf` (see
+        # `DEFAULT_SHPD_VALUES_TEMPLATE`) always defines its own
+        # `envs_path` -- raw and not tilde-expanded, since
+        # `os.path.expanduser` only runs for fields literally named
+        # `*_path`. Left alone, that stale entry would shadow the
+        # resolved value above for every *other* field referencing
+        # `${envs_path}` (e.g. a service_template's `volumes`), which
+        # would silently keep a literal `~` in a bind-mount source.
+        self.user_values["envs_path"] = resolved_envs_path
+        config.set_resolver(resolver, self.user_values)
         return config
 
     def load(self):

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -11,7 +11,7 @@ import os
 import re
 from copy import copy, deepcopy
 from dataclasses import dataclass, field, fields, is_dataclass
-from typing import Any, Dict, Match, Optional, cast
+from typing import Any, Dict, Iterable, Match, Optional, cast
 
 import yaml
 from glom import glom  # type: ignore[import]
@@ -215,11 +215,13 @@ class Resolvable:
 
         This is the core state-wiring pass used by `set_resolved`,
         `set_unresolved`, and `set_resolver`. `user_values` is the same
-        mapping reference for the whole tree (it always wins in
-        `_resolve_str`, see there); `resolver` is the per-node mapping —
-        an `EnvironmentCfg` with its own `config` dict merges that on top
-        of the incoming `resolver` for itself and its subtree only,
-        leaving sibling subtrees on the unmerged mapping.
+        mapping reference for the whole tree by default (it always wins in
+        `_resolve_str`, see there) -- an `EnvironmentCfg` with its own
+        `env_values` (loaded from `envs_path/<tag>/.shpd.values`, see
+        `ConfigMng.load_config`) merges that on top of `user_values` for
+        itself and its subtree only, the per-environment analogue of how
+        its `config` dict merges into `resolver`; both leave sibling
+        subtrees on the unmerged mapping.
         """
         if obj is None:
             obj = self
@@ -227,17 +229,26 @@ class Resolvable:
         if is_dataclass(obj) and isinstance(obj, Resolvable):
             lRefMap = obj._set_refMap(refMap)
             node_resolver = resolver
-            if isinstance(obj, EnvironmentCfg) and obj.config and resolved:
-                node_resolver = dict(resolver or {})
-                node_resolver.update(
-                    {str(k): str(v) for k, v in obj.config.items()}
-                )
+            node_user_values = user_values
+            if isinstance(obj, EnvironmentCfg) and resolved:
+                if obj.config:
+                    node_resolver = dict(resolver or {})
+                    node_resolver.update(
+                        {str(k): str(v) for k, v in obj.config.items()}
+                    )
+                if obj.env_values:
+                    node_user_values = dict(user_values or {})
+                    node_user_values.update(obj.env_values)
             object.__setattr__(obj, "_resolver", node_resolver or os.environ)
-            object.__setattr__(obj, "_user_values", user_values or {})
+            object.__setattr__(obj, "_user_values", node_user_values or {})
             for f in fields(obj):
                 if fVal := getattr(obj, f.name, None):
                     self._walk_and_set(
-                        node_resolver, resolved, fVal, lRefMap, user_values
+                        node_resolver,
+                        resolved,
+                        fVal,
+                        lRefMap,
+                        node_user_values,
                     )
             object.__setattr__(obj, "_resolved", resolved)
 
@@ -809,6 +820,14 @@ class EnvironmentCfg(Resolvable):
     status: EntityStatus = field(default_factory=EntityStatus)
     config: Optional[dict[str, Any]] = None
     ingress: Optional[IngressCfg] = None
+    # Loaded fresh from `envs_path/<tag>/.shpd.values` on every
+    # `ConfigMng.load_config`, never persisted into `.shpd.yaml` -- the
+    # per-environment analogue of `~/.shpd.values`. See
+    # `Resolvable._walk_and_set`'s `EnvironmentCfg` branch, which layers
+    # this over `user_values` for this environment's subtree only.
+    env_values: Optional[dict[str, str]] = field(
+        default=None, metadata={"transient": True}
+    )
 
     def get_service(self, svcTag: str) -> Optional[ServiceCfg]:
         """
@@ -1629,6 +1648,41 @@ class ConfigMng:
 
         return pattern.sub(replacer, value)
 
+    def _parse_values_lines(
+        self, lines: Iterable[str], seed: Dict[str, str]
+    ) -> Dict[str, str]:
+        """
+        Parse `key=value` lines (blank lines and `#`-comments ignored),
+        expanding `${VAR}` against *seed* plus keys already parsed earlier
+        in the same file. Returns only this file's own keys, fully
+        expanded -- not merged with *seed*.
+
+        Notes:
+            Expansion is one-pass in file order. A key can reference only
+            *seed*, environment variables, or values already defined
+            above it in the same file.
+        """
+        raw_values: Dict[str, str] = {}
+        for line in lines:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            if "=" in line:
+                key, value = line.split("=", 1)
+                raw_values[key.strip()] = value.strip()
+            else:
+                raise ValueError(
+                    f"Invalid line format in config file: '{line}'"
+                )
+
+        combined = dict(seed)
+        values: Dict[str, str] = {}
+        for key, raw_value in raw_values.items():
+            combined[key] = self.expand_value(raw_value, combined)
+            values[key] = combined[key]
+        return values
+
     def load_user_values(self) -> Dict[str, str]:
         """
         Loads user-defined configuration values from a file in key=value
@@ -1642,10 +1696,6 @@ class ConfigMng:
 
         :raises FileNotFoundError: If the config file is missing.
         :raises ValueError: If a line is invalid (missing '=' separator).
-
-        Notes:
-            Expansion is one-pass in file order. A key can reference only
-            values already defined above it (plus environment variables).
         """
         user_values: Dict[str, str] = {}
 
@@ -1655,31 +1705,37 @@ class ConfigMng:
             )
 
         try:
-            raw_values: Dict[str, str] = {}
-
             with open(self.file_values_path, "r") as file:
-                for line in file:
-                    line = line.strip()
-                    if not line or line.startswith("#"):
-                        continue
-
-                    if "=" in line:
-                        key, value = line.split("=", 1)
-                        raw_values[key.strip()] = value.strip()
-                    else:
-                        raise ValueError(
-                            f"Invalid line format in config file: '{line}'"
-                        )
-
-            # Expand values using previously defined keys and environment
-            # variables
-            for key, raw_value in raw_values.items():
-                user_values[key] = self.expand_value(raw_value, user_values)
-
+                user_values = self._parse_values_lines(file, {})
         except Exception as e:
             Util.print_error_and_die(f"Error reading configuration file: {e}")
 
         return user_values
+
+    def load_env_values(
+        self, values_path: str, seed: Dict[str, str]
+    ) -> Dict[str, str]:
+        """
+        Loads an optional per-environment values file (same `key=value`
+        format as `~/.shpd.values`), expanding `${VAR}` against *seed*
+        (typically the global `user_values`).
+
+        Unlike `load_user_values`, a missing file is normal, not an
+        error -- most environments have none. See `EnvironmentCfg.env_values`
+        and its `Resolvable._walk_and_set` merge into `user_values` for
+        that environment's subtree only.
+        """
+        if not os.path.isfile(values_path):
+            return {}
+
+        try:
+            with open(values_path, "r") as file:
+                return self._parse_values_lines(file, seed)
+        except Exception as e:
+            Util.print_error_and_die(
+                f"Error reading values file '{values_path}': {e}"
+            )
+        return {}
 
     def _build_plugin_resolver(self, config: Config) -> Dict[str, str]:
         """
@@ -1713,26 +1769,44 @@ class ConfigMng:
         config = parse_config(yaml.dump(config_data, sort_keys=False))
 
         # `envs_path` itself only references `user_values` (e.g.
-        # `${shpd_path}`), so it can be resolved standalone, ahead of the
-        # real resolver below -- then exposed as `${envs_path}` so
-        # templates can anchor persistent state under shepherd's own
-        # per-environment directory (`${envs_path}/#{env.tag}/...`)
-        # instead of requiring a hand-supplied host path.
-        config.set_resolver({}, self.user_values)
-        resolved_envs_path = config.envs_path
+        # `${shpd_path}`), so it's resolved directly from the raw YAML
+        # value -- avoids a full-tree `set_resolver` pass just to read one
+        # field. Exposed as `${envs_path}` so templates can anchor
+        # persistent state under shepherd's own per-environment directory
+        # (`${envs_path}/#{env.tag}/...`) instead of requiring a
+        # hand-supplied host path.
+        #
+        # `var_repl` (`_resolve_str`) checks `user_values` before the
+        # `resolver` mapping `_build_plugin_resolver` builds below, and a
+        # real `~/.shpd.conf` (see `DEFAULT_SHPD_VALUES_TEMPLATE`) always
+        # defines its own `envs_path` -- raw and not tilde-expanded, since
+        # `os.path.expanduser` only runs for fields literally named
+        # `*_path`. So it must be set directly on `user_values`, not
+        # merely added to `resolver`, or that stale entry would shadow
+        # this resolved value for every *other* field referencing
+        # `${envs_path}` (e.g. a service_template's `volumes`), silently
+        # keeping a literal `~` in a bind-mount source.
+        resolved_envs_path = os.path.expanduser(
+            self.expand_value(config_data["envs_path"], self.user_values)
+        )
+        self.user_values["envs_path"] = resolved_envs_path
 
         resolver = self._build_plugin_resolver(config)
-        resolver["envs_path"] = resolved_envs_path
-        # `var_repl` (`_resolve_str`) checks `user_values` before
-        # `resolver`, and a real `~/.shpd.conf` (see
-        # `DEFAULT_SHPD_VALUES_TEMPLATE`) always defines its own
-        # `envs_path` -- raw and not tilde-expanded, since
-        # `os.path.expanduser` only runs for fields literally named
-        # `*_path`. Left alone, that stale entry would shadow the
-        # resolved value above for every *other* field referencing
-        # `${envs_path}` (e.g. a service_template's `volumes`), which
-        # would silently keep a literal `~` in a bind-mount source.
-        self.user_values["envs_path"] = resolved_envs_path
+
+        # Per-environment values file (`envs_path/<tag>/.shpd.values`),
+        # the per-environment analogue of `~/.shpd.values` -- an optional
+        # override layer *above* the global values file (not merely the
+        # `config:` block below it), scoped to that environment's
+        # subtree. See `EnvironmentCfg.env_values` and its
+        # `Resolvable._walk_and_set` merge.
+        for env in config.envs or []:
+            values_path = os.path.join(
+                resolved_envs_path, env.tag, ".shpd.values"
+            )
+            env.env_values = (
+                self.load_env_values(values_path, self.user_values) or None
+            )
+
         config.set_resolver(resolver, self.user_values)
         return config
 
@@ -2174,6 +2248,33 @@ class ConfigMng:
                 if env.tag == env_tag:
                     config = dict(env.config or {})
                     config[key] = value
+                    env.config = config
+                    self.store()
+                    return env
+            raise ValueError(f"Environment '{env_tag}' not found.")
+        finally:
+            if was_resolved:
+                self.config.set_resolved()
+            else:
+                self.config.set_unresolved()
+
+    def remove_environment_config_value(
+        self, env_tag: str, key: str
+    ) -> EnvironmentCfg:
+        """Remove one key from an environment's own config dict and
+        persist it. Counterpart to `set_environment_config_value`."""
+        was_resolved = self.config.is_resolved()
+        self.config.set_unresolved()
+        try:
+            for env in self.config.envs:
+                if env.tag == env_tag:
+                    if not env.config or key not in env.config:
+                        raise ValueError(
+                            f"Key '{key}' is not set in environment "
+                            f"'{env_tag}'."
+                        )
+                    config = dict(env.config)
+                    del config[key]
                     env.config = config
                     self.store()
                     return env

--- a/src/docker/docker_compose_svc.py
+++ b/src/docker/docker_compose_svc.py
@@ -13,7 +13,7 @@ from typing import Any, Optional, override
 import yaml
 
 from config import ConfigMng, EnvironmentCfg, ServiceCfg
-from service import Service
+from service import ExecResult, Service
 from util import Util
 
 from .docker_compose_util import (
@@ -311,6 +311,57 @@ class DockerComposeSvc(Service):
             Util.print_error_and_die(
                 f"Environment: '{self.envCfg.tag}' is not running."
             )
+
+    @override
+    def exec_impl(
+        self, cmd: list[str], cnt_tag: Optional[str] = None
+    ) -> ExecResult:
+        """
+        Run a command inside a service container and capture its output --
+        the scriptable counterpart to `get_shell_impl` (interactive, no
+        captured output) and `get_logs_impl` (streaming, no exit code).
+
+        `-T` disables pseudo-tty allocation, matching a non-interactive,
+        scripted invocation rather than a shell session.
+        """
+        rendered_stack = self._get_rendered_compose_stack()
+
+        if rendered_stack:
+            container = None
+            if cnt_tag:
+                container = self.svcCfg.get_container_by_tag(cnt_tag)
+                if not container:
+                    Util.print_error_and_die(
+                        f"Service '{self.svcCfg.tag}' does not have a "
+                        f"container named '{cnt_tag}'."
+                    )
+            elif self.svcCfg.containers and len(self.svcCfg.containers) == 1:
+                container = self.svcCfg.containers[0]
+            else:
+                Util.print_error_and_die(
+                    f"Service '{self.svcCfg.tag}' has multiple containers. "
+                    f"Specify a container name."
+                )
+
+            result = run_compose(
+                rendered_stack,
+                "exec",
+                "-T",
+                container.run_container_name or "" if container else "",
+                *cmd,
+                project_name=self.envCfg.tag,
+                capture=True,
+            )
+            return ExecResult(
+                stdout=result.stdout or "",
+                stderr=result.stderr or "",
+                returncode=result.returncode,
+            )
+        else:
+            Util.print_error_and_die(
+                f"Environment: '{self.envCfg.tag}' is not running."
+            )
+            raise AssertionError("unreachable")
 
     def _get_rendered_compose_stack(self) -> Optional[list[str]]:
         """

--- a/src/plugin/context.py
+++ b/src/plugin/context.py
@@ -29,7 +29,7 @@ from config import (
 )
 from config.config import RemoteCfg
 from environment import Environment
-from service import Service
+from service import ExecResult, Service
 from storage.snapshot import IndexCatalogue, SnapshotManifest
 
 
@@ -79,6 +79,18 @@ class PluginConfigView(Protocol):
         self, plugin_id: str, key: str, value: str
     ) -> PluginCfg:
         """Set one key in *plugin_id*'s own config dict and persist it."""
+        ...
+
+    def set_environment_config_value(
+        self, env_tag: str, key: str, value: str
+    ) -> EnvironmentCfg:
+        """Set one key in an environment's own config dict and persist it.
+
+        Values set here override the plugin's own config defaults for that
+        environment's ``${VAR}`` template resolution, but are still
+        overridable by ``~/.shpd.values`` or a per-environment values file
+        (see ``docs/plugins.md``'s resolution-precedence section).
+        """
         ...
 
 
@@ -207,6 +219,20 @@ class PluginServiceView(Protocol):
         cnt_tag: Optional[str] = None,
     ) -> None:
         """Open an interactive shell in the service container."""
+        ...
+
+    def exec_svc(
+        self,
+        envCfg: EnvironmentCfg,
+        svc_tag: str,
+        cmd: list[str],
+        cnt_tag: Optional[str] = None,
+    ) -> Optional[ExecResult]:
+        """Run *cmd* inside the service container and capture its output.
+
+        The scriptable counterpart to ``shell_svc`` (interactive, no
+        captured output) and ``logs_svc`` (streaming, no exit code).
+        """
         ...
 
     def render_svc(

--- a/src/service/__init__.py
+++ b/src/service/__init__.py
@@ -6,6 +6,6 @@
 # Commercial: see LICENSE-COMMERCIAL or contact licensing@moonyfringers.net.
 
 
-from .service import Service, ServiceFactory, ServiceMng
+from .service import ExecResult, Service, ServiceFactory, ServiceMng
 
-__all__ = ["Service", "ServiceMng", "ServiceFactory"]
+__all__ = ["ExecResult", "Service", "ServiceMng", "ServiceFactory"]

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Any, Optional
 
 import yaml
@@ -17,6 +18,17 @@ from config import ConfigMng, EnvironmentCfg, ServiceCfg
 from util import Util
 
 from .render import build_svc_details_tree, render_svc_summary
+
+
+@dataclass
+class ExecResult:
+    """Captured result of a non-interactive `exec` into a service
+    container -- the scriptable counterpart to `get_shell` (interactive)
+    and `get_logs` (streaming, no exit code)."""
+
+    stdout: str
+    stderr: str
+    returncode: int
 
 
 class Service(ABC):
@@ -133,6 +145,10 @@ class Service(ABC):
         """Get a shell session for the service."""
         return self.get_shell_impl(cnt_tag)
 
+    def exec(self, cmd: list[str], cnt_tag: Optional[str] = None) -> ExecResult:
+        """Run a command inside the service container, capturing output."""
+        return self.exec_impl(cmd, cnt_tag)
+
     @abstractmethod
     def render_target_impl(self, resolved: bool) -> str:
         """
@@ -174,6 +190,13 @@ class Service(ABC):
     @abstractmethod
     def get_shell_impl(self, cnt_tag: Optional[str] = None):
         """Get a shell session for the service."""
+        pass
+
+    @abstractmethod
+    def exec_impl(
+        self, cmd: list[str], cnt_tag: Optional[str] = None
+    ) -> ExecResult:
+        """Run a command inside the service container, capturing output."""
         pass
 
     def to_config(self) -> ServiceCfg:
@@ -380,3 +403,16 @@ class ServiceMng:
         service = self.get_service(envCfg, svc_tag)
         if service:
             service.get_shell(cnt_tag)
+
+    def exec_svc(
+        self,
+        envCfg: EnvironmentCfg,
+        svc_tag: str,
+        cmd: list[str],
+        cnt_tag: Optional[str] = None,
+    ) -> Optional[ExecResult]:
+        """Run a command inside a service container, capturing output."""
+        service = self.get_service(envCfg, svc_tag)
+        if service:
+            return service.exec(cmd, cnt_tag)
+        return None

--- a/src/shepctl.py
+++ b/src/shepctl.py
@@ -14,6 +14,7 @@ import sys
 from typing import Any, Callable, List, Optional
 
 import click
+import yaml
 
 from completion import CompletionMng
 from config import ConfigMng, EnvironmentCfg
@@ -396,6 +397,60 @@ def get_env(
 def add_env(shepherd: ShepherdMng, template: str, tag: str):
     """Add a new environment."""
     shepherd.environmentMng.add_env(template, tag)
+
+
+@env.group(name="config")
+def env_config():
+    """Manage an environment's own `config:` block (${VAR} overrides)."""
+
+
+@env_config.command(name="set")
+@click.argument("key", required=True)
+@click.argument("value", required=True)
+@click.argument("env_tag", required=False)
+@click.pass_obj
+def set_env_config(
+    shepherd: ShepherdMng, key: str, value: str, env_tag: Optional[str]
+):
+    """Set KEY=VALUE in ENV_TAG's (or the checked-out env's) config block.
+
+    Overrides a plugin's own config defaults for that environment's
+    ${VAR} template resolution -- still overridable by ~/.shpd.values or
+    a per-environment values file.
+    """
+    env_tag = _resolve_env_tag(shepherd, env_tag)
+    try:
+        shepherd.configMng.set_environment_config_value(env_tag, key, value)
+    except ValueError as e:
+        raise click.UsageError(str(e))
+
+
+@env_config.command(name="unset")
+@click.argument("key", required=True)
+@click.argument("env_tag", required=False)
+@click.pass_obj
+def unset_env_config(shepherd: ShepherdMng, key: str, env_tag: Optional[str]):
+    """Remove KEY from ENV_TAG's (or the checked-out env's) config block."""
+    env_tag = _resolve_env_tag(shepherd, env_tag)
+    try:
+        shepherd.configMng.remove_environment_config_value(env_tag, key)
+    except ValueError as e:
+        raise click.UsageError(str(e))
+
+
+@env_config.command(name="get")
+@click.argument("env_tag", required=False)
+@click.pass_obj
+def get_env_config(shepherd: ShepherdMng, env_tag: Optional[str]):
+    """Print ENV_TAG's (or the checked-out env's) config block."""
+    env_tag = _resolve_env_tag(shepherd, env_tag)
+    envCfg = shepherd.configMng.get_environment(env_tag)
+    if not envCfg:
+        raise click.UsageError(f"Environment '{env_tag}' not found.")
+    if not envCfg.config:
+        click.echo("{}")
+        return
+    click.echo(yaml.dump(envCfg.config, sort_keys=False))
 
 
 @env.command(name="clone")

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -282,6 +282,75 @@ service_templates:
 
 
 @pytest.mark.cfg
+def test_envs_path_is_exposed_as_template_var(mocker: MockerFixture):
+    """`${envs_path}` resolves to shepherd's own per-environment root, so a
+    service_template can anchor persistent host state under
+    `${envs_path}/#{env.tag}/...` instead of requiring a hand-supplied
+    absolute host path in an environment's `config:` block."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+service_templates:
+  - tag: svc
+    factory: docker
+    containers:
+      - tag: c
+        image: nginx:latest
+        volumes:
+          - ${envs_path}/storage:/data
+"""
+    config = _load_config_with_yaml(mocker, config_yaml)
+    config.set_resolved()
+
+    assert config.envs_path == "/tmp/shpd/envs"
+    assert config.service_templates
+    volumes = config.service_templates[0].containers[0].volumes
+    assert volumes and volumes[0] == "/tmp/shpd/envs/storage:/data"
+
+
+@pytest.mark.cfg
+def test_envs_path_var_not_shadowed_by_stale_user_values(mocker: MockerFixture):
+    """A real `~/.shpd.conf` already defines its own `envs_path` (see
+    `DEFAULT_SHPD_VALUES_TEMPLATE`), raw and never tilde-expanded --
+    `_resolve_str.var_repl` checks `user_values` before the resolver
+    mapping, so that stale, unexpanded entry must not shadow the
+    properly resolved `${envs_path}` this feature exposes."""
+
+    values = (
+        "shpd_path=~/shpd\n"
+        "templates_path=${shpd_path}/templates\n"
+        "envs_path=${shpd_path}/envs\n"
+        "log_file=${shpd_path}/shepctl.log\n"
+        "log_level=WARNING\n"
+        "log_stdout=false\n"
+        "log_format=%(asctime)s - %(levelname)s - %(message)s\n"
+    )
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+service_templates:
+  - tag: svc
+    factory: docker
+    containers:
+      - tag: c
+        image: nginx:latest
+        volumes:
+          - ${envs_path}/storage:/data
+"""
+    config = _load_config_with_yaml(mocker, config_yaml, values=values)
+    config.set_resolved()
+
+    expected = os.path.expanduser("~/shpd/envs")
+    assert config.envs_path == expected
+    volumes = config.service_templates[0].containers[0].volumes
+    assert volumes and volumes[0] == f"{expected}/storage:/data"
+    assert "~" not in volumes[0]
+
+
+@pytest.mark.cfg
 def test_user_values_override_plugin_config(mocker: MockerFixture):
     """A user_values entry with the same key takes precedence over a
     plugin's `config` value on collision."""

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -8,6 +8,7 @@
 
 import os
 from copy import deepcopy
+from pathlib import Path
 from unittest.mock import mock_open
 
 import pytest
@@ -348,6 +349,149 @@ service_templates:
     volumes = config.service_templates[0].containers[0].volumes
     assert volumes and volumes[0] == f"{expected}/storage:/data"
     assert "~" not in volumes[0]
+
+
+@pytest.mark.cfg
+def test_env_values_file_overrides_global_user_values(tmp_path: Path):
+    """`envs_path/<tag>/.shpd.values` is the per-environment analogue of
+    `~/.shpd.values` -- an override layer *above* the global values file
+    (not merely the environment's own `config:` block), scoped to that
+    environment's subtree only. Uses real files (no mocking) since the
+    feature is filesystem-driven by design."""
+
+    shpd_path = tmp_path / "shpd"
+    shpd_path.mkdir()
+    (shpd_path / "envs" / "myenv").mkdir(parents=True)
+
+    conf_file = tmp_path / ".shpd.conf"
+    conf_file.write_text(
+        f"shpd_path={shpd_path}\n"
+        "templates_path=${shpd_path}/templates\n"
+        "envs_path=${shpd_path}/envs\n"
+        f"log_file={shpd_path}/shepctl.log\n"
+        "log_level=WARNING\n"
+        "log_stdout=false\n"
+        "log_format=%(asctime)s - %(levelname)s - %(message)s\n"
+        "region=global-region\n"
+    )
+
+    (shpd_path / "envs" / "myenv" / ".shpd.values").write_text(
+        "region=env-region\n"
+    )
+
+    (shpd_path / ".shpd.yaml").write_text("""
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs:
+  - template: default
+    factory: docker
+    tag: myenv
+    services:
+      - tag: svc
+        factory: docker
+        template: svc
+        containers:
+          - tag: c
+            image: nginx:latest
+            environment:
+              - REGION=${region}
+        status:
+          active: true
+          rendered_config: null
+    status:
+      active: true
+      rendered_config: null
+  - template: default
+    factory: docker
+    tag: other
+    services:
+      - tag: svc
+        factory: docker
+        template: svc
+        containers:
+          - tag: c
+            image: nginx:latest
+            environment:
+              - REGION=${region}
+        status:
+          active: true
+          rendered_config: null
+    status:
+      active: true
+      rendered_config: null
+""")
+
+    cMng = ConfigMng(str(conf_file))
+    config = cMng.load_config()
+    config.set_resolved()
+
+    assert config.envs
+    myenv = next(e for e in config.envs if e.tag == "myenv")
+    other = next(e for e in config.envs if e.tag == "other")
+    assert myenv.services
+    assert other.services
+
+    myenv_env = myenv.services[0].containers[0].environment
+    other_env = other.services[0].containers[0].environment
+    assert myenv_env and myenv_env[0] == "REGION=env-region"
+    assert other_env and other_env[0] == "REGION=global-region"
+
+
+@pytest.mark.cfg
+def test_env_values_file_absent_falls_back_to_global(tmp_path: Path):
+    """No per-environment values file is the common case -- the
+    environment's subtree keeps resolving against the global
+    `~/.shpd.values`."""
+
+    shpd_path = tmp_path / "shpd"
+    shpd_path.mkdir()
+
+    conf_file = tmp_path / ".shpd.conf"
+    conf_file.write_text(
+        f"shpd_path={shpd_path}\n"
+        "templates_path=${shpd_path}/templates\n"
+        "envs_path=${shpd_path}/envs\n"
+        f"log_file={shpd_path}/shepctl.log\n"
+        "log_level=WARNING\n"
+        "log_stdout=false\n"
+        "log_format=%(asctime)s - %(levelname)s - %(message)s\n"
+        "region=global-region\n"
+    )
+
+    (shpd_path / ".shpd.yaml").write_text("""
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs:
+  - template: default
+    factory: docker
+    tag: myenv
+    services:
+      - tag: svc
+        factory: docker
+        template: svc
+        containers:
+          - tag: c
+            image: nginx:latest
+            environment:
+              - REGION=${region}
+        status:
+          active: true
+          rendered_config: null
+    status:
+      active: true
+      rendered_config: null
+""")
+
+    cMng = ConfigMng(str(conf_file))
+    config = cMng.load_config()
+    config.set_resolved()
+
+    assert config.envs
+    myenv = config.envs[0]
+    assert myenv.env_values is None
+    assert myenv.services
+    environment = myenv.services[0].containers[0].environment
+    assert environment and environment[0] == "REGION=global-region"
 
 
 @pytest.mark.cfg

--- a/src/tests/test_shepherd.py
+++ b/src/tests/test_shepherd.py
@@ -960,6 +960,104 @@ def test_cli_add_env(
 
 
 @pytest.mark.shpd
+def test_cli_env_config_set_and_get(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+):
+    """'env config set' persists a key into the checked-out env's own
+    config block; 'env config get' prints it back."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["env", "config", "set", "region", "eu-west-1"])
+    assert result.exit_code == 0, result.output
+
+    sm = ShepherdMng()
+    env = sm.configMng.get_environment("test-1")
+    assert env
+    assert env.config == {"region": "eu-west-1"}
+
+    result = runner.invoke(cli, ["env", "config", "get"])
+    assert result.exit_code == 0, result.output
+    assert "region: eu-west-1" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_env_config_set_explicit_tag(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(
+        cli, ["env", "config", "set", "region", "eu-west-1", "test-1"]
+    )
+    assert result.exit_code == 0, result.output
+
+    sm = ShepherdMng()
+    env = sm.configMng.get_environment("test-1")
+    assert env
+    assert env.config == {"region": "eu-west-1"}
+
+
+@pytest.mark.shpd
+def test_cli_env_config_set_unknown_env_errors(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(
+        cli, ["env", "config", "set", "region", "eu-west-1", "does-not-exist"]
+    )
+    assert result.exit_code != 0
+    assert "not found" in result.output
+
+
+@pytest.mark.shpd
+def test_cli_env_config_unset(shpd_conf: tuple[Path, Path], runner: CliRunner):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["env", "config", "set", "region", "eu-west-1"])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(cli, ["env", "config", "unset", "region"])
+    assert result.exit_code == 0, result.output
+
+    sm = ShepherdMng()
+    env = sm.configMng.get_environment("test-1")
+    assert env
+    assert not env.config
+
+
+@pytest.mark.shpd
+def test_cli_env_config_unset_missing_key_errors(
+    shpd_conf: tuple[Path, Path], runner: CliRunner
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("shpd", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    result = runner.invoke(cli, ["env", "config", "unset", "region"])
+    assert result.exit_code != 0
+    assert "not set" in result.output
+
+
+@pytest.mark.shpd
 def test_cli_clone_env(
     shpd_conf: tuple[Path, Path], runner: CliRunner, mocker: MockerFixture
 ):

--- a/src/tests/test_svc_docker_compose.py
+++ b/src/tests/test_svc_docker_compose.py
@@ -17,7 +17,7 @@ from click.testing import CliRunner
 from pytest_mock import MockerFixture
 from test_util import add_container_field_defaults, read_fixture
 
-from shepctl import cli
+from shepctl import ShepherdMng, cli
 from util import Util
 
 svc_env_running_ps_output = (
@@ -606,6 +606,74 @@ def test_shell_svc_cnt_2(
     result = runner.invoke(cli, ["svc", "shell", "test-1", "container-2"])
     assert result.exit_code == 0
     mock_subproc.assert_called_once()
+
+
+@pytest.mark.docker
+def test_exec_svc_captures_output(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    """The scriptable counterpart to `shell_svc` -- disables `-T` pseudo-tty
+    allocation and returns an ExecResult instead of streaming to the
+    terminal, so plugin code can inspect stdout/stderr/exit code."""
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("svc_docker", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    mock_subprocess_with_running_ps(mocker)
+    result = runner.invoke(cli, ["env", "up"])
+    assert result.exit_code == 0
+
+    mock_subproc = mocker.patch(
+        "docker.docker_compose_util.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=["docker", "compose", "exec", "-T", "test-test-1", "id"],
+            returncode=0,
+            stdout="uid=0(root)\n",
+            stderr="",
+        ),
+    )
+
+    sm = ShepherdMng()
+    envCfg = sm.configMng.get_environment("test-1")
+    assert envCfg
+
+    exec_result = sm.serviceMng.exec_svc(envCfg, "test", ["id"])
+
+    assert exec_result is not None
+    assert exec_result.stdout == "uid=0(root)\n"
+    assert exec_result.stderr == ""
+    assert exec_result.returncode == 0
+    mock_subproc.assert_called_once()
+    exec_cmd = mock_subproc.call_args.args[0]
+    assert "-T" in exec_cmd
+    assert "id" in exec_cmd
+
+
+@pytest.mark.docker
+def test_exec_svc_unknown_service_returns_none(
+    shpd_conf: tuple[Path, Path],
+    runner: CliRunner,
+    mocker: MockerFixture,
+):
+    shpd_path = shpd_conf[0]
+    shpd_path.mkdir(parents=True, exist_ok=True)
+    shpd_yaml = shpd_path / ".shpd.yaml"
+    shpd_config = read_fixture("svc_docker", "shpd.yaml")
+    shpd_yaml.write_text(shpd_config)
+
+    mock_subprocess_with_running_ps(mocker)
+    result = runner.invoke(cli, ["env", "up"])
+    assert result.exit_code == 0
+
+    sm = ShepherdMng()
+    envCfg = sm.configMng.get_environment("test-1")
+    assert envCfg
+
+    assert sm.serviceMng.exec_svc(envCfg, "does-not-exist", ["id"]) is None
 
 
 @pytest.mark.docker


### PR DESCRIPTION
Fixes #298

## Summary

Three plugin-API gaps found while building an external plugin:

- **`${envs_path}` template var** — no way for a template to reference shepherd's own per-environment directory (`#{env.path}` isn't a valid ref; `envs_path` wasn't in the base `${VAR}` resolver). Every plugin needing persistent per-environment host storage had to make the user hand-compute an absolute path. Now `${envs_path}/#{env.tag}/...` resolves directly. Also fixes a real shadowing bug: a real `~/.shpd.conf` already defines its own `envs_path` (raw, not tilde-expanded), which would otherwise silently leak a literal `~` into bind-mount sources.
- **`exec_svc` / `ExecResult`** — `PluginServiceView` only exposed `logs_svc` (streaming) and `shell_svc` (interactive); nothing scriptable. Adds `Service.exec`/`exec_impl`, `ServiceMng.exec_svc`, `DockerComposeSvc.exec_impl` (`docker compose exec -T`), and declares `set_environment_config_value` (already existed on `ConfigMng`) on `PluginConfigView`.
- **`shepctl env config set/get/unset`** + **per-environment values file** (`envs_path/<tag>/.shpd.values`) — no CLI command existed to set an environment's own `config:` block outside a plugin, and no way to override `~/.shpd.values` scoped to one environment without touching the global file.

`docs/plugins.md`'s resolution-precedence section updated for both the CLI command and the new values-file layer.

## Test plan

- [x] `pytest` (756 passed)
- [x] `black --check` / `isort --check-only` / `pyright` (0 errors)
- [x] Verified live against a real environment: `${envs_path}` renders correctly, no literal `~` in bind mounts
- [x] `/code-review` run, both findings (dead code, redundant full-tree resolve pass) fixed