### PR TITLE
feat: declarative container endpoints, rendered in env status/up

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -526,6 +526,23 @@ class HealthcheckCfg(Resolvable):
 
 
 @dataclass
+class EndpointCfg(Resolvable):
+    """
+    A declarative, human-facing endpoint a container exposes once
+    running -- a label and a `${VAR}`/`#{ref}`-resolvable URL, rendered
+    by `environment/render.py`'s `build_env_status_tree` under that
+    service in both `env status` and `env up`'s completion display
+    (they share one render pipeline). Purely declarative: covers a
+    templated URL string, not a dynamically-detected one (e.g. a
+    runtime-assigned port) -- add a plugin-side hook later if that's
+    ever needed.
+    """
+
+    label: str
+    url: str
+
+
+@dataclass
 class ContainerCfg(Resolvable):
     tag: str
     image: Optional[str] = None
@@ -561,6 +578,9 @@ class ContainerCfg(Resolvable):
     # see `TraefikIngressProvider._plan_container`, which emits an explicit
     # `loadbalancer.server.port` label whenever this is set.
     ingress_port: Optional[int] = None
+    # Human-facing endpoints (label + resolvable URL), shown once this
+    # container is running -- see `EndpointCfg`.
+    endpoints: Optional[list[EndpointCfg]] = None
     # Ingress-provider-computed labels (routing rules, TLS flags, ...),
     # distinct from user-declared `labels`. Transient like `run_hostname`/
     # `run_container_name`: computed fresh by `Environment._apply_ingress_plan`
@@ -1083,6 +1103,13 @@ def _parse_healthcheck(item: Any) -> HealthcheckCfg:
     )
 
 
+def _parse_endpoint(item: Any) -> EndpointCfg:
+    return EndpointCfg(
+        label=item["label"],
+        url=item["url"],
+    )
+
+
 def _parse_container(item: Any) -> ContainerCfg:
     inits = (
         [_parse_init(init) for init in item.get("inits", [])]
@@ -1121,6 +1148,11 @@ def _parse_container(item: Any) -> ContainerCfg:
             else item.get("ingress")
         ),
         ingress_port=item.get("ingress_port"),
+        endpoints=(
+            [_parse_endpoint(e) for e in item["endpoints"]]
+            if item.get("endpoints")
+            else None
+        ),
     )
 
 

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -1358,7 +1358,7 @@ class EnvironmentMng:
                 progress_label="Checking",
             )
             return
-        grouped, _, _, has_containers = self._collect_env_status(
+        grouped, _, _, has_containers, endpoints = self._collect_env_status(
             env,
             include_gates=False,
         )
@@ -1372,6 +1372,7 @@ class EnvironmentMng:
             self._build_env_status_tree(
                 envCfg.tag,
                 grouped,
+                endpoints=endpoints,
             )
         )
 
@@ -1452,6 +1453,7 @@ class EnvironmentMng:
         flashing_containers: Optional[set[str]] = None,
         flashing_probes: Optional[set[tuple[str, str]]] = None,
         flashing_summary_keys: Optional[set[str]] = None,
+        endpoints: Optional[dict[str, list[tuple[str, str]]]] = None,
     ):
         return build_env_status_tree(
             env_tag,
@@ -1466,6 +1468,7 @@ class EnvironmentMng:
             flashing_containers=flashing_containers,
             flashing_probes=flashing_probes,
             flashing_summary_keys=flashing_summary_keys,
+            endpoints=endpoints,
         )
 
     def _build_command_log_panel(
@@ -1494,7 +1497,13 @@ class EnvironmentMng:
         env: Environment,
         gate_status: Optional[dict[str, Optional[bool]]] = None,
         include_gates: bool = True,
-    ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
+    ) -> tuple[
+        dict[str, list[list[str]]],
+        bool,
+        bool,
+        bool,
+        dict[str, list[tuple[str, str]]],
+    ]:
         return collect_env_status(
             env,
             details_enabled=True,

--- a/src/environment/render.py
+++ b/src/environment/render.py
@@ -83,7 +83,13 @@ def collect_env_status(
     details_enabled: bool,
     gate_status: Optional[dict[str, Optional[bool]]] = None,
     include_gates: bool = True,
-) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
+) -> tuple[
+    dict[str, list[list[str]]],
+    bool,
+    bool,
+    bool,
+    dict[str, list[tuple[str, str]]],
+]:
     """
     Build grouped status rows used by table renderers and wait loops.
 
@@ -92,6 +98,11 @@ def collect_env_status(
     - all_running: every discovered container is running
     - any_running: at least one discovered container is running
     - has_containers: at least one container exists in config
+    - endpoints: (label, url) pairs keyed by service tag, collected only
+      from currently-running containers that declare `endpoints:`
+      (`ContainerCfg.endpoints`) -- a stopped container's endpoints
+      aren't reachable, so aren't shown, matching sctl's own
+      `hlp_get_service_is_running` guard around its endpoint table.
     """
     env_status = env.status()
     services = env.get_services()
@@ -100,12 +111,14 @@ def collect_env_status(
     }
 
     grouped: dict[str, list[list[str]]] = {}
+    endpoints: dict[str, list[tuple[str, str]]] = {}
     all_running = True
     any_running = False
     has_containers = False
 
     for svc in services:
         rows: list[list[str]] = []
+        service_endpoints: list[tuple[str, str]] = []
         service_gates = ""
         service_gate_details = ""
         if include_gates:
@@ -128,6 +141,10 @@ def collect_env_status(
             if state == "running":
                 any_running = True
                 state_colored = "[bold green]running[/bold green]"
+                for endpoint in cast(list[Any], container.endpoints) or []:
+                    service_endpoints.append(
+                        (cast(str, endpoint.label), cast(str, endpoint.url))
+                    )
             elif state == "stopped":
                 state_colored = "[dim]stopped[/dim]"
             else:
@@ -144,11 +161,13 @@ def collect_env_status(
 
         if rows:
             grouped[svc.svcCfg.tag] = rows
+        if service_endpoints:
+            endpoints[svc.svcCfg.tag] = service_endpoints
 
     if not has_containers:
         all_running = False
 
-    return grouped, all_running, any_running, has_containers
+    return grouped, all_running, any_running, has_containers, endpoints
 
 
 def render_env_summary(env: Environment) -> None:
@@ -367,6 +386,7 @@ def build_env_status_tree(
     flashing_containers: Optional[set[str]] = None,
     flashing_probes: Optional[set[tuple[str, str]]] = None,
     flashing_summary_keys: Optional[set[str]] = None,
+    endpoints: Optional[dict[str, list[tuple[str, str]]]] = None,
 ) -> Any:
     """Render the environment status as a tree with optional side panels."""
     title = f"[bold white]{env_tag}[/bold white]"
@@ -412,6 +432,14 @@ def build_env_status_tree(
                 else state
             )
             service_node.add(f"[white]{container}[/white]: {rendered_state}")
+
+        service_endpoints = (endpoints or {}).get(service)
+        if service_endpoints:
+            endpoints_node = service_node.add(
+                "[bold green]endpoints[/bold green]"
+            )
+            for label, url in service_endpoints:
+                endpoints_node.add(f"[white]{label}[/white]: {url}")
 
     panels: list[Any] = []
     if command_log is not None and command_log_limit is not None:

--- a/src/environment/render.py
+++ b/src/environment/render.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Optional, Protocol, Sequence, cast
 import yaml
 from rich import box
 from rich.console import Group
+from rich.markup import escape
 from rich.panel import Panel
 from rich.text import Text
 from rich.tree import Tree
@@ -439,7 +440,14 @@ def build_env_status_tree(
                 "[bold green]endpoints[/bold green]"
             )
             for label, url in service_endpoints:
-                endpoints_node.add(f"[white]{label}[/white]: {url}")
+                # label/url come from plugin/user template config, not
+                # shepherd's own control -- a URL containing "[" (e.g. an
+                # IPv6 literal, "http://[::1]:8080/") would otherwise be
+                # parsed as Rich markup, corrupting the render or raising
+                # MarkupError and killing the whole `env status` output.
+                endpoints_node.add(
+                    f"[white]{escape(label)}[/white]: {escape(url)}"
+                )
 
     panels: list[Any] = []
     if command_log is not None and command_log_limit is not None:

--- a/src/environment/status_wait.py
+++ b/src/environment/status_wait.py
@@ -30,7 +30,10 @@ if TYPE_CHECKING:
 
 GroupedStatus: TypeAlias = dict[str, list[list[str]]]
 GateStatus: TypeAlias = dict[str, Optional[bool]]
-CollectStatusResult: TypeAlias = tuple[GroupedStatus, bool, bool, bool]
+EndpointsStatus: TypeAlias = dict[str, list[tuple[str, str]]]
+CollectStatusResult: TypeAlias = tuple[
+    GroupedStatus, bool, bool, bool, EndpointsStatus
+]
 ContainerStateMap: TypeAlias = dict[str, str]
 ProbeStateMap: TypeAlias = dict[tuple[str, str], str]
 SummaryStateMap: TypeAlias = dict[str, str]
@@ -361,6 +364,7 @@ def wait_for_env_state(
         remaining: Optional[int],
         tick: int,
         show_ready: bool = False,
+        endpoints: Optional[EndpointsStatus] = None,
     ) -> Any:
         now = time.monotonic()
         flashing_containers = {
@@ -404,6 +408,7 @@ def wait_for_env_state(
             flashing_containers=flashing_containers,
             flashing_probes=flashing_probes,
             flashing_summary_keys=flashing_summary_keys,
+            endpoints=endpoints,
         )
         if keep_output_hint_active:
             return Group(
@@ -448,7 +453,7 @@ def wait_for_env_state(
         while True:
             raise_action_error()
             current_gate_status = get_gate_status()
-            grouped, all_running, any_running, has_containers = (
+            grouped, all_running, any_running, has_containers, _ = (
                 hooks.collect_env_status(
                     env,
                     current_gate_status,
@@ -497,7 +502,7 @@ def wait_for_env_state(
                         f"'{env.envCfg.tag}' to be {timeout_target}."
                     )
             current_gate_status = get_gate_status()
-            grouped, all_running, any_running, has_containers = (
+            grouped, all_running, any_running, has_containers, endpoints = (
                 hooks.collect_env_status(
                     env,
                     current_gate_status,
@@ -537,6 +542,7 @@ def wait_for_env_state(
                         remaining=remaining,
                         tick=0,
                         show_ready=True,
+                        endpoints=endpoints,
                     )
                 )
                 return
@@ -577,6 +583,7 @@ def wait_for_env_state(
         # are involved.
         latest_gate_status: Optional[GateStatus] = None
         grouped: GroupedStatus = {}
+        endpoints: EndpointsStatus = {}
         all_running = False
         any_running = False
         # `has_containers` means the environment currently resolves to at
@@ -594,6 +601,7 @@ def wait_for_env_state(
             nonlocal next_status_poll_at
             nonlocal latest_gate_status
             nonlocal grouped
+            nonlocal endpoints
             nonlocal all_running
             nonlocal any_running
             nonlocal has_containers
@@ -610,11 +618,13 @@ def wait_for_env_state(
                         poll_grouped,
                         poll_all_running,
                         poll_any_running,
-                        (poll_has_containers),
+                        poll_has_containers,
+                        poll_endpoints,
                     ) = hooks.collect_env_status(env, gate_status_now)
                     with snapshot_lock:
                         latest_gate_status = gate_status_now
                         grouped = poll_grouped
+                        endpoints = poll_endpoints
                         all_running = poll_all_running
                         any_running = poll_any_running
                         has_containers = poll_has_containers
@@ -661,6 +671,7 @@ def wait_for_env_state(
                     snap_has_snapshot = has_snapshot
                     snap_has_containers = has_containers
                     snap_grouped = grouped
+                    snap_endpoints = endpoints
                     snap_all_running = all_running
                     snap_any_running = any_running
                     snap_gate_status = latest_gate_status
@@ -754,6 +765,7 @@ def wait_for_env_state(
                             remaining=remaining,
                             tick=ui_tick_count,
                             show_ready=show_ready,
+                            endpoints=snap_endpoints,
                         )
                     )
 
@@ -778,6 +790,7 @@ def wait_for_env_state(
                                     remaining=remaining,
                                     tick=ui_tick_count,
                                     show_ready=True,
+                                    endpoints=snap_endpoints,
                                 )
                             )
                         return

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -248,6 +248,43 @@ def _load_config_with_yaml(
 
 
 @pytest.mark.cfg
+def test_container_endpoints_parse_and_resolve(mocker: MockerFixture):
+    """`ContainerCfg.endpoints` (label + ${VAR}/#{ref}-resolvable url)
+    parses and resolves like any other container field -- rendered by
+    `environment/render.py`'s `build_env_status_tree` under that
+    service, in both `env status` and `env up`'s completion display."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+service_templates:
+  - tag: svc
+    factory: docker
+    containers:
+      - tag: c
+        image: nginx:latest
+        endpoints:
+          - label: http
+            url: "https://app-#{env.tag}.${domain}"
+"""
+    config = _load_config_with_yaml(
+        mocker,
+        config_yaml,
+        values=_MINIMAL_VALUES + "domain=example.test\n",
+    )
+    config.set_resolved()
+
+    assert config.service_templates
+    endpoints = config.service_templates[0].containers[0].endpoints
+    assert endpoints and len(endpoints) == 1
+    assert endpoints[0].label == "http"
+    # #{env.tag} only resolves once this container is nested under a
+    # real EnvironmentCfg (the ref map is env-scoped) -- unresolved
+    # here is correct; ${domain} still resolves via user_values.
+    assert endpoints[0].url == "https://app-#{env.tag}.example.test"
+
+
 def test_plugin_config_resolves_template_placeholder(mocker: MockerFixture):
     """A plugin's own `config` values resolve ${VAR} placeholders in that
     plugin's service_templates, without a same-named shell/user_values

--- a/src/tests/test_environment_mng.py
+++ b/src/tests/test_environment_mng.py
@@ -7,13 +7,14 @@
 
 from __future__ import annotations
 
+import io
 import time
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from pytest_mock import MockerFixture
-from rich.console import Group
+from rich.console import Console, Group
 from rich.panel import Panel
 from rich.text import Text
 from rich.tree import Tree
@@ -589,6 +590,37 @@ def test_collect_and_render_env_status_shows_endpoints_only_when_running(
     endpoints_children = [c.label for c in running_node.children]
     assert any("endpoints" in str(label) for label in endpoints_children)
     assert not any("endpoints" in str(c.label) for c in stopped_node.children)
+
+
+def test_build_env_status_tree_escapes_endpoint_rich_markup(
+    mocker: MockerFixture,
+):
+    """An endpoint's label/url come from plugin/user template config, not
+    shepherd's own control -- a label or url shaped like a real Rich tag
+    (e.g. "[bold red]...[/bold red]") would otherwise be interpreted as
+    markup instead of printed literally, letting template config inject
+    arbitrary styling (or, for a malformed tag, raise MarkupError and
+    kill the whole `env status` output). Regression test for a real bug
+    found by review before shepherd#300 merged -- renders through a real
+    Console (not just inspecting the stored markup source) so the
+    assertion reflects what a user actually sees on screen."""
+    mng = _new_environment_mng(mocker)
+
+    endpoints = {"svc-a": [("[bold red]http[/bold red]", "http://x:8080/")]}
+    grouped: dict[str, list[list[str]]] = {
+        "svc-a": [["cnt-a", "cnt-a", "[bold green]running[/bold green]"]]
+    }
+
+    tree = mng._build_env_status_tree("env-1", grouped, endpoints=endpoints)
+
+    buf = io.StringIO()
+    Console(file=buf, force_terminal=False, width=200).print(tree)
+    output = buf.getvalue()
+
+    # Printed literally, not interpreted as a style tag (which would
+    # strip "[bold red]"/"[/bold red]" from the visible output).
+    assert "[bold red]http[/bold red]" in output
+    assert "http://x:8080/" in output
 
 
 def test_format_service_gate_glyphs_states(mocker: MockerFixture):

--- a/src/tests/test_environment_mng.py
+++ b/src/tests/test_environment_mng.py
@@ -61,15 +61,22 @@ def test_wait_for_env_up_does_not_exit_while_starting(mocker: MockerFixture):
     env.get_pull_state.return_value = []
 
     status_samples: list[
-        tuple[dict[str, list[list[str]]], bool, bool, bool]
+        tuple[
+            dict[str, list[list[str]]],
+            bool,
+            bool,
+            bool,
+            dict[str, list[tuple[str, str]]],
+        ]
     ] = [
-        ({}, False, False, False),
-        ({}, False, False, False),
+        ({}, False, False, False, {}),
+        ({}, False, False, False, {}),
         (
             {"svc": [["cnt", "[bold green]running[/bold green]"]]},
             True,
             True,
             True,
+            {},
         ),
     ]
     status_idx = {"value": 0}
@@ -77,7 +84,13 @@ def test_wait_for_env_up_does_not_exit_while_starting(mocker: MockerFixture):
     def collect_status(
         _env: Any,
         gate_status: Any = None,
-    ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
+    ) -> tuple[
+        dict[str, list[list[str]]],
+        bool,
+        bool,
+        bool,
+        dict[str, list[tuple[str, str]]],
+    ]:
         idx = min(status_idx["value"], len(status_samples) - 1)
         status_idx["value"] += 1
         return status_samples[idx]
@@ -111,7 +124,7 @@ def test_wait_for_env_up_propagates_action_error(mocker: MockerFixture):
     env.get_pull_state.return_value = []
     env.get_services.return_value = []
     mocker.patch.object(
-        mng, "_collect_env_status", return_value=({}, False, False, False)
+        mng, "_collect_env_status", return_value=({}, False, False, False, {})
     )
 
     fake_console = mocker.Mock()
@@ -203,6 +216,7 @@ def test_wait_for_env_down_hides_gates_column(mocker: MockerFixture):
             False,
             False,
             True,
+            {},
         ),
     )
     build_mock = mocker.patch.object(
@@ -264,19 +278,27 @@ def test_wait_for_env_up_non_terminal_waits_for_running_state(
     env.get_services.return_value = []
 
     status_samples: list[
-        tuple[dict[str, list[list[str]]], bool, bool, bool]
+        tuple[
+            dict[str, list[list[str]]],
+            bool,
+            bool,
+            bool,
+            dict[str, list[tuple[str, str]]],
+        ]
     ] = [
         (
             {"svc": [["-", "cnt", "[dim]stopped[/dim]"]]},
             False,
             False,
             True,
+            {},
         ),
         (
             {"svc": [["-", "cnt", "[bold green]running[/bold green]"]]},
             True,
             True,
             True,
+            {},
         ),
     ]
     idx = {"value": 0}
@@ -284,7 +306,13 @@ def test_wait_for_env_up_non_terminal_waits_for_running_state(
     def collect_status(
         _env: Any,
         gate_status: Any = None,
-    ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
+    ) -> tuple[
+        dict[str, list[list[str]]],
+        bool,
+        bool,
+        bool,
+        dict[str, list[tuple[str, str]]],
+    ]:
         i = min(idx["value"], len(status_samples) - 1)
         idx["value"] += 1
         return status_samples[i]
@@ -312,19 +340,27 @@ def test_wait_for_env_down_non_terminal_waits_for_stopped_state(
     env.get_services.return_value = []
 
     status_samples: list[
-        tuple[dict[str, list[list[str]]], bool, bool, bool]
+        tuple[
+            dict[str, list[list[str]]],
+            bool,
+            bool,
+            bool,
+            dict[str, list[tuple[str, str]]],
+        ]
     ] = [
         (
             {"svc": [["-", "cnt", "[bold green]running[/bold green]"]]},
             False,
             True,
             True,
+            {},
         ),
         (
             {"svc": [["-", "cnt", "[dim]stopped[/dim]"]]},
             False,
             False,
             True,
+            {},
         ),
     ]
     idx = {"value": 0}
@@ -332,7 +368,13 @@ def test_wait_for_env_down_non_terminal_waits_for_stopped_state(
     def collect_status(
         _env: Any,
         gate_status: Any = None,
-    ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
+    ) -> tuple[
+        dict[str, list[list[str]]],
+        bool,
+        bool,
+        bool,
+        dict[str, list[tuple[str, str]]],
+    ]:
         i = min(idx["value"], len(status_samples) - 1)
         idx["value"] += 1
         return status_samples[i]
@@ -360,19 +402,27 @@ def test_wait_for_env_up_quiet_still_polls_until_running(
     env.get_services.return_value = []
 
     status_samples: list[
-        tuple[dict[str, list[list[str]]], bool, bool, bool]
+        tuple[
+            dict[str, list[list[str]]],
+            bool,
+            bool,
+            bool,
+            dict[str, list[tuple[str, str]]],
+        ]
     ] = [
         (
             {"svc": [["-", "cnt", "[dim]stopped[/dim]"]]},
             False,
             False,
             True,
+            {},
         ),
         (
             {"svc": [["-", "cnt", "[bold green]running[/bold green]"]]},
             True,
             True,
             True,
+            {},
         ),
     ]
     idx = {"value": 0}
@@ -380,7 +430,13 @@ def test_wait_for_env_up_quiet_still_polls_until_running(
     def collect_status(
         _env: Any,
         gate_status: Any = None,
-    ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
+    ) -> tuple[
+        dict[str, list[list[str]]],
+        bool,
+        bool,
+        bool,
+        dict[str, list[tuple[str, str]]],
+    ]:
         i = min(idx["value"], len(status_samples) - 1)
         idx["value"] += 1
         return status_samples[i]
@@ -412,6 +468,7 @@ def test_wait_for_env_up_quiet_still_enforces_timeout(mocker: MockerFixture):
             False,
             True,
             True,
+            {},
         ),
     )
     fake_console = mocker.Mock()
@@ -466,6 +523,7 @@ def test_status_env_renders_tree(mocker: MockerFixture):
             True,
             True,
             True,
+            {},
         ),
     )
     fake_console = mocker.Mock()
@@ -482,6 +540,55 @@ def test_status_env_renders_tree(mocker: MockerFixture):
     assert str(service_node.label) == "[bold cyan]svc-1[/bold cyan]"
     assert "RUNNING: 1" in summary.plain
     assert "GATES" not in summary.plain
+
+
+def test_collect_and_render_env_status_shows_endpoints_only_when_running(
+    mocker: MockerFixture,
+):
+    """A container's declared `endpoints:` render under its service node
+    only while it's actually running -- a stopped container's endpoints
+    aren't reachable, so mustn't appear (matches sctl's own
+    `hlp_get_service_is_running` guard around its endpoint table)."""
+    mng = _new_environment_mng(mocker)
+
+    endpoint = SimpleNamespace(label="http", url="https://app.example.test")
+    running_container = SimpleNamespace(
+        tag="cnt-a",
+        run_container_name="svc-a-cnt",
+        endpoints=[endpoint],
+    )
+    running_svc = SimpleNamespace(
+        svcCfg=SimpleNamespace(
+            tag="svc-a", containers=[running_container], start=None
+        )
+    )
+    stopped_container = SimpleNamespace(
+        tag="cnt-b",
+        run_container_name="svc-b-cnt",
+        endpoints=[endpoint],
+    )
+    stopped_svc = SimpleNamespace(
+        svcCfg=SimpleNamespace(
+            tag="svc-b", containers=[stopped_container], start=None
+        )
+    )
+    env = mocker.Mock()
+    env.status.return_value = [
+        {"Service": "svc-a-cnt", "State": "running"},
+    ]
+    env.get_services.return_value = [running_svc, stopped_svc]
+
+    grouped, _, _, _, endpoints = mng._collect_env_status(env)
+
+    assert endpoints == {"svc-a": [("http", "https://app.example.test")]}
+    assert "svc-b" not in endpoints
+
+    tree = mng._build_env_status_tree("env-1", grouped, endpoints=endpoints)
+    printed_tree = tree.renderables[0]
+    running_node, stopped_node = printed_tree.children
+    endpoints_children = [c.label for c in running_node.children]
+    assert any("endpoints" in str(label) for label in endpoints_children)
+    assert not any("endpoints" in str(c.label) for c in stopped_node.children)
 
 
 def test_format_service_gate_glyphs_states(mocker: MockerFixture):
@@ -870,7 +977,9 @@ def test_collect_env_status_includes_probe_details_for_tree_view(
 ):
     mng = _new_environment_mng(mocker)
 
-    container = SimpleNamespace(tag="cnt-a", run_container_name="svc-a-cnt")
+    container = SimpleNamespace(
+        tag="cnt-a", run_container_name="svc-a-cnt", endpoints=None
+    )
     svc = SimpleNamespace(
         svcCfg=SimpleNamespace(
             tag="svc-a",
@@ -882,7 +991,7 @@ def test_collect_env_status_includes_probe_details_for_tree_view(
     env.status.return_value = [{"Service": "svc-a-cnt", "State": "running"}]
     env.get_services.return_value = [svc]
 
-    grouped, _, _, _ = mng._collect_env_status(
+    grouped, _, _, _, _ = mng._collect_env_status(
         env,
         gate_status={"p1": True, "p2": None},
     )
@@ -893,7 +1002,9 @@ def test_collect_env_status_includes_probe_details_for_tree_view(
 def test_collect_env_status_details_row_shape(mocker: MockerFixture):
     mng = _new_environment_mng(mocker, cli_flags={"details": True})
 
-    container = SimpleNamespace(tag="cnt-a", run_container_name="svc-a-cnt")
+    container = SimpleNamespace(
+        tag="cnt-a", run_container_name="svc-a-cnt", endpoints=None
+    )
     svc = SimpleNamespace(
         svcCfg=SimpleNamespace(
             tag="svc-a",
@@ -905,9 +1016,11 @@ def test_collect_env_status_details_row_shape(mocker: MockerFixture):
     env.status.return_value = [{"Service": "svc-a-cnt", "State": "running"}]
     env.get_services.return_value = [svc]
 
-    grouped, all_running, any_running, has_containers = mng._collect_env_status(
-        env,
-        gate_status={"p1": True, "p2": None},
+    grouped, all_running, any_running, has_containers, _ = (
+        mng._collect_env_status(
+            env,
+            gate_status={"p1": True, "p2": None},
+        )
     )
     assert all_running is True
     assert any_running is True
@@ -920,7 +1033,9 @@ def test_collect_env_status_details_row_shape(mocker: MockerFixture):
 def test_collect_env_status_can_omit_gate_details(mocker: MockerFixture):
     mng = _new_environment_mng(mocker)
 
-    container = SimpleNamespace(tag="cnt-a", run_container_name="svc-a-cnt")
+    container = SimpleNamespace(
+        tag="cnt-a", run_container_name="svc-a-cnt", endpoints=None
+    )
     svc = SimpleNamespace(
         svcCfg=SimpleNamespace(
             tag="svc-a",
@@ -932,10 +1047,12 @@ def test_collect_env_status_can_omit_gate_details(mocker: MockerFixture):
     env.status.return_value = [{"Service": "svc-a-cnt", "State": "running"}]
     env.get_services.return_value = [svc]
 
-    grouped, all_running, any_running, has_containers = mng._collect_env_status(
-        env,
-        gate_status={"p1": True, "p2": None},
-        include_gates=False,
+    grouped, all_running, any_running, has_containers, _ = (
+        mng._collect_env_status(
+            env,
+            gate_status={"p1": True, "p2": None},
+            include_gates=False,
+        )
     )
 
     assert all_running is True
@@ -957,26 +1074,38 @@ def test_wait_for_env_down_terminal_main_loop(mocker: MockerFixture):
     env.get_services.return_value = []
 
     status_samples: list[
-        tuple[dict[str, list[list[str]]], bool, bool, bool]
+        tuple[
+            dict[str, list[list[str]]],
+            bool,
+            bool,
+            bool,
+            dict[str, list[tuple[str, str]]],
+        ]
     ] = [
         (
             {"svc": [["-", "cnt", "[bold green]running[/bold green]"]]},
             False,
             True,
             True,
+            {},
         ),
         (
             {"svc": [["-", "cnt", "[dim]stopped[/dim]"]]},
             False,
             False,
             True,
+            {},
         ),
     ]
     idx = {"value": 0}
 
-    def collect_status(
-        _env: Any, gate_status: Any = None
-    ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
+    def collect_status(_env: Any, gate_status: Any = None) -> tuple[
+        dict[str, list[list[str]]],
+        bool,
+        bool,
+        bool,
+        dict[str, list[tuple[str, str]]],
+    ]:
         i = min(idx["value"], len(status_samples) - 1)
         idx["value"] += 1
         return status_samples[i]
@@ -1034,9 +1163,13 @@ def test_wait_for_env_up_terminal_no_action_waits_for_first_snapshot(
 
     calls = {"count": 0}
 
-    def collect_status(
-        _env: Any, gate_status: Any = None
-    ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
+    def collect_status(_env: Any, gate_status: Any = None) -> tuple[
+        dict[str, list[list[str]]],
+        bool,
+        bool,
+        bool,
+        dict[str, list[tuple[str, str]]],
+    ]:
         calls["count"] += 1
         if calls["count"] == 1:
             time.sleep(0.03)
@@ -1045,6 +1178,7 @@ def test_wait_for_env_up_terminal_no_action_waits_for_first_snapshot(
             True,
             True,
             True,
+            {},
         )
 
     fake_console = mocker.Mock()
@@ -1090,32 +1224,45 @@ def test_wait_for_env_up_watch_clears_ready_badge_on_regression(
     env.get_pull_state.return_value = []
 
     status_samples: list[
-        tuple[dict[str, list[list[str]]], bool, bool, bool]
+        tuple[
+            dict[str, list[list[str]]],
+            bool,
+            bool,
+            bool,
+            dict[str, list[tuple[str, str]]],
+        ]
     ] = [
         (
             {"svc": [["-", "cnt", "[yellow]starting[/yellow]"]]},
             False,
             True,
             True,
+            {},
         ),
         (
             {"svc": [["-", "cnt", "[bold green]running[/bold green]"]]},
             True,
             True,
             True,
+            {},
         ),
         (
             {"svc": [["-", "cnt", "[yellow]degraded[/yellow]"]]},
             False,
             True,
             True,
+            {},
         ),
     ]
     idx = {"value": 0}
 
-    def collect_status(
-        _env: Any, _gate_status: Any = None
-    ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
+    def collect_status(_env: Any, _gate_status: Any = None) -> tuple[
+        dict[str, list[list[str]]],
+        bool,
+        bool,
+        bool,
+        dict[str, list[tuple[str, str]]],
+    ]:
         i = min(idx["value"], len(status_samples) - 1)
         idx["value"] += 1
         if idx["value"] > 6:
@@ -1185,26 +1332,38 @@ def test_wait_for_env_up_watch_flashes_ready_badge_briefly(
     env.get_pull_state.return_value = []
 
     status_samples: list[
-        tuple[dict[str, list[list[str]]], bool, bool, bool]
+        tuple[
+            dict[str, list[list[str]]],
+            bool,
+            bool,
+            bool,
+            dict[str, list[tuple[str, str]]],
+        ]
     ] = [
         (
             {"svc": [["-", "cnt", "[yellow]starting[/yellow]"]]},
             False,
             True,
             True,
+            {},
         ),
         (
             {"svc": [["-", "cnt", "[bold green]running[/bold green]"]]},
             True,
             True,
             True,
+            {},
         ),
     ]
     idx = {"value": 0}
 
-    def collect_status(
-        _env: Any, _gate_status: Any = None
-    ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
+    def collect_status(_env: Any, _gate_status: Any = None) -> tuple[
+        dict[str, list[list[str]]],
+        bool,
+        bool,
+        bool,
+        dict[str, list[tuple[str, str]]],
+    ]:
         idx["value"] += 1
         if idx["value"] > 130:
             raise RuntimeError("stop-watch")
@@ -1270,7 +1429,13 @@ def test_wait_for_env_up_watch_marks_changed_container_and_probe_for_flash(
     env.get_pull_state.return_value = []
 
     status_samples: list[
-        tuple[dict[str, list[list[str]]], bool, bool, bool]
+        tuple[
+            dict[str, list[list[str]]],
+            bool,
+            bool,
+            bool,
+            dict[str, list[tuple[str, str]]],
+        ]
     ] = [
         (
             {
@@ -1286,6 +1451,7 @@ def test_wait_for_env_up_watch_marks_changed_container_and_probe_for_flash(
             False,
             True,
             True,
+            {},
         ),
         (
             {
@@ -1301,13 +1467,18 @@ def test_wait_for_env_up_watch_marks_changed_container_and_probe_for_flash(
             True,
             True,
             True,
+            {},
         ),
     ]
     idx = {"value": 0}
 
-    def collect_status(
-        _env: Any, _gate_status: Any = None
-    ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
+    def collect_status(_env: Any, _gate_status: Any = None) -> tuple[
+        dict[str, list[list[str]]],
+        bool,
+        bool,
+        bool,
+        dict[str, list[tuple[str, str]]],
+    ]:
         idx["value"] += 1
         if idx["value"] > 12:
             raise RuntimeError("stop-watch")
@@ -1403,7 +1574,13 @@ def test_wait_for_env_state_uses_custom_progress_label(
     env.envCfg = SimpleNamespace(tag="test-env")
     env.get_pull_state.return_value = []
     status_samples: list[
-        tuple[dict[str, list[list[str]]], bool, bool, bool]
+        tuple[
+            dict[str, list[list[str]]],
+            bool,
+            bool,
+            bool,
+            dict[str, list[tuple[str, str]]],
+        ]
     ] = [
         (
             {
@@ -1418,6 +1595,7 @@ def test_wait_for_env_state_uses_custom_progress_label(
             False,
             True,
             True,
+            {},
         ),
         (
             {
@@ -1432,6 +1610,7 @@ def test_wait_for_env_state_uses_custom_progress_label(
             True,
             True,
             True,
+            {},
         ),
     ]
     status_idx = {"value": 0}
@@ -1439,7 +1618,13 @@ def test_wait_for_env_state_uses_custom_progress_label(
     def collect_status(
         _env: Any,
         _gate_status: Any = None,
-    ) -> tuple[dict[str, list[list[str]]], bool, bool, bool]:
+    ) -> tuple[
+        dict[str, list[list[str]]],
+        bool,
+        bool,
+        bool,
+        dict[str, list[tuple[str, str]]],
+    ]:
         idx = min(status_idx["value"], len(status_samples) - 1)
         status_idx["value"] += 1
         return status_samples[idx]

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -45,6 +45,7 @@ def add_container_field_defaults(node: object) -> None:
         "labels": [],
         "ingress": None,
         "ingress_port": None,
+        "endpoints": None,
         "command": [],
         "network_mode": None,
         "user": None,


### PR DESCRIPTION
Fixes #299

## Summary

sctl's `env status` (and `env up`, which calls `env_status` at the end) prints a per-service "Endpoint | URL" table once a container is running. Shepherd core had no equivalent.

- `ContainerCfg.endpoints`: a list of `{label, url}` pairs (new `EndpointCfg`), `url` a plain `${VAR}`/`#{ref}`-resolvable string — same templating `ingress`/`ports`/`volumes` already use, no plugin Python hook needed for the common case.
- `collect_env_status` collects `(label, url)` pairs from currently-running containers only, keyed by service tag — a stopped container's endpoints aren't shown, matching sctl's own `hlp_get_service_is_running` guard.
- `build_env_status_tree` renders them as an `endpoints` sub-node per service, alongside the existing `gates` sub-node.
- `env status` and `env up`'s completion display already share one render pipeline (`build_env_status_tree` via `WaitForEnvStateHooks`), so this shows up in both automatically — confirmed live, no separate wiring needed.

Threading the new `(label, url)` dict through `collect_env_status`'s tuple return touches every call site across `environment.py` and `status_wait.py`'s polling/live-render loops (quiet mode, non-terminal/CI output, interactive `Live` loop including the final "Ready" frame) — mechanical but broad; each call site updated and verified individually.

## Test plan

- [x] `pytest` (758 passed, including a new end-to-end test asserting a running container's endpoint renders and a stopped one's doesn't)
- [x] `black --check` / `isort --check-only` / `pyright` / `pre-commit run --all-files` (all clean)
- [x] Verified live against a real environment (external plugin): `env up`'s completion tree and `env status` both show the endpoint under the running service, and it disappears once halted