### PR TITLE
feat(config,docker): support build args, host uid/gid and plugin-dir refs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -93,6 +93,41 @@ placeholder resolution — including in that plugin's own
 `eu-west-1` anywhere in the config tree, no separately-exported shell
 variable required.
 
+Two more resolvable forms are always available, no `config:` declaration
+needed:
+
+- `${<plugin-id>_dir}` — auto-injected for every installed plugin,
+  namespaced by its `id` so it can never collide with another plugin's
+  (unlike a hand-declared `config:` key would). Resolves to that
+  plugin's own managed install directory — use it to anchor a
+  `build.context_path`/`dockerfile_path` under assets shipped inside the
+  plugin itself, instead of requiring a hand-supplied absolute host
+  path:
+
+  ```yaml
+  containers:
+    - tag: app
+      build:
+        context_path: "${my-plugin_dir}/docker"
+        dockerfile_path: "${my-plugin_dir}/docker/Dockerfile"
+        args:
+          - "UID=#{host.uid}"
+          - "GID=#{host.gid}"
+  ```
+
+- `#{host.uid}` / `#{host.gid}` — the invoking host process's real
+  uid/gid (Linux/macOS/WSL; left unresolved on platforms without
+  `os.getuid`/`os.getgid`). Typically used in `build.args` so an image's
+  own user matches the host user that owns a bind-mounted volume; any
+  field using `${VAR}`/`#{ref}` resolution can reference it. To pin a
+  fixed value instead of resolving it from the host, write the literal
+  (e.g. `"UID=1000"`) rather than the ref token — no separate
+  static-override mechanism exists or is needed.
+
+`ContainerCfg.build` (`BuildCfg`) itself also accepts `args` — a list of
+`"KEY=VALUE"` strings passed to `docker build` as `--build-arg`, resolved
+like any other string field.
+
 An individual environment instance (an entry under `envs:`, the thing
 created by `env add <template> <tag>`) can also carry its own `config`
 block, keyed exactly like a plugin's:

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -304,6 +304,20 @@ class Resolvable:
             expr = match.group(1)  # e.g. "env.tag"
             parts = expr.split(".", 1)
             root = parts[0]
+            if root == "host":
+                # Pure computed pseudo-root (invoking host's real uid/gid),
+                # not backed by a Resolvable config object -- needed so a
+                # container's `build.args` can match a bind-mounted
+                # volume's host owner without a hand-supplied value. A
+                # template author wanting a fixed value instead just
+                # writes the literal (e.g. "UID=1000") rather than this
+                # ref -- no separate static-override mechanism needed.
+                attr = parts[1] if len(parts) > 1 else ""
+                if attr == "uid" and hasattr(os, "getuid"):
+                    return str(os.getuid())
+                if attr == "gid" and hasattr(os, "getgid"):
+                    return str(os.getgid())
+                return match.group(0)  # unsupported platform/attr
             if root not in refMap:
                 return match.group(0)  # return untouched
             target = refMap[root]
@@ -493,6 +507,12 @@ class BuildCfg(Resolvable):
 
     context_path: Optional[str] = None
     dockerfile_path: Optional[str] = None
+    # `docker build --build-arg` entries, "KEY=VALUE" -- same shape as
+    # `ContainerCfg.environment`/`labels`. Resolved through the usual
+    # `${VAR}`/`#{ref}` machinery, so a value can be a static literal or a
+    # dynamic ref (e.g. `#{host.uid}`) -- no separate static/dynamic
+    # mechanism needed.
+    args: Optional[list[str]] = None
 
 
 @dataclass
@@ -1095,6 +1115,7 @@ def _parse_build(item: Any) -> BuildCfg:
     return BuildCfg(
         context_path=item.get("context_path"),
         dockerfile_path=item.get("dockerfile_path"),
+        args=item.get("args"),
     )
 
 
@@ -1810,6 +1831,15 @@ class ConfigMng:
         for plugin_cfg in config.plugins or []:
             for key, value in (plugin_cfg.config or {}).items():
                 resolver[str(key)] = str(value)
+            # Auto-injected, namespaced by plugin id (never user-declared,
+            # so it can't collide across plugins the way a bare
+            # `${plugin_dir}` would) -- lets a plugin's own templates
+            # anchor `build.dockerfile_path`/`context_path` etc. under its
+            # own install directory without a hand-supplied absolute host
+            # path. Same class of gap `${envs_path}` closed (#297).
+            resolver[f"{plugin_cfg.id}_dir"] = self.get_plugin_dir(
+                plugin_cfg.id
+            )
         return resolver
 
     def load_config(self) -> Config:

--- a/src/docker/docker_compose_util.py
+++ b/src/docker/docker_compose_util.py
@@ -222,6 +222,7 @@ def build_docker_image(
     context_path: Path,
     tag: str,
     *,
+    build_args: Optional[list[str]] = None,
     verbose: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     """
@@ -232,6 +233,8 @@ def build_docker_image(
         dockerfile_path (Path): Path to the Dockerfile.
         context_path (Path): Path to the Docker build context (directory).
         tag (str): The resulting image tag, e.g. "myapp:latest".
+        build_args (Optional[list[str]]): "KEY=VALUE" entries passed as
+            `docker build --build-arg`.
 
     Returns:
         subprocess.CompletedProcess[str]: The result of the docker build
@@ -253,6 +256,10 @@ def build_docker_image(
         tag,
         "-f",
         str(dockerfile_path),
+    ]
+    for arg in build_args or []:
+        cmd += ["--build-arg", arg]
+    cmd += [
         "--progress=auto",
         str(context_path),
     ]
@@ -415,5 +422,6 @@ def build_container(container: ContainerCfg, *, verbose: bool = False) -> None:
                 Path(build.dockerfile_path),
                 Path(build.context_path),
                 container.image or "",
+                build_args=build.args,
                 verbose=verbose,
             )

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -373,6 +373,105 @@ service_templates:
 
 
 @pytest.mark.cfg
+def test_build_args_parse_and_resolve(mocker: MockerFixture):
+    """`ContainerCfg.build.args` ("KEY=VALUE" `docker build --build-arg`
+    entries) parses and resolves like `environment`/`labels` -- a value
+    can be a static literal or a dynamic ref (e.g. `#{host.uid}`)."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+service_templates:
+  - tag: svc
+    factory: docker
+    containers:
+      - tag: c
+        image: nginx:latest
+        build:
+          context_path: .
+          dockerfile_path: Dockerfile
+          args:
+            - "UID=#{host.uid}"
+            - "GID=1000"
+"""
+    config = _load_config_with_yaml(mocker, config_yaml)
+    config.set_resolved()
+
+    assert config.service_templates
+    build = config.service_templates[0].containers[0].build
+    assert build and build.args
+    assert build.args[0] == f"UID={os.getuid()}"
+    assert build.args[1] == "GID=1000"
+
+
+@pytest.mark.cfg
+def test_host_uid_gid_refs_resolve_anywhere(mocker: MockerFixture):
+    """`#{host.uid}`/`#{host.gid}` resolve to the invoking process's real
+    uid/gid in any `${VAR}`/`#{ref}`-resolvable field, not just
+    `build.args` -- it's a pure computed pseudo-root, not scoped to one
+    field type."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+service_templates:
+  - tag: svc
+    factory: docker
+    containers:
+      - tag: c
+        image: nginx:latest
+        environment:
+          - "OWNER=#{host.uid}:#{host.gid}"
+"""
+    config = _load_config_with_yaml(mocker, config_yaml)
+    config.set_resolved()
+
+    assert config.service_templates
+    environment = config.service_templates[0].containers[0].environment
+    assert environment == [f"OWNER={os.getuid()}:{os.getgid()}"]
+
+
+@pytest.mark.cfg
+def test_plugin_dir_var_is_auto_injected_per_plugin(mocker: MockerFixture):
+    """`${<plugin-id>_dir}` is auto-injected (never user-declared) for
+    every installed plugin, namespaced by id so it can't collide across
+    plugins the way a bare `${plugin_dir}` would -- lets a plugin anchor
+    `build.dockerfile_path`/`context_path` under its own install
+    directory without a hand-supplied absolute host path."""
+
+    config_yaml = """
+templates_path: ${shpd_path}/templates
+envs_path: ${shpd_path}/envs
+envs: []
+plugins:
+  - id: acme-plugin
+    enabled: true
+service_templates:
+  - tag: svc
+    factory: docker
+    containers:
+      - tag: c
+        image: nginx:latest
+        build:
+          context_path: ${acme-plugin_dir}/docker
+          dockerfile_path: ${acme-plugin_dir}/docker/Dockerfile
+"""
+    config = _load_config_with_yaml(mocker, config_yaml)
+    config.set_resolved()
+
+    assert config.service_templates
+    build = config.service_templates[0].containers[0].build
+    assert build
+    assert build.context_path == "/tmp/shpd/plugins/acme-plugin/docker"
+    assert (
+        build.dockerfile_path
+        == "/tmp/shpd/plugins/acme-plugin/docker/Dockerfile"
+    )
+
+
+@pytest.mark.cfg
 def test_envs_path_is_exposed_as_template_var(mocker: MockerFixture):
     """`${envs_path}` resolves to shepherd's own per-environment root, so a
     service_template can anchor persistent host state under

--- a/src/tests/test_svc_docker_compose.py
+++ b/src/tests/test_svc_docker_compose.py
@@ -836,3 +836,47 @@ def test_build_svc_dockerfile_does_not_exist(
     result = runner.invoke(cli, ["svc", "build", "test-4"])
     assert result.exit_code == 1
     mock_subproc.assert_not_called()
+
+
+@pytest.mark.docker
+def test_build_container_passes_build_args(
+    tmp_path: Path,
+    mocker: MockerFixture,
+):
+    """`BuildCfg.args` ("KEY=VALUE" entries) are passed through to
+    `docker build` as `--build-arg`."""
+    from config import ContainerCfg
+    from config.config import BuildCfg
+    from docker.docker_compose_util import build_container
+
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text("FROM scratch\n")
+
+    mock_subproc = mocker.patch(
+        "docker.docker_compose_util.subprocess.run",
+        return_value=subprocess.CompletedProcess(
+            args=["docker", "build"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        ),
+    )
+
+    container = ContainerCfg(
+        tag="c",
+        image="test-image:latest",
+        build=BuildCfg(
+            context_path=str(tmp_path),
+            dockerfile_path=str(dockerfile),
+            args=["UID=1000", "GID=1000"],
+        ),
+    )
+
+    build_container(container, verbose=False)
+
+    mock_subproc.assert_called_once()
+    cmd = mock_subproc.call_args.args[0]
+    assert "--build-arg" in cmd
+    uid_index = cmd.index("--build-arg")
+    assert cmd[uid_index + 1] == "UID=1000"
+    assert "GID=1000" in cmd

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -61,13 +61,24 @@ def add_container_field_defaults(node: object) -> None:
                     if isinstance(container, dict):
                         for field_name, default in defaults.items():
                             container.setdefault(field_name, default)
+                        _add_build_field_defaults(container)
             if key == "container" and isinstance(value, dict):
                 for field_name, default in defaults.items():
                     value.setdefault(field_name, default)
+                _add_build_field_defaults(value)
             add_container_field_defaults(value)
     elif isinstance(node, list):
         for item in node:
             add_container_field_defaults(item)
+
+
+def _add_build_field_defaults(container: dict[str, object]) -> None:
+    """Default for `ContainerCfg.build.args`, mirroring
+    `add_container_field_defaults`'s own rationale but for a field nested
+    one level deeper, inside `build:`."""
+    build = container.get("build")
+    if isinstance(build, dict):
+        build.setdefault("args", None)
 
 
 def test_print_error_and_die_uses_minimal_error_prefix(


### PR DESCRIPTION
Closes #303.

Adds three small, related declarative-resolution capabilities needed by
any plugin that wants to build a custom image locally (via
`ContainerCfg.build`) instead of only ever pulling a prebuilt one:

- `BuildCfg.args`: `"KEY=VALUE"` entries passed to `docker build` as
  `--build-arg`, threaded through `build_container`/`build_docker_image`.
- `#{host.uid}` / `#{host.gid}`: resolve to the invoking process's real
  uid/gid anywhere `${VAR}`/`#{ref}` resolution runs (a pure computed
  pseudo-root, no new `Resolvable` object). A template author wanting a
  fixed value instead just writes the literal (e.g. `"UID=1000"`) — no
  separate static-override mechanism needed.
- `${<plugin-id>_dir}`: auto-injected per installed plugin (namespaced
  by id, so it can't collide across plugins), resolving to that
  plugin's own managed install directory — same class of gap
  `${envs_path}` closed in #297.

## Test plan

- [x] `pytest` (764 passed)
- [x] `pyright .`
- [x] `pre-commit run --all-files`
- [x] New tests: `test_build_args_parse_and_resolve`,
      `test_host_uid_gid_refs_resolve_anywhere`,
      `test_plugin_dir_var_is_auto_injected_per_plugin` (test_config.py),
      `test_build_container_passes_build_args` (test_svc_docker_compose.py)