### PR TITLE
feat: resolvable ingress host ports

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Iterable, Match, Optional, cast
 import yaml
 from glom import glom  # type: ignore[import]
 
+from ingress.provider import allocate_ports
 from util import Constants, Util
 
 # Regular expression for variables in .shpd.conf or environment variables
@@ -842,6 +843,24 @@ class EnvironmentCfg(Resolvable):
             if svc.tag == svcTag:
                 return svc
         return None
+
+    @property
+    def ingress_http_port(self) -> str:
+        """The host port shepherd's own ingress proxy publishes HTTP on
+        for this environment, resolvable as `#{env.ingress_http_port}`.
+        A pure function of `tag` (`ingress.provider.allocate_ports`) --
+        not a stored/transient value, so it's available to templating
+        without a `start()` having run in this process first (e.g. a
+        fresh `env status` in a new CLI invocation), and always matches
+        whatever `Environment._apply_ingress_plan` actually allocates,
+        with no synchronization needed between the two call sites."""
+        return str(allocate_ports(self.tag)[0])
+
+    @property
+    def ingress_https_port(self) -> str:
+        """See `ingress_http_port` -- the HTTPS counterpart, resolvable
+        as `#{env.ingress_https_port}`."""
+        return str(allocate_ports(self.tag)[1])
 
     def get_yaml(self, resolved: bool = False) -> str:
         """

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -846,14 +846,21 @@ class EnvironmentCfg(Resolvable):
 
     @property
     def ingress_http_port(self) -> str:
-        """The host port shepherd's own ingress proxy publishes HTTP on
-        for this environment, resolvable as `#{env.ingress_http_port}`.
-        A pure function of `tag` (`ingress.provider.allocate_ports`) --
-        not a stored/transient value, so it's available to templating
-        without a `start()` having run in this process first (e.g. a
-        fresh `env status` in a new CLI invocation), and always matches
-        whatever `Environment._apply_ingress_plan` actually allocates,
-        with no synchronization needed between the two call sites."""
+        """The host port shepherd's own *core* (traefik) ingress
+        provider publishes HTTP on for this environment, resolvable as
+        `#{env.ingress_http_port}`. A pure function of `tag`
+        (`ingress.provider.allocate_ports`) -- not a stored/transient
+        value, so it's available to templating without a `start()`
+        having run in this process first (e.g. a fresh `env status` in
+        a new CLI invocation), and always matches whatever
+        `Environment._apply_ingress_plan` allocates when the core
+        provider is selected (`_resolve_ingress_provider`'s
+        `CORE_INGRESS_PROVIDER_TYPE_IDS` branch), with no
+        synchronization needed between the two call sites. A
+        plugin-registered ingress provider is free to allocate its
+        ports however it likes -- this value is meaningless for one and
+        is returned regardless (also regardless of whether the
+        environment even opts into ingress via `EnvironmentCfg.ingress`)."""
         return str(allocate_ports(self.tag)[0])
 
     @property

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -29,6 +29,7 @@ from config import (
 )
 from docker import DockerComposeEnv, DockerComposeSvc
 from factory import ShpdEnvironmentFactory, ShpdServiceFactory
+from ingress import allocate_ports
 from util import Constants
 
 
@@ -248,6 +249,53 @@ def _load_config_with_yaml(
 
 
 @pytest.mark.cfg
+def test_environment_ingress_ports_resolve_and_match_allocate_ports(
+    mocker: MockerFixture,
+):
+    """`#{env.ingress_http_port}`/`#{env.ingress_https_port}` let a
+    template embed the real, reachable ingress URL (including port --
+    shepherd's traefik provider never publishes the conventional
+    80/443, see `ingress.provider.allocate_ports`) in any
+    `${VAR}`/`#{ref}`-resolvable field, without any plugin Python code.
+    Deterministic and available without a `start()` having run in this
+    process -- `EnvironmentCfg.ingress_http_port`/`ingress_https_port`
+    are computed properties, not stored state."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs:
+  - template: t
+    factory: docker
+    tag: e1
+    status:
+      active: true
+    services:
+      - tag: svc
+        factory: docker
+        template: t
+        status:
+          active: true
+        containers:
+          - tag: c
+            image: nginx:latest
+            environment:
+              - "URL=https://svc-#{env.tag}.example.test:#{env.ingress_https_port}"
+"""
+    config = _load_config_with_yaml(mocker, config_yaml)
+    config.set_resolved()
+
+    env = config.envs[0]
+    assert env.services
+    environment = env.services[0].containers[0].environment
+    assert environment
+
+    http_port, https_port = allocate_ports("e1")
+    assert env.ingress_http_port == str(http_port)
+    assert env.ingress_https_port == str(https_port)
+    assert environment[0] == (f"URL=https://svc-e1.example.test:{https_port}")
+
+
 def test_plugin_config_resolves_template_placeholder(mocker: MockerFixture):
     """A plugin's own `config` values resolve ${VAR} placeholders in that
     plugin's service_templates, without a same-named shell/user_values

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -281,6 +281,7 @@ envs:
             image: nginx:latest
             environment:
               - "URL=https://svc-#{env.tag}.example.test:#{env.ingress_https_port}"
+              - "HTTP_URL=http://svc-#{env.tag}.example.test:#{env.ingress_http_port}"
 """
     config = _load_config_with_yaml(mocker, config_yaml)
     config.set_resolved()
@@ -294,6 +295,9 @@ envs:
     assert env.ingress_http_port == str(http_port)
     assert env.ingress_https_port == str(https_port)
     assert environment[0] == (f"URL=https://svc-e1.example.test:{https_port}")
+    assert environment[1] == (
+        f"HTTP_URL=http://svc-e1.example.test:{http_port}"
+    )
 
 
 def test_plugin_config_resolves_template_placeholder(mocker: MockerFixture):


### PR DESCRIPTION
## Summary
- Adds `EnvironmentCfg.ingress_http_port`/`ingress_https_port` computed properties, resolvable as `#{env.ingress_http_port}`/`#{env.ingress_https_port}` in any `${VAR}`/`#{ref}` template field.
- Pure function of `tag` via `ingress.provider.allocate_ports` (the same call the real ingress proxy setup already makes) -- no stored/cached state, so it's correct without a `start()` having run in the current process, and can never drift from the real allocation.

Fixes #301

## Test plan
- `pytest` (full suite, 757 passed)
- `black`/`isort`/`pyright`/`pre-commit run --all-files` all clean
- New test: `test_environment_ingress_ports_resolve_and_match_allocate_ports` -- asserts the resolved value matches `allocate_ports` directly, and that a template field embedding `#{env.ingress_https_port}` resolves to the real port.